### PR TITLE
Add terminal reopen Playwright repro and stress harnesses

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:coverage": "cd runtime && rm -rf generated/coverage && PICLAW_DB_IN_MEMORY=1 bun test --max-concurrency=1 --coverage --coverage-dir=generated/coverage --coverage-reporter=text --coverage-reporter=lcov",
     "test:optional:browser-isolation": "cd runtime && PICLAW_DB_IN_MEMORY=1 PICLAW_RUN_OPTIONAL_BROWSER_TESTS=1 bun test --max-concurrency=1 --timeout=30000 test/channels/web/browser-chat-isolation.optional.test.ts",
     "test:oobe:local-container": "./scripts/ensure-playwright-browser-isolation.sh && bun run runtime/scripts/playwright/oobe-local-container.ts",
+    "test:e2e:terminal-reopen": "bun run runtime/scripts/playwright/terminal-reopen.ts",
     "check:pack-hygiene": "bun run runtime/scripts/pack-hygiene.ts",
     "check:stale-dist": "cd runtime && bun run scripts/check-stale-dist.ts",
     "check:import-boundaries": "cd runtime && bun run scripts/check-import-boundaries.ts",

--- a/runtime/scripts/playwright/terminal-reopen-multicycle.ts
+++ b/runtime/scripts/playwright/terminal-reopen-multicycle.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+import { chromium } from 'playwright';
+import { bootstrapE2EStorageState } from './web-auth-bootstrap.ts';
+
+function readDebug(page: any) {
+  return page.evaluate(() => {
+    const host = document.querySelector('.terminal-live-host');
+    const term = host && (host as any).__terminal;
+    if (!term) return null;
+    return {
+      sessionMeta: term.__piclawSessionMeta || null,
+      lines: Array.from({ length: 8 }, (_, row) => {
+        const line = term.wasmTerm?.getLine?.(row);
+        if (!line) return null;
+        return line.map((cell: any) => (!cell || cell.width === 0) ? '' : String.fromCodePoint(cell.codepoint || 32)).join('').replace(/\s+$/g, '');
+      }),
+      activeTag: document.activeElement?.tagName || null,
+      activeAria: document.activeElement?.getAttribute?.('aria-label') || null,
+    };
+  });
+}
+
+const cycles = Number(process.env.PICLAW_MULTICYCLE_COUNT || '5');
+const storageState = await bootstrapE2EStorageState({
+  baseUrl: 'http://127.0.0.1:8080',
+  internalSecret: process.env.PICLAW_INTERNAL_SECRET || process.env.PICLAW_WEB_INTERNAL_SECRET,
+});
+const browser = await chromium.launch({ headless: true, executablePath: process.env.PICLAW_PLAYWRIGHT_EXECUTABLE_PATH });
+const context = await browser.newContext({ storageState });
+const page = await context.newPage();
+await page.goto('http://127.0.0.1:8080', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(2000);
+
+for (let cycle = 1; cycle <= cycles; cycle += 1) {
+  await page.keyboard.press('Control+`');
+  await page.locator('.terminal-live-host').first().waitFor({ state: 'visible', timeout: 15000 });
+  await page.waitForTimeout(700);
+  await page.locator('.terminal-live-host').first().click({ position: { x: 24, y: 24 } });
+  await page.keyboard.type(`printf "__CYCLE_${cycle}__\\n"\n`, { delay: 10 });
+  await page.waitForTimeout(1500);
+  const afterType = await readDebug(page);
+  console.log(JSON.stringify({ cycle, phase: 'afterType', state: afterType }));
+  if (cycle < cycles) {
+    await page.locator('button[aria-label="Hide terminal"]').first().click();
+    await page.waitForTimeout(350);
+  }
+}
+
+await context.close();
+await browser.close();

--- a/runtime/scripts/playwright/terminal-reopen-race.ts
+++ b/runtime/scripts/playwright/terminal-reopen-race.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+import { chromium } from 'playwright';
+import { bootstrapE2EStorageState } from './web-auth-bootstrap.ts';
+
+const cycles = Number(process.env.PICLAW_RACE_CYCLES || '12');
+const reopenWaitMs = Number(process.env.PICLAW_RACE_REOPEN_WAIT_MS || '40');
+const typeDelayMs = Number(process.env.PICLAW_RACE_TYPE_DELAY_MS || '8');
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readState(page: any) {
+  return page.evaluate(() => {
+    const host = document.querySelector('.terminal-live-host');
+    const term = host && (host as any).__terminal;
+    const lines = [];
+    if (term?.wasmTerm?.getLine) {
+      for (let row = 0; row < 8; row += 1) {
+        const line = term.wasmTerm.getLine(row);
+        if (!line) {
+          lines.push(null);
+          continue;
+        }
+        lines.push(line.map((cell: any) => (!cell || cell.width === 0) ? '' : String.fromCodePoint(cell.codepoint || 32)).join('').replace(/\s+$/g, ''));
+      }
+    }
+    return {
+      activeTag: document.activeElement?.tagName || null,
+      activeAria: document.activeElement?.getAttribute?.('aria-label') || null,
+      status: document.querySelector('.terminal-pane-content')?.getAttribute('data-connection-status') || null,
+      sessionMeta: term?.__piclawSessionMeta || null,
+      hasBlankSnapshot: term?.hasSnapshot?.() ?? null,
+      isResizing: term?._isResizing ?? null,
+      writeQueueLength: term?._writeQueue?.length ?? null,
+      cols: term?.cols ?? null,
+      rows: term?.rows ?? null,
+      lines,
+    };
+  });
+}
+
+const storageState = await bootstrapE2EStorageState({
+  baseUrl: 'http://127.0.0.1:8080',
+  internalSecret: process.env.PICLAW_INTERNAL_SECRET || process.env.PICLAW_WEB_INTERNAL_SECRET,
+});
+const browser = await chromium.launch({ headless: true, executablePath: process.env.PICLAW_PLAYWRIGHT_EXECUTABLE_PATH });
+const context = await browser.newContext({ storageState, viewport: { width: 1280, height: 900 } });
+const page = await context.newPage();
+const events: any[] = [];
+page.on('console', (msg) => events.push({ kind: 'console', type: msg.type(), text: msg.text(), ts: Date.now() }));
+page.on('pageerror', (err) => events.push({ kind: 'pageerror', text: String(err), ts: Date.now() }));
+
+await page.goto('http://127.0.0.1:8080', { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(2000);
+
+for (let cycle = 1; cycle <= cycles; cycle += 1) {
+  if (cycle === 1) {
+    await page.keyboard.press('Control+`');
+    await page.locator('.terminal-live-host').first().waitFor({ state: 'visible', timeout: 15000 });
+    await page.waitForTimeout(200);
+  } else {
+    await page.locator('button[aria-label="Hide terminal"]').first().click();
+    await page.waitForTimeout(120);
+    await page.keyboard.press('Control+`');
+    await page.locator('.terminal-live-host').first().waitFor({ state: 'visible', timeout: 15000 });
+    await page.waitForTimeout(reopenWaitMs);
+  }
+
+  await page.locator('.terminal-live-host').first().click({ position: { x: 30, y: 30 } });
+  const before = await readState(page);
+  const cmd = `printf "__RACE_${cycle}__\\n"`;
+  await page.keyboard.type(cmd, { delay: typeDelayMs });
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(450);
+  const after450 = await readState(page);
+  await page.waitForTimeout(1500);
+  const after1950 = await readState(page);
+  const joined = JSON.stringify(after1950.lines || []);
+  const ok = joined.includes(`__RACE_${cycle}__`);
+  console.log(JSON.stringify({ cycle, before, after450, after1950, ok }));
+}
+
+console.log('EVENTS=' + JSON.stringify(events));
+await context.close();
+await browser.close();

--- a/runtime/scripts/playwright/terminal-reopen.ts
+++ b/runtime/scripts/playwright/terminal-reopen.ts
@@ -1,0 +1,367 @@
+#!/usr/bin/env bun
+// @ts-nocheck
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { chromium } from 'playwright';
+
+import { bootstrapE2EStorageState } from './web-auth-bootstrap.ts';
+
+const DEFAULT_BASE_URL = process.env.PICLAW_E2E_BASE_URL || 'http://127.0.0.1:8080';
+const DEFAULT_HEADLESS = process.env.PICLAW_E2E_HEADLESS !== '0';
+const DEFAULT_SLOW_MO = Number(process.env.PICLAW_E2E_SLOW_MO || 0);
+const DEFAULT_WAIT_MS = Number(process.env.PICLAW_E2E_WAIT_MS || 250);
+const DEFAULT_EXECUTABLE_PATH = process.env.PICLAW_PLAYWRIGHT_EXECUTABLE_PATH || '';
+
+function parseArgs(argv: string[]) {
+  const args = {
+    baseUrl: DEFAULT_BASE_URL,
+    headless: DEFAULT_HEADLESS,
+    slowMo: DEFAULT_SLOW_MO,
+    waitMs: DEFAULT_WAIT_MS,
+    internalSecret: process.env.PICLAW_INTERNAL_SECRET || process.env.PICLAW_WEB_INTERNAL_SECRET || '',
+    executablePath: DEFAULT_EXECUTABLE_PATH,
+    label: 'terminal-reopen',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    const next = i + 1 < argv.length ? argv[i + 1] : '';
+    if (value === '--base-url' && next) {
+      args.baseUrl = next;
+      i += 1;
+      continue;
+    }
+    if (value === '--internal-secret' && next) {
+      args.internalSecret = next;
+      i += 1;
+      continue;
+    }
+    if (value === '--label' && next) {
+      args.label = next;
+      i += 1;
+      continue;
+    }
+    if (value === '--executable-path' && next) {
+      args.executablePath = next;
+      i += 1;
+      continue;
+    }
+    if (value === '--wait-ms' && next) {
+      args.waitMs = Number(next);
+      i += 1;
+      continue;
+    }
+    if (value === '--headed') {
+      args.headless = false;
+      continue;
+    }
+    if (value === '--slow-mo' && next) {
+      args.slowMo = Number(next);
+      i += 1;
+      continue;
+    }
+  }
+
+  if (!Number.isFinite(args.waitMs) || args.waitMs < 0) throw new Error(`Invalid --wait-ms value: ${args.waitMs}`);
+  if (!Number.isFinite(args.slowMo) || args.slowMo < 0) throw new Error(`Invalid --slow-mo value: ${args.slowMo}`);
+  return args;
+}
+
+function stampNow() {
+  return new Date().toISOString().replace(/[.:]/g, '-');
+}
+
+function log(message: string, ...rest: unknown[]) {
+  console.log(`[terminal-reopen] ${message}`, ...rest);
+}
+
+async function wait(ms: number) {
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+async function installPageInstrumentation(page) {
+  await page.addInitScript(() => {
+    const target = (window.__PICLAW_E2E__ = window.__PICLAW_E2E__ || { events: [] });
+    const push = (type, extra = {}) => {
+      try {
+        target.events.push({ t: Number(performance.now().toFixed(1)), type, ...extra });
+      } catch {}
+    };
+
+    const summarize = (node) => ({
+      tag: node?.tagName || null,
+      className: typeof node?.className === 'string' ? node.className : null,
+      text: typeof node?.textContent === 'string' ? node.textContent.slice(0, 120) : null,
+    });
+
+    const install = () => {
+      push('instrumentation-ready', { readyState: document.readyState });
+      const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of mutation.addedNodes || []) {
+            if (!(node instanceof Element)) continue;
+            if (node.matches('.dock-panel, .terminal-pane-content, .terminal-live-host, canvas')) {
+              push('node-added', summarize(node));
+            }
+            for (const child of node.querySelectorAll?.('.dock-panel, .terminal-pane-content, .terminal-live-host, canvas') || []) {
+              push('node-added', summarize(child));
+            }
+          }
+          for (const node of mutation.removedNodes || []) {
+            if (!(node instanceof Element)) continue;
+            if (node.matches('.dock-panel, .terminal-pane-content, .terminal-live-host, canvas')) {
+              push('node-removed', summarize(node));
+            }
+            for (const child of node.querySelectorAll?.('.dock-panel, .terminal-pane-content, .terminal-live-host, canvas') || []) {
+              push('node-removed', summarize(child));
+            }
+          }
+        }
+      });
+      observer.observe(document.documentElement, { childList: true, subtree: true });
+      target.snapshot = () => {
+        const dockPanel = document.querySelector('.dock-panel');
+        const terminalPane = document.querySelector('.terminal-pane-content');
+        const host = document.querySelector('.terminal-live-host');
+        const canvases = Array.from(document.querySelectorAll('canvas')).map((canvas) => ({
+          width: canvas.width,
+          height: canvas.height,
+          className: canvas.className || '',
+          parentClassName: canvas.parentElement?.className || '',
+        }));
+        const liveHost = document.querySelector('.terminal-live-host');
+        const terminalDebug = liveHost && liveHost.__terminal ? (() => {
+          try {
+            const term = liveHost.__terminal;
+            const lines = [];
+            const count = Math.min(8, term.rows || 0);
+            for (let row = 0; row < count; row += 1) {
+              const line = term.wasmTerm?.getLine?.(row);
+              if (!line) {
+                lines.push(null);
+                continue;
+              }
+              const text = line.map((cell) => {
+                if (!cell || cell.width === 0) return '';
+                return String.fromCodePoint(cell.codepoint || 32);
+              }).join('');
+              lines.push(text.replace(/\s+$/g, ''));
+            }
+            return {
+              cols: term.cols,
+              rows: term.rows,
+              viewportY: term.viewportY,
+              title: term.currentTitle,
+              sessionMeta: term.__piclawSessionMeta || null,
+              lines,
+            };
+          } catch (error) {
+            return { error: String(error) };
+          }
+        })() : null;
+        return {
+          url: window.location.href,
+          title: document.title,
+          activeElement: document.activeElement ? {
+            tag: document.activeElement.tagName,
+            className: document.activeElement.className || '',
+            ariaLabel: document.activeElement.getAttribute?.('aria-label') || null,
+          } : null,
+          dockPanelClass: dockPanel?.className || null,
+          terminalPaneStatus: terminalPane?.getAttribute?.('data-connection-status') || null,
+          terminalPaneCount: document.querySelectorAll('.terminal-pane-content').length,
+          terminalHostCount: document.querySelectorAll('.terminal-live-host').length,
+          canvasCount: canvases.length,
+          canvases,
+          dockText: dockPanel?.textContent?.slice(0, 200) || null,
+          hostRect: host ? {
+            width: Math.round(host.getBoundingClientRect().width),
+            height: Math.round(host.getBoundingClientRect().height),
+          } : null,
+          terminalDebug,
+        };
+      };
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', install, { once: true });
+    } else {
+      install();
+    }
+  });
+}
+
+async function capture(page, artifactDir: string, name: string, meta: Record<string, unknown> = {}) {
+  const screenshotPath = join(artifactDir, `${name}.png`);
+  const jsonPath = join(artifactDir, `${name}.json`);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  const snapshot = await page.evaluate((extra) => ({
+    extra,
+    state: window.__PICLAW_E2E__?.snapshot?.() || null,
+    events: window.__PICLAW_E2E__?.events || [],
+  }), meta);
+  writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2));
+}
+
+async function toggleTerminal(page) {
+  await page.keyboard.press('Control+`');
+}
+
+async function openTerminal(page) {
+  if (await page.locator('.terminal-live-host').count()) return;
+  await toggleTerminal(page);
+  await page.locator('.terminal-live-host').first().waitFor({ state: 'visible', timeout: 15000 });
+}
+
+async function closeTerminal(page) {
+  if (!(await page.locator('.terminal-live-host').count())) return;
+  const closeButton = page.locator('button[aria-label="Hide terminal"]:visible').first();
+  if (await closeButton.count()) {
+    await closeButton.click();
+  } else {
+    await toggleTerminal(page);
+  }
+  await page.waitForFunction(() => document.querySelectorAll('.terminal-live-host').length === 0, undefined, { timeout: 15000 });
+}
+
+async function focusTerminal(page) {
+  const host = page.locator('.terminal-live-host').first();
+  await host.click({ position: { x: 24, y: 24 } });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = resolve(import.meta.dir, '..', '..', '..');
+  const stamp = stampNow();
+  const artifactDir = resolve(repoRoot, 'artifacts', 'playwright-terminal-reopen', `${stamp}-${args.label}`);
+  mkdirSync(artifactDir, { recursive: true });
+
+  const consoleLines: string[] = [];
+  const terminalNetwork: Array<Record<string, unknown>> = [];
+  let browser = null;
+  let context = null;
+  let page = null;
+
+  try {
+    const storageState = await bootstrapE2EStorageState({
+      baseUrl: args.baseUrl,
+      internalSecret: args.internalSecret,
+    });
+
+    browser = await chromium.launch({
+      headless: args.headless,
+      slowMo: args.slowMo || undefined,
+      executablePath: args.executablePath || undefined,
+    });
+    context = await browser.newContext({ storageState });
+    await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+    page = await context.newPage();
+
+    await installPageInstrumentation(page);
+
+    page.on('console', (message) => {
+      consoleLines.push(`[${message.type()}] ${message.text()}`);
+    });
+    page.on('request', (request) => {
+      const url = request.url();
+      if (url.includes('/terminal/')) {
+        terminalNetwork.push({ kind: 'request', method: request.method(), url, ts: Date.now() });
+      }
+    });
+    page.on('response', async (response) => {
+      const url = response.url();
+      if (url.includes('/terminal/')) {
+        terminalNetwork.push({ kind: 'response', status: response.status(), url, ts: Date.now() });
+      }
+    });
+    page.on('websocket', (ws) => {
+      const url = ws.url();
+      if (!url.includes('/terminal/ws')) return;
+      terminalNetwork.push({ kind: 'websocket-open', url, ts: Date.now() });
+      ws.on('framereceived', (event) => {
+        const payload = String(event.payload || '');
+        terminalNetwork.push({
+          kind: 'ws-frame-received',
+          url,
+          ts: Date.now(),
+          size: payload.length,
+          preview: payload.slice(0, 240),
+        });
+      });
+      ws.on('framesent', (event) => {
+        const payload = String(event.payload || '');
+        terminalNetwork.push({
+          kind: 'ws-frame-sent',
+          url,
+          ts: Date.now(),
+          size: payload.length,
+          preview: payload.slice(0, 240),
+        });
+      });
+      ws.on('close', () => {
+        terminalNetwork.push({ kind: 'websocket-close', url, ts: Date.now() });
+      });
+    });
+
+    await page.goto(args.baseUrl, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(2000);
+    await capture(page, artifactDir, '00-loaded');
+
+    await openTerminal(page);
+    await wait(args.waitMs);
+    await focusTerminal(page);
+    await page.keyboard.type('echo __PICLAW_TERMINAL_REOPEN__\n', { delay: 8 });
+    await wait(args.waitMs);
+    await capture(page, artifactDir, '01-opened-after-command');
+
+    await closeTerminal(page);
+    await wait(100);
+    await capture(page, artifactDir, '02-closed');
+
+    await openTerminal(page);
+    await capture(page, artifactDir, '03-reopened-immediate');
+    for (const [idx, delay] of [50, 100, 200, 400].entries()) {
+      await wait(delay);
+      await capture(page, artifactDir, `04-reopened-plus-${idx + 1}-${delay}ms`, { delay });
+    }
+
+    await focusTerminal(page);
+    await page.keyboard.type('printf "__PICLAW_REOPEN_TYPECHECK__\\n"\n', { delay: 8 });
+    await wait(args.waitMs + 200);
+    await capture(page, artifactDir, '05-reopened-after-typing');
+
+    const finalState = await page.evaluate(() => ({
+      state: window.__PICLAW_E2E__?.snapshot?.() || null,
+      events: window.__PICLAW_E2E__?.events || [],
+    }));
+
+    const tracePath = join(artifactDir, 'trace.zip');
+    await context.tracing.stop({ path: tracePath });
+
+    writeFileSync(join(artifactDir, 'report.json'), JSON.stringify({
+      baseUrl: args.baseUrl,
+      artifactDir,
+      consoleLines,
+      terminalNetwork,
+      finalState,
+      tracePath,
+    }, null, 2));
+
+    log(`Artifacts written to ${artifactDir}`);
+    log(`Trace: ${tracePath}`);
+  } finally {
+    if (context) {
+      try {
+        await context.close();
+      } catch {}
+    }
+    if (browser) {
+      try {
+        await browser.close();
+      } catch {}
+    }
+  }
+}
+
+await main();

--- a/runtime/scripts/playwright/web-auth-bootstrap.ts
+++ b/runtime/scripts/playwright/web-auth-bootstrap.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+// @ts-nocheck
+
+export function resolveInternalSecret(explicitSecret?: string): string {
+  const value = String(
+    explicitSecret ||
+    process.env.PICLAW_INTERNAL_SECRET ||
+    process.env.PICLAW_WEB_INTERNAL_SECRET ||
+    ''
+  ).trim();
+  if (!value) {
+    throw new Error('Missing internal secret. Pass --internal-secret or set PICLAW_INTERNAL_SECRET / PICLAW_WEB_INTERNAL_SECRET.');
+  }
+  return value;
+}
+
+function parseSetCookie(setCookieHeader: string | null, baseUrl: string) {
+  if (!setCookieHeader) {
+    throw new Error('E2E auth bootstrap did not return a Set-Cookie header.');
+  }
+
+  const parts = setCookieHeader.split(';').map((part) => part.trim()).filter(Boolean);
+  const [nameValue, ...attrs] = parts;
+  const eq = nameValue.indexOf('=');
+  if (eq <= 0) {
+    throw new Error(`Invalid Set-Cookie header: ${setCookieHeader}`);
+  }
+
+  const name = nameValue.slice(0, eq).trim();
+  const value = nameValue.slice(eq + 1);
+  const url = new URL(baseUrl);
+  const cookie = {
+    name,
+    value,
+    domain: url.hostname,
+    path: '/',
+    httpOnly: false,
+    secure: url.protocol === 'https:',
+    sameSite: 'Lax',
+    expires: -1,
+  } as any;
+
+  for (const attr of attrs) {
+    const [rawKey, ...rawRest] = attr.split('=');
+    const key = String(rawKey || '').trim().toLowerCase();
+    const attrValue = rawRest.join('=').trim();
+    if (key === 'path' && attrValue) cookie.path = attrValue;
+    else if (key === 'domain' && attrValue) cookie.domain = attrValue.replace(/^\./, '');
+    else if (key === 'httponly') cookie.httpOnly = true;
+    else if (key === 'secure') cookie.secure = true;
+    else if (key === 'samesite' && attrValue) {
+      const normalized = attrValue.toLowerCase();
+      if (normalized === 'strict') cookie.sameSite = 'Strict';
+      else if (normalized === 'none') cookie.sameSite = 'None';
+      else cookie.sameSite = 'Lax';
+    } else if (key === 'max-age' && attrValue && Number.isFinite(Number(attrValue))) {
+      cookie.expires = Math.floor(Date.now() / 1000) + Number(attrValue);
+    }
+  }
+
+  return cookie;
+}
+
+export async function bootstrapE2EStorageState(options: {
+  baseUrl: string;
+  internalSecret?: string;
+}) {
+  const baseUrl = String(options.baseUrl || '').trim().replace(/\/$/, '');
+  if (!baseUrl) throw new Error('bootstrapE2EStorageState requires a baseUrl.');
+
+  const response = await fetch(`${baseUrl}/auth/e2e/bootstrap`, {
+    method: 'POST',
+    headers: {
+      'x-piclaw-internal-secret': resolveInternalSecret(options.internalSecret),
+    },
+  });
+
+  const bodyText = await response.text();
+  if (!response.ok) {
+    throw new Error([
+      `E2E auth bootstrap failed: HTTP ${response.status}`,
+      bodyText && `body: ${bodyText}`,
+      'Expected loopback access to the local web server plus a valid internal secret.',
+    ].filter(Boolean).join('\n'));
+  }
+
+  const cookie = parseSetCookie(response.headers.get('set-cookie'), baseUrl);
+  return {
+    cookies: [cookie],
+    origins: [],
+  };
+}


### PR DESCRIPTION
## Summary

Add local Playwright repro and stress harnesses for terminal reopen and handoff regressions, plus a small reusable browser-auth bootstrap client.

## Problem

The terminal reopen bugs were timing-sensitive and difficult to validate manually. We needed a repeatable way to:

- open and reopen the dock terminal rapidly
- exercise popout and reattach flows
- capture terminal/session/debug state while reproducing races

## What this PR changes

Adds:

- `runtime/scripts/playwright/web-auth-bootstrap.ts`
- `runtime/scripts/playwright/terminal-reopen.ts`
- `runtime/scripts/playwright/terminal-reopen-multicycle.ts`
- `runtime/scripts/playwright/terminal-reopen-race.ts`
- `test:e2e:terminal-reopen` in `package.json`

These scripts:

- bootstrap local authenticated browser state
- reproduce reopen timing races
- run multicycle reopen checks
- capture terminal/session/debug state for investigation

## Why keep this separate

This is generic regression tooling. It stays useful even as the implementation changes, and it is much easier to review separately from the actual terminal fixes.

## Testing

Used during the terminal reopen investigation to reproduce and validate:

- rapid close → reopen → type failures
- popout/reattach regressions
- same-session handoff behavior after fixes

Representative commands:

```bash
bun run test:e2e:terminal-reopen
bun run runtime/scripts/playwright/terminal-reopen-multicycle.ts
bun run runtime/scripts/playwright/terminal-reopen-race.ts
```

## Dependency note

This harness expects the localhost-only auth bootstrap lane to land alongside it or first.

— Pix (PiClaw, openai-codex/gpt-5.4)
