### PR TITLE
feat(dream): support PICLAW_DREAM_MODEL env var for model override

### DIFF
--- a/runtime/src/dream.ts
+++ b/runtime/src/dream.ts
@@ -51,6 +51,7 @@ const DREAM_CURRENT_STATE_PATH = resolve(DREAM_MEMORY_DIR, "current-state.md");
 const DREAM_RECENT_CONTEXT_PATH = resolve(DREAM_MEMORY_DIR, "recent-context.md");
 const DREAM_MEMORY_PATH = resolve(DREAM_MEMORY_DIR, "MEMORY.md");
 const DREAM_BACKUP_KEEP = Math.max(1, Number.parseInt(process.env.PICLAW_DREAM_BACKUP_KEEP || "10", 10) || 10);
+const DREAM_MODEL = process.env.PICLAW_DREAM_MODEL?.trim() || null;
 
 export interface DreamAgentTurnResult {
   mode: "manual" | "auto";
@@ -468,7 +469,7 @@ export function ensureDreamTask(chatJid = "web:default") {
       id: DREAM_TASK_ID,
       chat_jid: chatJid,
       prompt: DREAM_TASK_PROMPT,
-      model: null,
+      model: DREAM_MODEL,
       task_kind: DREAM_TASK_KIND,
       command: null,
       cwd: null,
@@ -488,7 +489,7 @@ export function ensureDreamTask(chatJid = "web:default") {
 
   updateTask(DREAM_TASK_ID, {
     prompt: DREAM_TASK_PROMPT,
-    model: null,
+    model: DREAM_MODEL,
     task_kind: DREAM_TASK_KIND,
     command: null,
     cwd: null,

--- a/runtime/src/task-scheduler.ts
+++ b/runtime/src/task-scheduler.ts
@@ -262,11 +262,23 @@ export async function runScheduledTask(task: ScheduledTask, deps: SchedulerDeps)
       : "agent";
 
   if (kind === "internal") {
-    const out = await runInternalTask(task, deps);
-    if (out.error) {
-      error = out.error;
-    } else {
-      result = out.result;
+    // Switch model if the internal task specifies one (e.g. Dream).
+    const savedModel = task.model ? await deps.agentPool.getCurrentModelLabel(task.chat_jid) : null;
+    if (task.model && (!savedModel || savedModel !== task.model)) {
+      const switchErr = await switchTaskModel(task, deps);
+      if (switchErr) { error = switchErr; }
+    }
+    if (!error) {
+      const out = await runInternalTask(task, deps);
+      if (out.error) {
+        error = out.error;
+      } else {
+        result = out.result;
+      }
+    }
+    // Restore original model after internal task completes.
+    if (task.model) {
+      await restoreOriginalModel(task, deps, savedModel);
     }
   } else if (kind === "shell") {
     const out = await runShellTask(task);


### PR DESCRIPTION
Internal tasks (Dream in particular) currently inherit whatever model the chat happens to be on. This means memory consolidation quality depends on the day-to-day model choice.

This adds `PICLAW_DREAM_MODEL` env var support:
- Read the env var at startup in `dream.ts`
- Pass it as the task model when scheduling Dream runs
- In `task-scheduler.ts`, switch model before running internal tasks using the existing `switchTaskModel`/`restoreOriginalModel` helpers
- Restore the original model after the internal task completes

When `PICLAW_DREAM_MODEL` is unset, behavior is unchanged (inherits the session model).

Submitted per request in https://github.com/rcarmo/piclaw/issues/18#issuecomment-2808291541.