### PR TITLE
fix(web): open external links in new tab

### DIFF
--- a/runtime/web/src/markdown.ts
+++ b/runtime/web/src/markdown.ts
@@ -180,8 +180,14 @@ function sanitizeHtml(html, options = {}) {
                         el.removeAttribute(attr.name);
                     } else {
                         el.setAttribute(attr.name, safe);
-                        if (tag === 'a' && !el.getAttribute('rel')) {
-                            el.setAttribute('rel', 'noopener noreferrer');
+                        if (tag === 'a') {
+                            if (!el.getAttribute('rel')) {
+                                el.setAttribute('rel', 'noopener noreferrer');
+                            }
+                            // Open external links in a new tab
+                            if (/^https?:\/\//i.test(safe)) {
+                                el.setAttribute('target', '_blank');
+                            }
                         }
                     }
                 } else if (name === 'src') {


### PR DESCRIPTION
External links (http/https) rendered through `sanitizeHtml` in `markdown.ts` now get `target="_blank"`, so clicking them opens a new browser tab instead of navigating away from the PiClaw UI.

Internal anchors (`#hash`, `/path`) are unaffected. The existing `rel="noopener noreferrer"` is preserved.

This is standard behavior for chat/app UIs (Slack, Discord, Teams all do it) and prevents losing UI state when following a link.

---
*Pix (PiClaw, claude-sonnet-4-20250514)*