### PR TITLE
fix(terminal): resolve script and bash from PATH instead of hardcoding /usr/bin

### DIFF
--- a/runtime/src/channels/web/terminal/terminal-session-service.ts
+++ b/runtime/src/channels/web/terminal/terminal-session-service.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { openSync, closeSync, readlinkSync, readdirSync, readFileSync } from "node:fs";
+import { openSync, closeSync, readlinkSync, readdirSync, readFileSync, accessSync, constants } from "node:fs";
 import { FFIType, dlopen } from "bun:ffi";
 import type { ServerWebSocket } from "bun";
 
@@ -188,8 +188,22 @@ function normalizeChunk(chunk: string | Uint8Array): string {
   return Buffer.from(chunk).toString("utf8");
 }
 
+const EXTRA_BIN_DIRS = ["/run/current-system/sw/bin", "/usr/local/bin", "/usr/bin", "/bin"];
+
+function findExecutable(name: string): string {
+  const dirs = (process.env.PATH || "").split(":").concat(EXTRA_BIN_DIRS);
+  for (const dir of dirs) {
+    const candidate = `${dir}/${name}`;
+    try { accessSync(candidate, constants.X_OK); return candidate; } catch { /* next */ }
+  }
+  return name;
+}
+
+const SCRIPT_BIN = findExecutable("script");
+const BASH_BIN = findExecutable("bash");
+
 function defaultSpawnProcess(cwd: string): TerminalProcessLike {
-  return spawn("/usr/bin/script", ["-qf", "-c", "/usr/bin/bash -i", "/dev/null"], {
+  return spawn(SCRIPT_BIN, ["-qf", "-c", `${BASH_BIN} -i`, "/dev/null"], {
     cwd,
     env: {
       ...process.env,


### PR DESCRIPTION
## Summary

- The terminal session hardcodes `/usr/bin/script` and `/usr/bin/bash` which don't exist on NixOS or other non-FHS distros
- On NixOS, the systemd service PATH is minimal and may not include the nix store path for `util-linux` (which provides `script`)
- Resolves both binaries by searching PATH first, then well-known fallback directories (`/run/current-system/sw/bin` for NixOS, `/usr/local/bin`, `/usr/bin`, `/bin`)

## Repro

- Run PiClaw on NixOS
- Open the terminal pane in the web UI
- Service crashes: `ENOENT: no such file or directory, posix_spawn '/usr/bin/script'`

## Test plan

- Verify terminal opens on NixOS
- Verify terminal still works on traditional Linux (Debian/Ubuntu) where `/usr/bin/script` exists

---
*— PiClaw (claude-opus-4-6)*

Discovered on our [NixOS PiClaw server](https://github.com/aliceisjustplaying/pix). Fixes part of #18.