### PR TITLE
fix(terminal): dock CSS/layout — flex sizing for terminal sidebar

### DIFF
--- a/runtime/web/src/panes/terminal-pane.ts
+++ b/runtime/web/src/panes/terminal-pane.ts
@@ -263,6 +263,9 @@ class TerminalPaneInstance implements PaneInstance {
 
         this.bodyEl = this.ownerDocument.createElement('div');
         this.bodyEl.className = 'terminal-pane-body';
+        this.bodyEl.style.display = 'flex';
+        this.bodyEl.style.flex = '1 1 auto';
+        this.bodyEl.style.minHeight = '0';
         this.bodyEl.innerHTML = '<div class="terminal-placeholder">Bootstrapping ghostty-web…</div>';
 
         this.termEl.append(this.bodyEl);
@@ -295,12 +298,22 @@ class TerminalPaneInstance implements PaneInstance {
         const host = this.bodyEl.querySelector('.terminal-live-host');
         if (!(host instanceof HTMLElement)) return;
 
+        host.style.display = 'flex';
+        host.style.flex = '1 1 auto';
+        host.style.width = '100%';
+        host.style.height = '100%';
+        host.style.minWidth = '0';
+        host.style.minHeight = '0';
+        host.style.overflow = 'hidden';
+
         const primaryChild = host.firstElementChild;
         if (primaryChild instanceof HTMLElement) {
             primaryChild.style.width = '100%';
             primaryChild.style.height = '100%';
             primaryChild.style.maxWidth = '100%';
             primaryChild.style.minWidth = '0';
+            primaryChild.style.minHeight = '0';
+            primaryChild.style.flex = '1 1 auto';
             primaryChild.style.display = 'block';
         }
 
@@ -308,6 +321,7 @@ class TerminalPaneInstance implements PaneInstance {
         if (canvas instanceof HTMLElement) {
             canvas.style.display = 'block';
             canvas.style.maxWidth = 'none';
+            canvas.style.maxHeight = 'none';
         }
     }
 
@@ -336,8 +350,14 @@ class TerminalPaneInstance implements PaneInstance {
             if (this.disposed) return;
 
             this.bodyEl.innerHTML = '';
-            const terminalHost = document.createElement('div');
+            const terminalHost = this.ownerDocument.createElement('div');
             terminalHost.className = 'terminal-live-host';
+            terminalHost.style.display = 'flex';
+            terminalHost.style.flex = '1 1 auto';
+            terminalHost.style.width = '100%';
+            terminalHost.style.height = '100%';
+            terminalHost.style.minWidth = '0';
+            terminalHost.style.minHeight = '0';
             this.bodyEl.appendChild(terminalHost);
 
             const terminal = new mod.Terminal({

--- a/runtime/web/src/ui/app-main-shell-render.ts
+++ b/runtime/web/src/ui/app-main-shell-render.ts
@@ -378,7 +378,7 @@ export function renderMainShell(options: MainShellRenderOptions): any {
             />
           `}
           ${hasDockPanes && dockVisible && html`<div class="dock-splitter" onMouseDown=${handleDockSplitterMouseDown} onTouchStart=${handleDockSplitterTouchStart}></div>`}
-          ${hasDockPanes && html`<div class=${`dock-panel${dockVisible ? '' : ' hidden'}`}>
+          ${hasDockPanes && html`<div class=${`dock-panel${dockVisible ? '' : ' hidden'}${editorOpen ? '' : ' standalone'}`}>
             <div class="dock-panel-header">
               <span class="dock-panel-title">Terminal</span>
               <div class="dock-panel-actions">

--- a/runtime/web/static/css/editor.css
+++ b/runtime/web/static/css/editor.css
@@ -749,6 +749,14 @@
     overflow: hidden;
 }
 
+.dock-panel.standalone {
+    height: 100%;
+    min-height: 0;
+    max-height: none;
+    flex: 1 1 auto;
+    border-top: none;
+}
+
 .dock-panel.hidden {
     display: none;
 }
@@ -816,7 +824,14 @@
 .dock-panel-body {
     flex: 1;
     min-height: 0;
-    overflow: auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.dock-panel-body > * {
+    flex: 1 1 auto;
+    min-height: 0;
 }
 
 .dock-panel-body-detached {


### PR DESCRIPTION
## Problem

When the terminal dock is the only panel visible (no editor open), it was constrained to `max-height: 50vh` and did not fill the sidebar. The terminal host and its children also lacked proper flex layout, causing the terminal to render at a tiny fixed size (~80×20) — vim/htop were garbled and barely usable.

## Changes

- Add `.dock-panel.standalone` CSS class (`height: 100%`, no max-height cap) applied when the editor pane is closed
- Make `.dock-panel-body` a flex column so children fill available space
- Set flex layout on `terminal-pane-body`, `terminal-live-host`, and their children so the terminal canvas fills the dock
- Use `ownerDocument.createElement` instead of `document.createElement` for correct document context in popout windows
- Add `maxHeight: none` on canvas to prevent height capping

## Files changed

- `runtime/web/static/css/editor.css` — standalone dock class, panel-body flex layout
- `runtime/web/src/ui/app-main-shell-render.ts` — toggle standalone class based on editor state
- `runtime/web/src/panes/terminal-pane.ts` — flex styles on body/host/child elements

## Testing

Verified on Chrome and Firefox: terminal fills the full sidebar in standalone mode, and correctly shares space with the editor when both are open.

---

Split from [#18](https://github.com/rcarmo/piclaw/issues/18) (patch 06) as requested — this is the CSS/layout portion.

---
*— PiClaw (claude-opus-4-6)*