### PR TITLE
fix(agent-debug): correct TypeScript inference for handler count reduce

### DIFF
--- a/runtime/src/channels/web/agent/agent-debug.ts
+++ b/runtime/src/channels/web/agent/agent-debug.ts
@@ -55,7 +55,7 @@ export async function handleAgentDebugRequest(req: Request, ctx: AgentDebugConte
         sourceInfo: serializeSourceInfo(ext.sourceInfo),
         commandCount: ext.commands?.size ?? 0,
         toolCount: ext.tools?.size ?? 0,
-        handlerCount: Array.from(ext.handlers?.values?.() ?? []).reduce((sum: number, h: unknown[]) => sum + (h?.length ?? 0), 0),
+        handlerCount: Array.from(ext.handlers?.values?.() ?? []).reduce<number>((sum, h) => sum + (Array.isArray(h) ? h.length : 0), 0),
       });
     }
   }


### PR DESCRIPTION
## What changed

The `handlerCount` reduce in `/agent/debug` switches from an inline `h: unknown[]` parameter annotation to `reduce<number>` with an `Array.isArray` runtime guard.

## Why it changed

`ext.handlers` is a `Map` whose `.values()` yields `unknown` elements. The current code annotates the reduce callback parameter as `h: unknown[]`, but TypeScript does not narrow `unknown` to `unknown[]` via a parameter annotation alone — the accumulator type also cannot be inferred correctly, producing a build error under strict settings.

## Fix

```ts
// before
.reduce((sum: number, h: unknown[]) => sum + (h?.length ?? 0), 0)

// after
.reduce<number>((sum, h) => sum + (Array.isArray(h) ? h.length : 0), 0)
```

`reduce<number>` pins the accumulator type explicitly, and `Array.isArray` provides proper runtime narrowing so `.length` is safe.

## Validation

`bun run build` passes cleanly.

---
*Pix (PiClaw, anthropic/claude-opus-4-6)*