### PR TITLE
fix: strip appended Files/Attachments footer from /shell args

### DIFF
--- a/runtime/src/agent-control/command-parsers.ts
+++ b/runtime/src/agent-control/command-parsers.ts
@@ -23,6 +23,24 @@ type PasskeyAction = Extract<AgentControlCommand, { type: "passkey" }>["action"]
 type TotpAction = Extract<AgentControlCommand, { type: "totp" }>["action"];
 type SearchScope = Extract<AgentControlCommand, { type: "search_workspace" }>["scope"];
 
+function sanitizeShellArgs(args: string): string {
+  let cleaned = (args || "").replace(/\r\n/g, "\n").trim();
+  if (!cleaned) return "";
+
+  const lines = cleaned.split("\n");
+  const blockIndex = lines.findIndex((line, index) => index > 0 && /^(files|attachments):\s*$/i.test(line.trim()));
+  if (blockIndex !== -1) {
+    const tail = lines.slice(blockIndex + 1).map((line) => line.trim()).filter(Boolean);
+    const looksLikeAttachmentList = tail.length === 0 || tail.every((line) => /^-\s+/.test(line));
+    if (looksLikeAttachmentList) {
+      cleaned = lines.slice(0, blockIndex).join("\n").trim();
+    }
+  }
+
+  cleaned = cleaned.replace(/\s+(?:Files|Attachments):\s*(?:-\s+.*)?$/i, "").trim();
+  return cleaned;
+}
+
 function parsePasskeyAction(action: string | undefined): PasskeyAction {
   if (!action) return undefined;
   return ["enrol", "enroll", "list", "delete", "remove"].includes(action) ? (action as PasskeyAction) : undefined;
@@ -88,9 +106,10 @@ export function parseThinking(args: string, raw: string): AgentControlCommand {
 
 /** Parse /shell arguments: optional command string. */
 export function parseShell(args: string, raw: string): AgentControlCommand {
+  const command = sanitizeShellArgs(args);
   return {
     type: "shell",
-    command: args || undefined,
+    command: command || undefined,
     raw,
   };
 }
@@ -272,9 +291,10 @@ export function parseQr(args: string, raw: string): AgentControlCommand {
 
 /** Parse /bash arguments: optional command string. */
 export function parseBash(args: string, raw: string): AgentControlCommand {
+  const command = sanitizeShellArgs(args);
   return {
     type: "bash",
-    command: args || undefined,
+    command: command || undefined,
     raw,
   };
 }

--- a/runtime/test/agent-control/parser.test.ts
+++ b/runtime/test/agent-control/parser.test.ts
@@ -137,9 +137,21 @@ describe("parseControlCommand", () => {
     expect(cmd).toEqual({ type: "shell", command: undefined, raw: "/shell" });
   });
 
+  test("/shell strips appended Files footer", () => {
+    const raw = "/shell ls\n\nFiles:\n- tmp/doc-log.txt";
+    const cmd = parseControlCommand(raw);
+    expect(cmd).toEqual({ type: "shell", command: "ls", raw });
+  });
+
   test("/bash with command", () => {
     const cmd = parseControlCommand("/bash echo hello");
     expect(cmd).toEqual({ type: "bash", command: "echo hello", raw: "/bash echo hello" });
+  });
+
+  test("/bash strips inline attachment footer after whitespace normalization", () => {
+    const raw = "/bash pwd\n\nAttachments:\n- notes/today.md";
+    const cmd = parseControlCommand(raw);
+    expect(cmd).toEqual({ type: "bash", command: "pwd", raw });
   });
 
   // /queue


### PR DESCRIPTION
## Summary
- add shell-arg sanitization for /shell and /bash control commands
- strip trailing Files:/Attachments: footer blocks before command execution
- add parser tests covering both footer cases

## Problem
Some chat transports append attachment metadata (for example: \Files:\n- tmp/doc-log.txt\) to command messages. Without sanitization, /shell and /bash can parse that metadata as extra command arguments, breaking valid commands like \/shell ls\.

## Validation
- bun test runtime/test/agent-control/parser.test.ts