### PR TITLE
Fix workspace rename key handling to avoid accidental delete

### DIFF
--- a/runtime/web/src/components/workspace-explorer.ts
+++ b/runtime/web/src/components/workspace-explorer.ts
@@ -1452,6 +1452,12 @@ export function WorkspaceExplorer({
         return Boolean(targetEl?.closest?.('.workspace-node-icon, .workspace-label-text'));
     };
 
+    const isEditableKeyboardTarget = (targetEl) => {
+        if (!targetEl) return false;
+        if (targetEl.closest?.('input, textarea, [contenteditable="true"]')) return true;
+        return Boolean(targetEl.isContentEditable);
+    };
+
     // ── Double-click to rename selected workspace entry ────────────────────
     const handleTreeDblClick = useRef((e) => {
         const targetEl = getEventTargetElement(e);
@@ -1585,6 +1591,8 @@ export function WorkspaceExplorer({
     }, []);
 
     const handleTreeKeyDown = useCallback((e) => {
+        const targetEl = getEventTargetElement(e);
+        if (renamingPathRef.current || isEditableKeyboardTarget(targetEl)) return;
         const currentRows = rows;
         if (!currentRows || currentRows.length === 0) return;
         const currentIndex = selectedPath
@@ -2352,6 +2360,7 @@ export function WorkspaceExplorer({
                                                 value=${renameValue}
                                                 onInput=${(e) => setRenameValue(e?.target?.value || '')}
                                                 onKeyDown=${(e) => {
+                                                    e.stopPropagation();
                                                     if (e.key === 'Enter') {
                                                         e.preventDefault();
                                                         commitRename();


### PR DESCRIPTION
## Summary
- prevent rename input keydown from bubbling into workspace tree shortcuts
- ignore tree keyboard handling when rename mode is active or the event target is editable
- fix the case where Backspace/Delete during filename rename opened a delete-file confirmation

## Reproduction
1. Open workspace explorer and select a file.
2. Double-click the file name to enter rename mode.
3. Press Backspace or Delete.
4. Before this fix, a delete confirmation dialog appears.

## Expected after fix
- Backspace/Delete only edits the rename input value.
- No delete confirmation is triggered while renaming.

## Validation
- Reproduced on latest main clone before fix.
- Verified after fix: no delete dialog, rename input remains active, value updates as expected.