### PR TITLE
fix(terminal): reliable popout→dock reattach via live transfer claims

### DIFF
--- a/runtime/web/src/ui/app-pane-runtime-orchestration.ts
+++ b/runtime/web/src/ui/app-pane-runtime-orchestration.ts
@@ -1202,23 +1202,74 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
       return;
     }
 
-    const instance = ext.mount(container, { mode: 'view' });
-    dockInstanceRef.current = instance;
-    void invokePaneAfterAttachToHost(instance, {
-      path: terminalTabPath,
-      hostMode: panePopoutMode ? 'popout' : 'main',
-      transferState: pendingPaneHostTransferRef.current?.path === terminalTabPath
-        ? (pendingPaneHostTransferRef.current.payload || null)
-        : null,
-    }).catch((error) => {
-      console.warn('[pane-attach] afterAttachToHost failed:', error);
-    });
-    if (pendingPaneHostTransferRef.current?.path === terminalTabPath) {
-      pendingPaneHostTransferRef.current = null;
-    }
-    requestAnimationFrame(() => instance.focus?.());
+    const pendingPopoutHostTransfer = pendingPaneHostTransferRef.current?.path === terminalTabPath
+      ? pendingPaneHostTransferRef.current
+      : null;
+    const pendingReattachHostTransfer = pendingReattachPaneHostTransfersRef.current.get(terminalTabPath) || null;
+    const pendingHostTransfer = pendingPopoutHostTransfer || pendingReattachHostTransfer;
+    const resolvedTransferState = pendingHostTransfer?.payload || null;
+    const liveTransferClaim = pendingReattachPaneClaimsRef.current.get(terminalTabPath) || null;
+    const liveTransferSourceWindow = pendingReattachPaneSourceWindowsRef.current.get(terminalTabPath) || null;
+    const hostMode = panePopoutMode ? 'popout' : 'main';
+
+    let instance: any = null;
+    let disposed = false;
+
+    const bindInstance = (nextInstance: any) => {
+      instance = nextInstance;
+      dockInstanceRef.current = nextInstance;
+      void invokePaneAfterAttachToHost(nextInstance, {
+        path: terminalTabPath,
+        hostMode,
+        transferState: resolvedTransferState,
+      }).catch((error) => {
+        console.warn('[pane-attach] afterAttachToHost failed:', error);
+      });
+      requestAnimationFrame(() => nextInstance.focus?.());
+    };
+
+    void (async () => {
+      if (pendingHostTransfer && liveTransferClaim && liveTransferSourceWindow) {
+        try {
+          const claimedInstance = await claimPaneLiveTransfer(liveTransferSourceWindow, liveTransferClaim, container, {
+            path: terminalTabPath,
+            hostMode,
+            transferState: resolvedTransferState,
+          });
+          if (!disposed && claimedInstance) {
+            bindInstance(claimedInstance);
+            if (pendingPopoutHostTransfer) {
+              pendingPaneHostTransferRef.current = null;
+            }
+            if (pendingReattachHostTransfer) {
+              pendingReattachPaneHostTransfersRef.current.delete(terminalTabPath);
+            }
+            pendingReattachPaneSourceWindowsRef.current.delete(terminalTabPath);
+            pendingReattachPaneClaimsRef.current.delete(terminalTabPath);
+            return;
+          }
+        } catch (error) {
+          console.warn('[pane-live-transfer] Failed to claim live dock pane instance:', error);
+        }
+      }
+
+      if (disposed) return;
+      bindInstance(ext.mount(container, {
+        mode: 'view',
+        ...(resolvedTransferState ? { transferState: resolvedTransferState } : {}),
+      }));
+      if (pendingPopoutHostTransfer) {
+        pendingPaneHostTransferRef.current = null;
+      }
+      if (pendingReattachHostTransfer) {
+        pendingReattachPaneHostTransfersRef.current.delete(terminalTabPath);
+      }
+      pendingReattachPaneSourceWindowsRef.current.delete(terminalTabPath);
+      pendingReattachPaneClaimsRef.current.delete(terminalTabPath);
+    })();
 
     return () => {
+      disposed = true;
       if (dockInstanceRef.current === instance) {
         instance.dispose();
         dockInstanceRef.current = null;


### PR DESCRIPTION
## Problem

When closing a popout terminal window, the terminal pane should reattach to the main window's dock without losing the WebSocket connection or requiring a full reconnect. Previously the dock mount effect always created a fresh instance via `ext.mount()`, which:

1. Lost the live terminal session (scrollback, working directory, running processes)
2. Required a full WebSocket reconnect
3. Could race with the popout's disposal, causing brief flickers or duplicate instances

## Changes

The dock mount effect now checks for pending live transfer claims before creating a fresh instance:

1. Gather pending transfer state from both popout and reattach refs
2. If a live transfer claim exists, attempt `claimPaneLiveTransfer()` — this moves the live pane DOM and WebSocket from the popout window into the dock container
3. Only fall back to fresh `ext.mount()` if the claim fails or no transfer is pending
4. Pass `transferState` through to both claim and fresh-mount paths
5. Clean up all pending transfer refs after resolution
6. Guard against disposal during the async claim with a `disposed` flag

## Files changed

- `runtime/web/src/ui/app-pane-runtime-orchestration.ts` — dock mount effect rewrite

## Testing

Verified: pop out terminal → close popout window → terminal reattaches to dock with session intact (scrollback preserved, processes still running, no reconnect flash).

---

Split from [#18](https://github.com/rcarmo/piclaw/issues/18) (patch 06) as requested — this is the popout→dock reattach portion.

Note: This PR overlaps with the Safari popout/reattach item mentioned in [#18 comment](https://github.com/rcarmo/piclaw/issues/18#issuecomment-4225676970).

---
*— PiClaw (claude-opus-4-6)*