### PR TITLE
Surface provider errors instead of silent 'no response'

### DIFF
--- a/runtime/src/agent-pool/run-agent-orchestrator.ts
+++ b/runtime/src/agent-pool/run-agent-orchestrator.ts
@@ -217,6 +217,11 @@ export async function runAgentPrompt(
         return { status: "error", result: null, error: `Timed out after ${formatTimeoutDuration(timeoutMs)}` };
       }
 
+      const turnError = tracker.getError();
+      if (turnError) {
+        return { status: "error", result: null, error: turnError.errorMessage };
+      }
+
       options.onInfo?.("Agent run completed", {
         operation: "run_agent.complete",
         chatJid,

--- a/runtime/src/agent-pool/turn-coordinator.ts
+++ b/runtime/src/agent-pool/turn-coordinator.ts
@@ -24,11 +24,18 @@ export interface AgentTurnOutput {
   attachments: AttachmentInfo[];
 }
 
+/** Error state captured from an assistant message with stopReason "error". */
+export interface AgentTurnError {
+  stopReason: "error";
+  errorMessage: string;
+}
+
 /** Aggregated assistant-turn tracking state for a single prompt run. */
 export interface AgentTurnTracker {
   handleMessageUpdate: (event: AgentSessionEvent) => void;
   getFinalText: () => string;
   getTurnCount: () => number;
+  getError: () => AgentTurnError | null;
 }
 
 /**
@@ -63,6 +70,7 @@ export class AgentTurnCoordinator {
     let currentTurnPhase: AssistantTextPhase = null;
     let turnCount = 0;
     let messageHasDelta = false;
+    let lastError: AgentTurnError | null = null;
 
     const parseTextPhase = (signature: unknown): AssistantTextPhase => {
       if (typeof signature !== "string" || !signature.trim()) return null;
@@ -162,8 +170,16 @@ export class AgentTurnCoordinator {
       }
 
       if (event.type === "message_end") {
-        const message = event.message as { role?: string; content?: unknown } | undefined;
+        const message = event.message as {
+          role?: string;
+          content?: unknown;
+          stopReason?: string;
+          errorMessage?: string;
+        } | undefined;
         if (message?.role === "assistant") {
+          if (message.stopReason === "error" && message.errorMessage) {
+            lastError = { stopReason: "error", errorMessage: message.errorMessage };
+          }
           const extracted = extractAssistantTextFromContent(message.content);
           if (!messageHasDelta) {
             currentTurnText = extracted.text;
@@ -181,6 +197,7 @@ export class AgentTurnCoordinator {
       handleMessageUpdate,
       getFinalText: () => currentTurnPhase === "commentary" ? "" : currentTurnText.trim(),
       getTurnCount: () => turnCount,
+      getError: () => lastError,
     };
   }
 

--- a/runtime/test/agent-pool/run-agent-orchestrator.test.ts
+++ b/runtime/test/agent-pool/run-agent-orchestrator.test.ts
@@ -209,6 +209,59 @@ test("runAgentPrompt skips pre-prompt auto-compaction when it is disabled", asyn
   expect(calls).toEqual(["prompt"]);
 });
 
+test("runAgentPrompt surfaces provider error instead of returning null result", async () => {
+  class StubSession {
+    private listeners: Array<(event: any) => void> = [];
+    sessionManager = { getLeafId: () => "leaf-1" };
+    isStreaming = false;
+    isCompacting = false;
+    isRetrying = false;
+    subscribe(listener: (event: any) => void) {
+      this.listeners.push(listener);
+      return () => {
+        this.listeners = this.listeners.filter((entry) => entry !== listener);
+      };
+    }
+    async prompt() {
+      for (const listener of this.listeners) {
+        listener({
+          type: "message_end",
+          message: {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage:
+              'Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"You\'re out of extra usage."},"request_id":"req_abc123"}',
+            content: [],
+          },
+        });
+      }
+    }
+    async abort() {}
+  }
+
+  const session = new StubSession();
+  const turnCoordinator = new AgentTurnCoordinator({
+    takeAttachments: () => [],
+    touchSession: () => {},
+    recordMessageUsage: () => {},
+  });
+
+  const result = await runAgentPrompt("hello", "web:default", { timeoutMs: 0 }, {
+    getOrCreateRuntime: async () => createRuntime(session) as any,
+    turnCoordinator,
+    clearAttachments: () => {},
+    takeAttachments: () => [],
+    logsDir: process.env.PICLAW_WORKSPACE || "/workspace",
+    setActiveForkBaseLeaf: () => {},
+    clearActiveForkBaseLeaf: () => {},
+  });
+
+  expect(result.status).toBe("error");
+  expect(result.error).toContain("invalid_request_error");
+  expect(result.error).toContain("extra usage");
+  expect(result.result).toBeNull();
+});
+
 test("runAgentPrompt ignores commentary-only aborted output", async () => {
   class StubSession {
     private listeners: Array<(event: any) => void> = [];

--- a/runtime/test/agent-pool/turn-coordinator.test.ts
+++ b/runtime/test/agent-pool/turn-coordinator.test.ts
@@ -200,6 +200,58 @@ test("AgentTurnCoordinator subscribes, records usage, and downgrades handler fai
   expect(listener).toBeNull();
 });
 
+test("AgentTurnCoordinator captures provider error from assistant message_end", () => {
+  const coordinator = new AgentTurnCoordinator({
+    takeAttachments: () => [],
+    touchSession: () => {},
+    recordMessageUsage: () => {},
+  });
+
+  const tracker = coordinator.createTracker("web:default");
+
+  tracker.handleMessageUpdate({
+    type: "message_end",
+    message: {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage:
+        'Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"You\'re out of extra usage. Add more at claude.ai/settings/usage and keep going."},"request_id":"req_011Ca3hFFk6E3FKGv1Hv52K9"}',
+      content: [],
+    },
+  } as any);
+
+  expect(tracker.getFinalText()).toBe("");
+  expect(tracker.getError()).not.toBeNull();
+  expect(tracker.getError()?.stopReason).toBe("error");
+  expect(tracker.getError()?.errorMessage).toContain("invalid_request_error");
+  expect(tracker.getError()?.errorMessage).toContain("extra usage");
+});
+
+test("AgentTurnCoordinator does not set error for normal assistant messages", () => {
+  const coordinator = new AgentTurnCoordinator({
+    takeAttachments: () => [],
+    touchSession: () => {},
+    recordMessageUsage: () => {},
+  });
+
+  const tracker = coordinator.createTracker("web:default");
+
+  tracker.handleMessageUpdate({
+    type: "message_update",
+    assistantMessageEvent: { type: "text_delta", delta: "hello" },
+  } as any);
+  tracker.handleMessageUpdate({
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+    },
+  } as any);
+
+  expect(tracker.getFinalText()).toBe("hello");
+  expect(tracker.getError()).toBeNull();
+});
+
 test("AgentTurnCoordinator aborts timed-out prompts", async () => {
   let abortCalls = 0;
   const errors: string[] = [];


### PR DESCRIPTION
## Problem

When a provider returns an error (e.g. Anthropic `400 invalid_request_error`), the assistant message arrives with `stopReason: "error"` and an `errorMessage`, but empty `content: []`.

The turn coordinator only extracts text content, so `getFinalText()` returns empty. The orchestrator then returns `status: "success"` with `result: null`, and the web handler shows:

> ⚠️ Your message was received but the agent produced no response.

The real error is silently swallowed.

## Fix

- `AgentTurnTracker` now captures `stopReason` and `errorMessage` from the `message_end` event when `stopReason === "error"`
- `runAgentPrompt` checks the tracker's error state after the prompt completes and returns `status: "error"` with the real provider message
- The web handler's existing error path then surfaces the actual error to the user

## Tests

Added 3 tests:
- Turn coordinator: captures error from known Anthropic 400 format
- Turn coordinator: normal messages don't trigger error state
- Orchestrator: full flow returns `status: "error"` with real error message

All existing tests continue to pass.

---
Pix (PiClaw, claude-opus-4-6)