### PR TITLE
Switch terminal popout/return to backend handoff-only reattach

### DIFF
--- a/runtime/web/src/panes/terminal-pane.ts
+++ b/runtime/web/src/panes/terminal-pane.ts
@@ -288,10 +288,12 @@ class TerminalPaneInstance implements PaneInstance {
     private dockResizeListener = null;
     private windowResizeListener = null;
     private resizeFrame = 0;
+    private resizeRetryTimers = new Set<number>();
     private lastAppliedThemeSignature = null;
     private lastResizeSignature: string | null = null;
     private pendingHandoffToken: string | null = null;
-    private transferHandoffToken: string | null = null;
+    private standbyHandoffToken: string | null = null;
+    private standbyHandoffRequest: Promise<string | null> | null = null;
 
     constructor(container: HTMLElement, context: PaneContext) {
         this.container = container;
@@ -302,7 +304,6 @@ class TerminalPaneInstance implements PaneInstance {
             : null;
         const popoutHandoffToken = consumePanePopoutTransferToken('terminal_handoff');
         this.pendingHandoffToken = transferHandoffToken || popoutHandoffToken || null;
-        this.transferHandoffToken = this.pendingHandoffToken;
 
         this.termEl = this.ownerDocument.createElement('div');
         this.termEl.className = 'terminal-pane-content';
@@ -314,6 +315,9 @@ class TerminalPaneInstance implements PaneInstance {
 
         this.bodyEl = this.ownerDocument.createElement('div');
         this.bodyEl.className = 'terminal-pane-body';
+        this.bodyEl.style.display = 'flex';
+        this.bodyEl.style.flex = '1 1 auto';
+        this.bodyEl.style.minHeight = '0';
         this.bodyEl.innerHTML = '<div class="terminal-placeholder">Bootstrapping ghostty-web…</div>';
 
         this.termEl.append(this.bodyEl);
@@ -346,12 +350,22 @@ class TerminalPaneInstance implements PaneInstance {
         const host = this.bodyEl.querySelector('.terminal-live-host');
         if (!(host instanceof HTMLElement)) return;
 
+        host.style.display = 'flex';
+        host.style.flex = '1 1 auto';
+        host.style.width = '100%';
+        host.style.height = '100%';
+        host.style.minWidth = '0';
+        host.style.minHeight = '0';
+        host.style.overflow = 'hidden';
+
         const primaryChild = host.firstElementChild;
         if (primaryChild instanceof HTMLElement) {
             primaryChild.style.width = '100%';
             primaryChild.style.height = '100%';
             primaryChild.style.maxWidth = '100%';
             primaryChild.style.minWidth = '0';
+            primaryChild.style.minHeight = '0';
+            primaryChild.style.flex = '1 1 auto';
             primaryChild.style.display = 'block';
         }
 
@@ -359,14 +373,40 @@ class TerminalPaneInstance implements PaneInstance {
         if (canvas instanceof HTMLElement) {
             canvas.style.display = 'block';
             canvas.style.maxWidth = 'none';
+            canvas.style.maxHeight = 'none';
         }
     }
 
-    private scheduleResize(): void {
+    private queueResizeRetries(delays: number[] = [32, 96, 180, 320, 520, 900]): void {
+        if (this.disposed || !this.ownerWindow) return;
+        this.clearResizeRetries();
+        for (const delay of delays) {
+            const timer = this.ownerWindow.setTimeout(() => {
+                this.resizeRetryTimers.delete(timer);
+                if (this.disposed) return;
+                this.scheduleResize(true);
+            }, delay);
+            this.resizeRetryTimers.add(timer);
+        }
+    }
+
+    private clearResizeRetries(): void {
+        if (!this.ownerWindow || this.resizeRetryTimers.size === 0) return;
+        for (const timer of Array.from(this.resizeRetryTimers)) {
+            try {
+                this.ownerWindow.clearTimeout(timer);
+            } catch {
+                /* expected: timeout may already be cleared while a resize retry is draining. */
+            }
+        }
+        this.resizeRetryTimers.clear();
+    }
+
+    private scheduleResize(force = false): void {
         if (this.disposed) return;
 
         const signature = this.getResizeSignature();
-        if (this.lastResizeSignature === signature) {
+        if (!force && this.lastResizeSignature === signature) {
             return;
         }
 
@@ -387,8 +427,14 @@ class TerminalPaneInstance implements PaneInstance {
             if (this.disposed) return;
 
             this.bodyEl.innerHTML = '';
-            const terminalHost = document.createElement('div');
+            const terminalHost = this.ownerDocument.createElement('div');
             terminalHost.className = 'terminal-live-host';
+            terminalHost.style.display = 'flex';
+            terminalHost.style.flex = '1 1 auto';
+            terminalHost.style.width = '100%';
+            terminalHost.style.height = '100%';
+            terminalHost.style.minWidth = '0';
+            terminalHost.style.minHeight = '0';
             this.bodyEl.appendChild(terminalHost);
 
             const terminal = new mod.Terminal({
@@ -407,6 +453,7 @@ class TerminalPaneInstance implements PaneInstance {
             }
 
             await terminal.open(terminalHost);
+            (terminalHost as any).__terminal = terminal;
             this.syncHostLayout();
             terminal.loadFonts?.();
             fitAddon?.observeResize?.();
@@ -415,7 +462,8 @@ class TerminalPaneInstance implements PaneInstance {
             this.fitAddon = fitAddon;
             this.installThemeSync();
             this.installResizeSync();
-            this.scheduleResize();
+            this.scheduleResize(true);
+            this.queueResizeRetries([32, 96, 180, 320]);
 
             await this.connectBackend();
         } catch (error) {
@@ -491,8 +539,42 @@ class TerminalPaneInstance implements PaneInstance {
                 this.scheduleResize();
             });
             observer.observe(this.container);
+            observer.observe(this.termEl);
+            observer.observe(this.bodyEl);
             this.resizeObserver = observer;
         }
+    }
+
+    private consumeStandbyHandoffToken(): string | null {
+        const token = this.standbyHandoffToken || null;
+        this.standbyHandoffToken = null;
+        return token;
+    }
+
+    private async ensureStandbyHandoffToken(force = false): Promise<string | null> {
+        if (this.disposed) return null;
+        if (!force && this.standbyHandoffToken) {
+            return this.standbyHandoffToken;
+        }
+        if (this.standbyHandoffRequest) {
+            return await this.standbyHandoffRequest;
+        }
+        this.standbyHandoffRequest = requestTerminalHandoff()
+            .then((token) => {
+                if (!token || this.disposed) {
+                    return null;
+                }
+                this.standbyHandoffToken = token;
+                return token;
+            })
+            .catch((error) => {
+                console.warn('[terminal-pane] Failed to prepare standby handoff token:', error);
+                return null;
+            })
+            .finally(() => {
+                this.standbyHandoffRequest = null;
+            });
+        return await this.standbyHandoffRequest;
     }
 
     private async connectBackend() {
@@ -530,10 +612,11 @@ class TerminalPaneInstance implements PaneInstance {
                 if (this.disposed) return;
                 if (handoffToken && this.pendingHandoffToken === handoffToken) {
                     this.pendingHandoffToken = null;
-                    this.transferHandoffToken = handoffToken;
                 }
+                void this.ensureStandbyHandoffToken(false);
                 this.setStatus('Connected');
-                this.scheduleResize();
+                this.scheduleResize(true);
+                this.queueResizeRetries([24, 72, 160, 320]);
             });
 
             socket.addEventListener('message', (event) => {
@@ -545,6 +628,18 @@ class TerminalPaneInstance implements PaneInstance {
                     payload = { type: 'output', data: String(event.data) };
                 }
 
+                if (payload?.type === 'session') {
+                    const sessionId = typeof payload.session_id === 'string' ? payload.session_id : null;
+                    (terminal as any).__piclawSessionMeta = {
+                        sessionId,
+                        createdAt: typeof payload.created_at === 'string' ? payload.created_at : null,
+                        processPid: typeof payload.process_pid === 'number' ? payload.process_pid : null,
+                    };
+                    if (!this.standbyHandoffToken) {
+                        void this.ensureStandbyHandoffToken(false);
+                    }
+                    return;
+                }
                 if (payload?.type === 'output' && typeof payload.data === 'string') {
                     terminal.write?.(payload.data);
                     return;
@@ -603,7 +698,13 @@ class TerminalPaneInstance implements PaneInstance {
         this.setStatus('Moving terminal…');
     }
 
-    afterAttachToHost(): void {
+    afterAttachToHost(context?: { transferState?: Record<string, unknown> | null }): void {
+        const transferHandoffToken = typeof context?.transferState?.handoffToken === 'string' && context.transferState.handoffToken.trim()
+            ? context.transferState.handoffToken.trim()
+            : null;
+        if (transferHandoffToken) {
+            this.pendingHandoffToken = transferHandoffToken;
+        }
         this.installThemeSync();
         this.installResizeSync();
         if (this.socket?.readyState === WebSocket.OPEN) {
@@ -613,36 +714,34 @@ class TerminalPaneInstance implements PaneInstance {
         } else if (this.socket?.readyState === WebSocket.CONNECTING) {
             this.setStatus('Connecting…');
         }
-        this.scheduleResize();
+        this.scheduleResize(true);
+        this.queueResizeRetries([32, 96, 180, 320]);
         requestAnimationFrame(() => this.focus());
     }
 
-    moveHost(container: HTMLElement): boolean {
-        if (this.disposed) return false;
-        this.detachHostListeners();
-        this.container = container;
-        this.ownerDocument = container.ownerDocument || this.ownerDocument || document;
-        this.ownerWindow = (this.ownerDocument.defaultView || this.ownerWindow || window) as Window & typeof globalThis;
-        if (!relocateTerminalPaneRoot(this.termEl, container)) {
-            return false;
-        }
-        this.afterAttachToHost();
-        return true;
+    moveHost(_container: HTMLElement): boolean {
+        return false;
     }
 
     exportHostTransferState(): Record<string, unknown> | null {
-        return {
-            kind: 'terminal',
-            live: true,
-            handoffToken: this.transferHandoffToken || null,
-        };
+        const handoffToken = this.standbyHandoffToken || this.pendingHandoffToken || null;
+        return handoffToken
+            ? {
+                kind: 'terminal',
+                live: false,
+                handoffToken,
+            }
+            : null;
     }
 
     async preparePopoutTransfer(): Promise<Record<string, string> | null> {
-        const handoffToken = await requestTerminalHandoff();
+        let handoffToken = this.consumeStandbyHandoffToken();
+        if (!handoffToken) {
+            await this.ensureStandbyHandoffToken(true);
+            handoffToken = this.consumeStandbyHandoffToken();
+        }
         if (!handoffToken) return null;
         this.pendingHandoffToken = handoffToken;
-        this.transferHandoffToken = handoffToken;
         return { terminal_handoff: handoffToken };
     }
 
@@ -674,6 +773,9 @@ class TerminalPaneInstance implements PaneInstance {
     dispose(): void {
         if (this.disposed) return;
         this.disposed = true;
+        this.standbyHandoffToken = null;
+        this.standbyHandoffRequest = null;
+        this.clearResizeRetries();
         this.detachHostListeners();
         this.resizeFrame = disposeTerminalRuntimeBestEffort({
             resizeFrame: this.resizeFrame,

--- a/runtime/web/src/ui/app-branch-pane-lifecycle-actions.ts
+++ b/runtime/web/src/ui/app-branch-pane-lifecycle-actions.ts
@@ -366,6 +366,7 @@ export async function popOutPaneAction(options: PopOutPaneActionOptions): Promis
         detachTransfer?.paneInstanceId
         && detachTransfer?.paneWindowId
         && sourceInstance
+        && panePath !== terminalTabPath
         && exportedHostTransfer?.kind !== 'terminal'
       ) {
         registerPaneLiveTransfer({

--- a/runtime/web/src/ui/app-main-shell-render.ts
+++ b/runtime/web/src/ui/app-main-shell-render.ts
@@ -381,7 +381,7 @@ export function renderMainShell(options: MainShellRenderOptions): any {
             />
           `}
           ${hasDockPanes && dockVisible && html`<div class="dock-splitter" onMouseDown=${handleDockSplitterMouseDown} onTouchStart=${handleDockSplitterTouchStart}></div>`}
-          ${hasDockPanes && html`<div class=${`dock-panel${dockVisible ? '' : ' hidden'}`}>
+          ${hasDockPanes && html`<div class=${`dock-panel${dockVisible ? '' : ' hidden'}${editorOpen ? '' : ' standalone'}`}>
             <div class="dock-panel-header">
               <span class="dock-panel-title">Terminal</span>
               <div class="dock-panel-actions">

--- a/runtime/web/src/ui/app-pane-runtime-orchestration.ts
+++ b/runtime/web/src/ui/app-pane-runtime-orchestration.ts
@@ -191,12 +191,22 @@ export function shouldDisableTerminalReattach(options: {
   return isLikelySafariBrowser(options?.runtimeNavigator);
 }
 
+function shouldUseLivePaneTransfer(options: {
+  panePath: string;
+  terminalTabPath: string;
+}): boolean {
+  const panePath = typeof options?.panePath === 'string' ? options.panePath.trim() : '';
+  if (!panePath) return false;
+  return panePath !== options?.terminalTabPath;
+}
+
 export interface PanePopoutReattachRequestMessage {
   type: 'piclaw-pane-reattach-request';
   panePath: string;
   paneInstanceId?: string;
   editorPopoutToken?: string;
   paneTransferToken?: string;
+  paneTransferPayload?: Record<string, unknown>;
   allowLiveTransfer?: boolean;
 }
 
@@ -228,7 +238,8 @@ export function buildPanePopoutReattachRequestMessage(options: {
   const exportedHostTransfer = typeof instance?.exportHostTransferState === 'function'
     ? instance.exportHostTransferState()
     : null;
-  const paneTransfer = exportedHostTransfer
+  const useInlineHostTransfer = panePath === terminalTabPath;
+  const paneTransfer = exportedHostTransfer && !useInlineHostTransfer
     ? createPaneHostTransferPayload({
       path: panePath,
       payload: exportedHostTransfer,
@@ -259,6 +270,7 @@ export function buildPanePopoutReattachRequestMessage(options: {
     ...(paneInstanceId ? { paneInstanceId } : {}),
     ...(editorTransfer?.editor_popout ? { editorPopoutToken: editorTransfer.editor_popout } : {}),
     ...(paneTransfer?.pane_transfer ? { paneTransferToken: paneTransfer.pane_transfer } : {}),
+    ...(useInlineHostTransfer && exportedHostTransfer ? { paneTransferPayload: exportedHostTransfer } : {}),
     ...(allowLiveTransfer ? {} : { allowLiveTransfer: false }),
   };
 }
@@ -283,13 +295,18 @@ export function consumePanePopoutReattachRequestMessage(options: {
     : null;
   const editorPopoutToken = typeof options?.payload?.editorPopoutToken === 'string' ? options.payload.editorPopoutToken.trim() : '';
   const paneTransferToken = typeof options?.payload?.paneTransferToken === 'string' ? options.payload.paneTransferToken.trim() : '';
+  const inlineHostTransferPayload = options?.payload?.paneTransferPayload && typeof options.payload.paneTransferPayload === 'object' && !Array.isArray(options.payload.paneTransferPayload)
+    ? options.payload.paneTransferPayload as Record<string, unknown>
+    : null;
 
   const editorTransfer = editorPopoutToken
     ? consumeEditorPopoutState(editorPopoutToken, runtime, nowMs)
     : null;
-  const hostTransfer = paneTransferToken
-    ? consumePaneHostTransferState(paneTransferToken, runtime, nowMs)
-    : null;
+  const hostTransfer = inlineHostTransferPayload
+    ? { panePath, path: panePath, payload: inlineHostTransferPayload, capturedAt: nowMs }
+    : (paneTransferToken
+      ? consumePaneHostTransferState(paneTransferToken, runtime, nowMs)
+      : null);
 
   return {
     panePath,
@@ -545,7 +562,8 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
     const pendingTab = pendingDetachedTabsRef.current.get(panePath) || null;
     if (matchesPaneDetachClaim(pendingTab, claim)) {
       const preservedInstance = editorInstanceRef.current;
-      if (preservedInstance && typeof preservedInstance.moveHost === 'function') {
+      const useLiveTransfer = shouldUseLivePaneTransfer({ panePath, terminalTabPath });
+      if (useLiveTransfer && preservedInstance && typeof preservedInstance.moveHost === 'function') {
         registerPaneLiveTransfer({
           panePath,
           paneInstanceId: pendingTab.paneInstanceId,
@@ -558,7 +576,7 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
           },
         });
       }
-      if (editorInstanceRef.current) {
+      if (useLiveTransfer && editorInstanceRef.current) {
         editorInstanceRef.current = null;
       }
       const nextState = finalizePendingPaneOwnership(pendingTab);
@@ -587,7 +605,8 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
 
     const pendingDock = pendingDetachedDockPaneRef.current;
     const preservedDockInstance = dockInstanceRef.current;
-    if (pendingDock && preservedDockInstance && typeof preservedDockInstance.moveHost === 'function') {
+    const useLiveTransfer = shouldUseLivePaneTransfer({ panePath, terminalTabPath });
+    if (useLiveTransfer && pendingDock && preservedDockInstance && typeof preservedDockInstance.moveHost === 'function') {
       registerPaneLiveTransfer({
         panePath,
         paneInstanceId: pendingDock.paneInstanceId,
@@ -600,7 +619,7 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
         },
       });
     }
-    if (dockInstanceRef.current) {
+    if (useLiveTransfer && dockInstanceRef.current) {
       dockInstanceRef.current = null;
     }
     if (!matchesPaneDetachClaim(pendingDock, claim)) return false;
@@ -633,6 +652,7 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
     const instance = panePath === terminalTabPath
       ? (dockInstanceRef.current || editorInstanceRef.current)
       : editorInstanceRef.current;
+    const effectiveAllowLiveTransfer = allowLiveTransfer && shouldUseLivePaneTransfer({ panePath, terminalTabPath });
     const payload = buildPanePopoutReattachRequestMessage({
       panePath,
       paneInstanceId: detachState.paneInstanceId,
@@ -641,12 +661,12 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
         : (typeof (tabPaneOverrides as any)?.get === 'function' ? ((tabPaneOverrides as any).get(panePath) || null) : null),
       terminalTabPath,
       viewState: panePath === terminalTabPath ? null : (tabStore.getViewState(panePath) || null),
-      allowLiveTransfer,
+      allowLiveTransfer: effectiveAllowLiveTransfer,
       instance,
     });
     if (!payload) return false;
 
-    if (allowLiveTransfer && payload.paneTransferToken && typeof instance?.moveHost === 'function') {
+    if (effectiveAllowLiveTransfer && payload.paneTransferToken && typeof instance?.moveHost === 'function') {
       if (dockInstanceRef.current === instance) {
         dockInstanceRef.current = null;
       }
@@ -828,6 +848,7 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
 
       const detachedTab = detachedTabsRef.current.get(panePath) || null;
       const detachedDock = panePath === terminalTabPath ? detachedDockPaneRef.current : null;
+      const useLiveTransfer = shouldUseLivePaneTransfer({ panePath, terminalTabPath });
       const detached = detachedTab || detachedDock;
       if (!detached) return;
       if (transfer?.paneInstanceId && transfer.paneInstanceId !== detached.paneInstanceId) return;
@@ -838,7 +859,7 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
         pendingReattachEditorTransfersRef.current.delete(panePath);
         return;
       }
-      if (transfer?.hostTransfer && transfer.allowLiveTransfer) {
+      if (transfer?.hostTransfer && transfer.allowLiveTransfer && useLiveTransfer) {
         pendingReattachPaneClaimsRef.current.set(panePath, {
           panePath,
           paneInstanceId: detached.paneInstanceId,
@@ -1038,6 +1059,7 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
         panePopoutMode
         && hasPaneDetachTransferState(detachState)
         && typeof nextInstance?.moveHost === 'function'
+        && shouldUseLivePaneTransfer({ panePath: activeId, terminalTabPath })
       ) {
         registerPaneLiveTransfer({
           panePath: activeId,
@@ -1076,7 +1098,9 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
         }
         : null;
       const reattachClaim = pendingReattachPaneClaimsRef.current.get(activeId) || null;
-      const liveTransferClaim = popoutClaim || reattachClaim;
+      const liveTransferClaim = shouldUseLivePaneTransfer({ panePath: activeId, terminalTabPath })
+        ? (popoutClaim || reattachClaim)
+        : null;
       const liveTransferSourceWindow = panePopoutMode
         ? (typeof window !== 'undefined' && window.opener && !window.opener.closed ? window.opener : null)
         : (pendingReattachPaneSourceWindowsRef.current.get(activeId) || null);
@@ -1185,19 +1209,29 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
       return;
     }
 
-    const instance = ext.mount(container, { mode: 'view' });
+    const pendingPopoutHostTransfer = pendingPaneHostTransferRef.current?.path === terminalTabPath
+      ? pendingPaneHostTransferRef.current
+      : null;
+    const pendingReattachHostTransfer = pendingReattachPaneHostTransfersRef.current.get(terminalTabPath) || null;
+    const pendingHostTransfer = pendingPopoutHostTransfer || pendingReattachHostTransfer;
+
+    const instance = ext.mount(container, {
+      mode: 'view',
+      ...(pendingHostTransfer?.payload ? { transferState: pendingHostTransfer.payload } : {}),
+    });
     dockInstanceRef.current = instance;
     void invokePaneAfterAttachToHost(instance, {
       path: terminalTabPath,
       hostMode: panePopoutMode ? 'popout' : 'main',
-      transferState: pendingPaneHostTransferRef.current?.path === terminalTabPath
-        ? (pendingPaneHostTransferRef.current.payload || null)
-        : null,
+      transferState: pendingHostTransfer?.payload || null,
     }).catch((error) => {
       console.warn('[pane-attach] afterAttachToHost failed:', error);
     });
-    if (pendingPaneHostTransferRef.current?.path === terminalTabPath) {
+    if (pendingPopoutHostTransfer) {
       pendingPaneHostTransferRef.current = null;
+    }
+    if (pendingReattachHostTransfer) {
+      pendingReattachPaneHostTransfersRef.current.delete(terminalTabPath);
     }
     requestAnimationFrame(() => instance.focus?.());
 

--- a/runtime/web/static/css/editor.css
+++ b/runtime/web/static/css/editor.css
@@ -767,6 +767,14 @@
     overflow: hidden;
 }
 
+.dock-panel.standalone {
+    height: 100%;
+    min-height: 0;
+    max-height: none;
+    flex: 1 1 auto;
+    border-top: none;
+}
+
 .dock-panel.hidden {
     display: none;
 }
@@ -834,7 +842,14 @@
 .dock-panel-body {
     flex: 1;
     min-height: 0;
-    overflow: auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.dock-panel-body > * {
+    flex: 1 1 auto;
+    min-height: 0;
 }
 
 .dock-panel-body-detached {


### PR DESCRIPTION
## Summary

Switch terminal popout/return to backend handoff-only reattach instead of attempting unsafe cross-window live transfer.

## Problem

The terminal popout path had two frontend/runtime issues:

1. dock reattach was not consuming the same transfer path used by detached tabs, so return-to-dock could remount a fresh terminal instead of reusing the intended session handoff
2. live cross-window DOM transfer was unsafe for `ghostty-web`, which relies on document-level listeners and broke mouse/selection behavior in popouts

## What this PR changes

### Terminal uses backend session handoff only

For the terminal specifically:

- popout/return no longer tries to move the live terminal DOM across windows
- the frontend exports backend handoff state instead
- dock remounts consume the reattach payload and pass it back into the terminal pane

### Dock reattach symmetry

The dock path now consumes pending reattach host transfer state the same way detached tab panes do.

### Safer close-window return path

Terminal return messages carry the handoff payload inline so popup-close recovery does not depend on a close-time `localStorage` race.

### Dock layout baseline

This also keeps the dock terminal layout/sizing changes together with the terminal frontend lane so the terminal host is mounted and resized in the shape the handoff flow expects.

## Why this fixes the bug

The terminal should not be treated like editor panes that can safely move a live instance between windows. `ghostty-web` assumes a stable document/window environment. Backend session handoff is the safe transfer mechanism here.

## Testing

Validated with Playwright popout/return flows and manual Chromium verification after the backend continuity fix landed.

## Scope note

This PR is about pane/runtime transfer behavior and terminal dock layout. It does not attempt to change `ghostty-web` rendering internals.

— Pix (PiClaw, openai-codex/gpt-5.4)
