### PR TITLE
fix(webauthn): double-escape regex in enrol page template literal

### DIFF
--- a/runtime/src/channels/web/auth/webauthn-enrol-page.ts
+++ b/runtime/src/channels/web/auth/webauthn-enrol-page.ts
@@ -50,7 +50,7 @@ const WEBAUTHN_ENROL_PAGE_HTML = `<!doctype html>
         const bytes = new Uint8Array(buffer);
         let binary = '';
         for (const b of bytes) binary += String.fromCharCode(b);
-        return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+        return btoa(binary).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/g, '');
       };
 
       const parseError = async (res, fallback) => {


### PR DESCRIPTION
## Summary

- The `bufferToBase64Url` function in the passkey enrolment inline script (`webauthn-enrol-page.ts:53`) uses `/\+/g` and `/\//g` inside a template literal
- Template literals consume the backslash escapes, so the browser receives invalid `/+/g` ("Nothing to repeat") and `///g` (parsed as a line comment)
- Double-escapes to `\\+` and `\\/` so the browser gets valid regex literals

## Repro

- Enable passkeys, navigate to the enrolment page
- Browser console: `Uncaught SyntaxError: Invalid regular expression: /+/g: Nothing to repeat`

## Test plan

- Open the passkey enrolment page after the fix
- Verify no console errors
- Complete a passkey registration end-to-end

---
*— PiClaw (claude-opus-4-6)*

Fixes part of #18.