### PR TITLE
fix(ui-bridge): TS2352 build error in extension error formatting

### DIFF
--- a/runtime/src/channels/web/theming/ui-bridge.ts
+++ b/runtime/src/channels/web/theming/ui-bridge.ts
@@ -106,21 +106,11 @@ export class UiBridge {
         reload: () => session.reload(),
       },
       onError: (error) => {
-        const formattedError = error instanceof Error
-          ? error.message
-          : error && typeof error === "object"
-            ? [
-                typeof (error as Record<string, unknown>).error === "string"
-                  ? (error as Record<string, unknown>).error
-                  : null,
-                typeof (error as Record<string, unknown>).event === "string"
-                  ? `during ${(error as Record<string, unknown>).event}`
-                  : null,
-                typeof (error as Record<string, unknown>).extensionPath === "string"
-                  ? `in ${(error as Record<string, unknown>).extensionPath}`
-                  : null,
-              ].filter(Boolean).join(" ") || String(error)
-            : String(error);
+        const formattedError = [
+          error.error || null,
+          error.event ? `during ${error.event}` : null,
+          error.extensionPath ? `in ${error.extensionPath}` : null,
+        ].filter(Boolean).join(" ") || String(error);
         log.error("Extension UI error", {
           chatJid,
           err: error,


### PR DESCRIPTION
Commit 4fcd82d introduced `Record<string, unknown>` casts on the `ExtensionError` parameter in the `onError` callback. TypeScript rejects these because `ExtensionError` is a concrete interface without an index signature.

The `onError` callback is typed as `ExtensionErrorListener` (from `pi-coding-agent`), which receives an `ExtensionError` with `.error`, `.event`, and `.extensionPath` as string fields. The casts are unnecessary — this PR accesses the fields directly.

**Before (fails `bun run build`):**
```ts
typeof (error as Record<string, unknown>).error === "string"
  ? (error as Record<string, unknown>).error
```

**After:**
```ts
error.error || null,
error.event ? \`during \${error.event}\` : null,
error.extensionPath ? \`in \${error.extensionPath}\` : null,
```