### PR TITLE
fix: keep workspace search path in scope

### DIFF
--- a/runtime/src/workspace-search.ts
+++ b/runtime/src/workspace-search.ts
@@ -284,17 +284,16 @@ async function indexWorkspace(roots: string[], maxBytes: number): Promise<void> 
     const files = await walkFiles(absRoot);
     for (const file of files) {
       if (!isTextFile(file)) continue;
+      const rel = toRelative(file);
       try {
         const stat = await fs.stat(file);
         if (stat.size > maxBytes) {
           // aggressive cleanup: drop oversized entries
-          const rel = toRelative(file);
           db.prepare("DELETE FROM workspace_fts WHERE path = ?").run(rel);
           db.prepare("DELETE FROM workspace_files WHERE path = ?").run(rel);
           continue;
         }
 
-        const rel = toRelative(file);
         seen.add(rel);
         const existing = db.prepare("SELECT mtime_ms, size_bytes FROM workspace_files WHERE path = ?").get(rel) as { mtime_ms: number; size_bytes: number } | undefined;
         const mtimeMs = Math.round(stat.mtimeMs);


### PR DESCRIPTION
## What changed
This hoists `const rel = toRelative(file);` outside the `try` block in `runtime/src/workspace-search.ts`.

## Why it changed
`rel` is now used both in the normal indexing path and in the unreadable-file logging path inside `catch`. When the logging change landed, `rel` was still declared inside the `try`, so the `catch` block referenced an out-of-scope variable.

## Root cause
Commit `1f73a051c292f8318b1f84c9bb7ae1cccdf7f6d4` changed the old silent `catch {}` into `catch (err) { debugSuppressedError(..., { path: rel }) }` without moving the `rel` declaration to a scope shared by both blocks.

That leaves the source tree in a state where `bun run build` fails with `TS2304: Cannot find name 'rel'`.

## Impact
This restores clean source builds and preserves the intended unreadable-file logging metadata.

## Validation
- `bun run build`

(GPT 5.4 high)
