### PR TITLE
Avoid blocking web model refresh on runtime hydration

### DIFF
--- a/runtime/src/agent-pool/provider-usage.ts
+++ b/runtime/src/agent-pool/provider-usage.ts
@@ -28,8 +28,11 @@ type CachedUsage = {
   value: ProviderUsageSnapshot | null;
 };
 
+type SupportedProviderId = ProviderUsageSnapshot["provider"];
+
 const USAGE_CACHE_TTL_MS = Number(process.env.PICLAW_PROVIDER_USAGE_TTL_MS || "60000");
 const usageCache = new Map<string, CachedUsage>();
+const usageRefreshInFlight = new Map<string, Promise<ProviderUsageSnapshot | null>>();
 const log = createLogger("agent-pool.provider-usage");
 
 function clampPercent(value: unknown): number | null {
@@ -232,34 +235,83 @@ async function fetchGitHubCopilotUsage(authStorage: AuthStorage): Promise<Provid
   };
 }
 
-export async function getProviderUsage(authStorage: AuthStorage, providerId: string): Promise<ProviderUsageSnapshot | null> {
-  if (providerId !== "openai-codex" && providerId !== "github-copilot") return null;
+function isSupportedProviderId(providerId: string): providerId is SupportedProviderId {
+  return providerId === "openai-codex" || providerId === "github-copilot";
+}
 
-  const cached = usageCache.get(providerId);
+function getCachedUsageEntry(providerId: string): CachedUsage | null {
+  return usageCache.get(providerId) ?? null;
+}
+
+function hasFreshCachedUsage(providerId: string): boolean {
+  const cached = getCachedUsageEntry(providerId);
+  return Boolean(cached && cached.expiresAt > Date.now());
+}
+
+async function fetchProviderUsage(authStorage: AuthStorage, providerId: SupportedProviderId): Promise<ProviderUsageSnapshot | null> {
+  return providerId === "openai-codex"
+    ? await fetchCodexUsage(authStorage)
+    : await fetchGitHubCopilotUsage(authStorage);
+}
+
+export function peekProviderUsage(providerId: string, options: { allowStale?: boolean } = {}): ProviderUsageSnapshot | null {
+  if (!isSupportedProviderId(providerId)) return null;
+  const cached = getCachedUsageEntry(providerId);
+  if (!cached) return null;
+  if (options.allowStale === true) {
+    return cached.value;
+  }
+  return cached.expiresAt > Date.now() ? cached.value : null;
+}
+
+export async function warmProviderUsage(authStorage: AuthStorage, providerId: string): Promise<ProviderUsageSnapshot | null> {
+  if (!isSupportedProviderId(providerId)) return null;
+  if (hasFreshCachedUsage(providerId)) {
+    return peekProviderUsage(providerId);
+  }
+
+  const existing = usageRefreshInFlight.get(providerId);
+  if (existing) {
+    return await existing;
+  }
+
+  const cached = getCachedUsageEntry(providerId);
+  const refreshPromise = (async () => {
+    let value: ProviderUsageSnapshot | null;
+    try {
+      value = await fetchProviderUsage(authStorage, providerId);
+    } catch (error) {
+      debugSuppressedError(log, "Provider usage refresh failed; returning the cached usage snapshot when available.", error, {
+        providerId,
+        hasCachedValue: cached?.value != null,
+      });
+      value = cached?.value ?? null;
+    }
+
+    usageCache.set(providerId, {
+      expiresAt: Date.now() + USAGE_CACHE_TTL_MS,
+      value,
+    });
+    usageRefreshInFlight.delete(providerId);
+    return value;
+  })();
+
+  usageRefreshInFlight.set(providerId, refreshPromise);
+  return await refreshPromise;
+}
+
+export async function getProviderUsage(authStorage: AuthStorage, providerId: string): Promise<ProviderUsageSnapshot | null> {
+  if (!isSupportedProviderId(providerId)) return null;
+
+  const cached = getCachedUsageEntry(providerId);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.value;
   }
 
-  let value: ProviderUsageSnapshot | null;
-  try {
-    value = providerId === "openai-codex"
-      ? await fetchCodexUsage(authStorage)
-      : await fetchGitHubCopilotUsage(authStorage);
-  } catch (error) {
-    debugSuppressedError(log, "Provider usage refresh failed; returning the cached usage snapshot when available.", error, {
-      providerId,
-      hasCachedValue: cached?.value != null,
-    });
-    value = cached?.value ?? null;
-  }
-
-  usageCache.set(providerId, {
-    expiresAt: Date.now() + USAGE_CACHE_TTL_MS,
-    value,
-  });
-  return value;
+  return await warmProviderUsage(authStorage, providerId);
 }
 
 export function clearProviderUsageCache(): void {
   usageCache.clear();
+  usageRefreshInFlight.clear();
 }

--- a/runtime/src/agent-pool/runtime-facade.ts
+++ b/runtime/src/agent-pool/runtime-facade.ts
@@ -11,7 +11,7 @@ import { applyControlCommand, type AgentControlCommand, type AgentControlResult 
 import { formatThinkingLevelForDisplay } from "../agent-control/agent-control-helpers.js";
 import { detectChannel } from "../router.js";
 import { executeSlashCommand } from "./slash-command.js";
-import { getProviderUsage } from "./provider-usage.js";
+import { peekProviderUsage, warmProviderUsage } from "./provider-usage.js";
 import { resolveModelLabel } from "../utils/model-utils.js";
 import { createLogger } from "../utils/logger.js";
 import { withChatContext } from "../core/chat-context.js";
@@ -367,7 +367,7 @@ export interface AvailableModelsResult {
   thinking_level: string | null;
   thinking_level_label: string | null;
   supports_thinking: boolean;
-  provider_usage: Awaited<ReturnType<typeof getProviderUsage>>;
+  provider_usage: Awaited<ReturnType<typeof warmProviderUsage>>;
 }
 
 /** Dependencies required by AgentRuntimeFacade. */
@@ -409,8 +409,10 @@ export class AgentRuntimeFacade {
   }
 
   async getAvailableModels(chatJid: string): Promise<AvailableModelsResult> {
-    const session = (await this.options.getOrCreateRuntime(chatJid)).session;
-    const registry = (session as AgentSession & { modelRegistry?: ModelRegistry }).modelRegistry ?? this.options.modelRegistry;
+    // Passive UI refreshes should not hydrate a cold runtime just to render
+    // model state for the picker.
+    const session = this.options.pool.get(chatJid)?.runtime.session ?? null;
+    const registry = (session as (AgentSession & { modelRegistry?: ModelRegistry }) | null)?.modelRegistry ?? this.options.modelRegistry;
     registry.refresh();
     const available = registry.getAvailable();
     const modelOptions = available.map((model) => ({
@@ -424,15 +426,18 @@ export class AgentRuntimeFacade {
       reasoning: Boolean(model.reasoning),
     }));
     const models = modelOptions.map((model) => model.label);
-    const currentModel = session.model ? `${session.model.provider}/${session.model.id}` : null;
-    const thinkingLevel = session.thinkingLevel ?? null;
-    const supportsThinking = typeof (session as AgentSession & { supportsThinking?: () => boolean }).supportsThinking === "function"
+    const currentModel = session?.model ? `${session.model.provider}/${session.model.id}` : null;
+    const thinkingLevel = session?.thinkingLevel ?? null;
+    const supportsThinking = session && typeof (session as AgentSession & { supportsThinking?: () => boolean }).supportsThinking === "function"
       ? (session as AgentSession & { supportsThinking: () => boolean }).supportsThinking()
-      : Boolean(session.model?.reasoning);
-    const providerUsage = session.model?.provider
-      ? await getProviderUsage(this.options.authStorage, session.model.provider)
+      : Boolean(session?.model?.reasoning);
+    const providerUsage = session?.model?.provider
+      ? (peekProviderUsage(session.model.provider, { allowStale: true }) ?? null)
       : null;
-    const thinkingLevelLabel = thinkingLevel && session.model?.provider
+    if (session?.model?.provider) {
+      void warmProviderUsage(this.options.authStorage, session.model.provider);
+    }
+    const thinkingLevelLabel = thinkingLevel && session?.model?.provider
       ? formatThinkingLevelForDisplay(thinkingLevel, session.model.provider)
       : thinkingLevel;
     return {

--- a/runtime/test/agent-pool/provider-usage.test.ts
+++ b/runtime/test/agent-pool/provider-usage.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { clearProviderUsageCache, getProviderUsage } from "../../src/agent-pool/provider-usage.js";
+import { clearProviderUsageCache, getProviderUsage, peekProviderUsage, warmProviderUsage } from "../../src/agent-pool/provider-usage.js";
 
 function createAuthStorage(credentials: Record<string, unknown>) {
   return {
@@ -108,6 +108,68 @@ describe("provider usage", () => {
       expect(usage?.secondary?.remaining_percent).toBe(80);
       expect(usage?.hint_short).toContain("premium 70%");
       expect(usage?.hint_short).toContain("chat 80%");
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test("warms provider usage in the background and reuses the same in-flight refresh", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fetchMock = mock(async () => {
+      await gate;
+      return new Response(JSON.stringify({
+        plan_type: "pro",
+        rate_limit: {
+          primary_window: {
+            used_percent: 10,
+            reset_at: Math.floor(Date.now() / 1000) + 3600,
+            limit_window_seconds: 18000,
+          },
+        },
+        credits: {
+          balance: 50,
+          unlimited: false,
+        },
+      }));
+    });
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const first = warmProviderUsage(
+        createAuthStorage({
+          "openai-codex": {
+            type: "oauth",
+            access: "token",
+            accountId: "acct_123",
+            expires: Date.now() + 60_000,
+          },
+        }),
+        "openai-codex"
+      );
+      const second = warmProviderUsage(
+        createAuthStorage({
+          "openai-codex": {
+            type: "oauth",
+            access: "token",
+            accountId: "acct_123",
+            expires: Date.now() + 60_000,
+          },
+        }),
+        "openai-codex"
+      );
+
+      expect(peekProviderUsage("openai-codex", { allowStale: true })).toBeNull();
+      await Promise.resolve();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      release();
+      const usage = await first;
+      expect(await second).toEqual(usage);
+      expect(peekProviderUsage("openai-codex", { allowStale: true })?.provider).toBe("openai-codex");
     } finally {
       globalThis.fetch = previousFetch;
     }

--- a/runtime/test/agent-pool/runtime-facade.test.ts
+++ b/runtime/test/agent-pool/runtime-facade.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
 
 import type { AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
+import { clearProviderUsageCache } from "../../src/agent-pool/provider-usage.js";
 import { AgentRuntimeFacade } from "../../src/agent-pool/runtime-facade.js";
 
 function createRuntime(session: any): AgentSessionRuntime {
@@ -17,6 +18,10 @@ function createRuntime(session: any): AgentSessionRuntime {
     dispose: async () => {},
   } as any;
 }
+
+afterEach(() => {
+  clearProviderUsageCache();
+});
 
 function createFacade(overrides: Partial<ConstructorParameters<typeof AgentRuntimeFacade>[0]> = {}) {
   const pool = new Map<string, { runtime: any; lastUsed: number }>();
@@ -94,6 +99,105 @@ test("AgentRuntimeFacade reports available models and context usage", async () =
     contextWindow: 100,
     percent: 10,
   });
+});
+
+test("AgentRuntimeFacade returns registry-backed model options without hydrating a cold chat runtime", async () => {
+  let refreshCalls = 0;
+  let getOrCreateCalls = 0;
+
+  const fixture = createFacade({
+    getOrCreateRuntime: async () => {
+      getOrCreateCalls += 1;
+      throw new Error("cold model lookup should not hydrate a runtime");
+    },
+    modelRegistry: {
+      refresh: () => { refreshCalls += 1; },
+      getAvailable: () => [
+        { provider: "openai", id: "gpt-fast", name: "GPT Fast", contextWindow: 128000, reasoning: true },
+      ],
+      getAll: () => [],
+      registerProvider: () => {},
+    } as any,
+  });
+
+  const available = await fixture.facade.getAvailableModels("web:cold");
+  expect(getOrCreateCalls).toBe(0);
+  expect(refreshCalls).toBe(1);
+  expect(available).toEqual({
+    current: null,
+    models: ["openai/gpt-fast"],
+    model_options: [
+      {
+        label: "openai/gpt-fast",
+        provider: "openai",
+        id: "gpt-fast",
+        name: "GPT Fast",
+        context_window: 128000,
+        reasoning: true,
+      },
+    ],
+    thinking_level: null,
+    thinking_level_label: null,
+    supports_thinking: false,
+    provider_usage: null,
+  });
+});
+
+test("AgentRuntimeFacade does not block getAvailableModels on a cold provider-usage refresh", async () => {
+  const previousFetch = globalThis.fetch;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  globalThis.fetch = (async () => {
+    await gate;
+    return new Response(JSON.stringify({
+      plan_type: "pro",
+      rate_limit: {
+        primary_window: {
+          used_percent: 10,
+          reset_at: Math.floor(Date.now() / 1000) + 3600,
+          limit_window_seconds: 18000,
+        },
+      },
+      credits: {
+        balance: 50,
+        unlimited: false,
+      },
+    }));
+  }) as any;
+
+  try {
+    const session = {
+      model: { provider: "openai-codex", id: "gpt-test", reasoning: true },
+      thinkingLevel: "high",
+      getContextUsage: () => null,
+      modelRegistry: {
+        refresh: () => {},
+        getAvailable: () => [
+          { provider: "openai-codex", id: "gpt-test", name: "GPT Test", contextWindow: 128000, reasoning: true },
+        ],
+      },
+    };
+
+    const fixture = createFacade({
+      authStorage: {
+        get: () => ({ type: "oauth", access: "token", accountId: "acct_123", expires: Date.now() + 60_000 }),
+      } as any,
+    });
+    fixture.pool.set("web:default", { runtime: createRuntime(session), lastUsed: Date.now() });
+
+    const available = await Promise.race([
+      fixture.facade.getAvailableModels("web:default"),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("timed out waiting for getAvailableModels")), 50)),
+    ]);
+
+    expect((available as any).current).toBe("openai-codex/gpt-test");
+    expect((available as any).provider_usage).toBeNull();
+  } finally {
+    release();
+    globalThis.fetch = previousFetch;
+  }
 });
 
 test("AgentRuntimeFacade removes one queued follow-up and replays the remaining queue", async () => {

--- a/runtime/test/web/app-main-render-composition.test.ts
+++ b/runtime/test/web/app-main-render-composition.test.ts
@@ -170,6 +170,7 @@ test('composeRenderedMainAppOptions builds final shell options from grouped app 
   expect(result.mainShellOptions.searchQuery).toBe('hello');
   expect(result.mainShellOptions.oobePanelState).toEqual({ kind: 'provider-ready' });
   expect(result.mainShellOptions.composePrefillRequest).toEqual({ token: 'prefill-2', text: '/model' });
+  expect(result.mainShellOptions.agentModelsPayload).toEqual({ models: ['openai/gpt-4.1'] });
   expect(typeof result.mainShellOptions.openEditor).toBe('function');
   expect(typeof result.mainShellOptions.openTerminalTab).toBe('function');
   expect(typeof result.mainShellOptions.openVncTab).toBe('function');

--- a/runtime/test/web/compose-box.test.ts
+++ b/runtime/test/web/compose-box.test.ts
@@ -7,6 +7,7 @@ import {
   getComposeHistoryStorageKey,
   getModelPickerOptionSearchLabel,
   normalizeModelPickerOptions,
+  resolveComposeModelPickerState,
   parseQueuedContent,
   resolveComposePrefillRequest,
   resolveUiOnlyCommandNotice,
@@ -148,6 +149,32 @@ test('model picker helpers expose searchable names and formatted context windows
   expect(getModelPickerOptionSearchLabel(option)).toContain('anthropic/claude-sonnet-4');
   expect(getModelPickerOptionSearchLabel(option)).toContain('Claude Sonnet 4');
   expect(getModelPickerOptionSearchLabel(option)).toContain('200K ctx');
+});
+
+test('resolveComposeModelPickerState keeps the model picker visible for cold chats with available models', () => {
+  expect(resolveComposeModelPickerState(null, {
+    current: null,
+    model_options: [{ label: 'openai/gpt-5', provider: 'openai', id: 'gpt-5' }],
+  })).toEqual({
+    showPicker: true,
+    label: 'Select model',
+    hasAvailableModels: true,
+  });
+
+  expect(resolveComposeModelPickerState('openai/gpt-5', {
+    current: null,
+    model_options: [{ label: 'openai/gpt-5', provider: 'openai', id: 'gpt-5' }],
+  })).toEqual({
+    showPicker: true,
+    label: 'openai/gpt-5',
+    hasAvailableModels: true,
+  });
+
+  expect(resolveComposeModelPickerState(null, { current: null, model_options: [] })).toEqual({
+    showPicker: false,
+    label: '',
+    hasAvailableModels: false,
+  });
 });
 
 test('resolveUiOnlyCommandNotice only surfaces read-only model and thinking queries', () => {

--- a/runtime/web/src/components/compose-box.ts
+++ b/runtime/web/src/components/compose-box.ts
@@ -249,6 +249,24 @@ export function getModelPickerOptionSearchLabel(option) {
     ].filter(Boolean).join(' ');
 }
 
+export function resolveComposeModelPickerState(activeModel, agentModelsPayload) {
+    const modelLabel = typeof activeModel === 'string' ? activeModel.trim() : '';
+    if (modelLabel) {
+        return {
+            showPicker: true,
+            label: modelLabel,
+            hasAvailableModels: true,
+        };
+    }
+
+    const hasAvailableModels = normalizeModelPickerOptions(agentModelsPayload).length > 0;
+    return {
+        showPicker: hasAvailableModels,
+        label: hasAvailableModels ? 'Select model' : '',
+        hasAvailableModels,
+    };
+}
+
 function unwrapQueuedTranscriptContent(value) {
     if (!value) return value;
     const normalized = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
@@ -513,6 +531,7 @@ export function ComposeBox({
     onRemoveMessageRef,
     onClearMessageRefs,
     activeModel = null,
+    agentModelsPayload = null,
     modelUsage = null,
     thinkingLevel = null,
     supportsThinking = false,
@@ -704,7 +723,9 @@ export function ComposeBox({
     const canCreateSession = !searchMode && typeof onCreateSession === 'function';
     const canDeleteSession = !searchMode && typeof onDeleteSession === 'function' && !isCurrentRootSession;
     const showSessionSwitcherButton = !searchMode && (canSwitchSession || canRestoreSession || canRenameSession || canCreateSession || canDeleteSession);
-    const modelHintLabel = activeModel || '';
+    const modelPickerState = resolveComposeModelPickerState(activeModel, agentModelsPayload);
+    const showModelPickerHint = modelPickerState.showPicker;
+    const modelHintLabel = modelPickerState.label;
     const modelHintSuffix = supportsThinking && thinkingLevel ? ` (${thinkingLevel})` : '';
     const modelThinkingLabel = modelHintSuffix.trim() ? `${thinkingLevel}` : '';
     const modelUsageLabel = typeof modelUsage?.hint_short === 'string' ? modelUsage.hint_short.trim() : '';
@@ -713,7 +734,7 @@ export function ComposeBox({
         modelUsageLabel || null,
     ].filter(Boolean).join(' • ');
     const modelUsageTitleParts = [
-        modelHintLabel ? `Current model: ${modelHintLabel}${modelHintSuffix}` : null,
+        activeModel ? `Current model: ${modelHintLabel}${modelHintSuffix}` : null,
         modelUsage?.plan ? `Plan: ${modelUsage.plan}` : null,
         modelUsageLabel || null,
         modelUsage?.primary?.reset_description || null,
@@ -721,7 +742,10 @@ export function ComposeBox({
     ].filter(Boolean);
     const modelHintTitle = switchingModel
         ? 'Switching model…'
-        : (modelUsageTitleParts.join(' • ') || `Current model: ${modelHintLabel}${modelHintSuffix} (tap to open model picker)`);
+        : (modelUsageTitleParts.join(' • ') || (showModelPickerHint
+            ? 'Select a model (tap to open model picker)'
+            : `Current model: ${modelHintLabel}${modelHintSuffix} (tap to open model picker)`));
+    const showComposeMetaRow = !searchMode && (showModelPickerHint || (contextUsage && contextUsage.percent != null));
 
     const emitModelState = (payload) => {
         if (!payload || typeof payload !== 'object') return;
@@ -2032,9 +2056,9 @@ export function ComposeBox({
                     `}
                 </div>
                 <div class="compose-footer" ref=${footerRef}>
-                    ${!searchMode && activeModel && html`
+                    ${showComposeMetaRow && html`
                     <div class="compose-meta-row">
-                        ${!searchMode && activeModel && html`
+                        ${showModelPickerHint && html`
                             <div class="compose-model-meta">
                                 <button
                                     ref=${modelHintRef}

--- a/runtime/web/src/ui/app-main-render-composition.ts
+++ b/runtime/web/src/ui/app-main-render-composition.ts
@@ -175,6 +175,7 @@ export function composeRenderedMainAppOptions(input: {
       activeChatAgents: input.surface.activeChatAgents,
       connectionStatus: input.surface.connectionStatus,
       activeModel: input.surface.activeModel,
+      agentModelsPayload: input.surface.agentModelsPayload,
       activeModelUsage: input.surface.activeModelUsage,
       activeThinkingLevel: input.surface.activeThinkingLevel,
       supportsThinking: input.surface.supportsThinking,

--- a/runtime/web/src/ui/app-main-shell-render.ts
+++ b/runtime/web/src/ui/app-main-shell-render.ts
@@ -240,6 +240,7 @@ export function renderMainShell(options: MainShellRenderOptions): any {
     activeChatAgents,
     connectionStatus,
     activeModel,
+    agentModelsPayload,
     activeModelUsage,
     activeThinkingLevel,
     supportsThinking,
@@ -610,6 +611,7 @@ export function renderMainShell(options: MainShellRenderOptions): any {
           currentChatJid=${currentChatJid}
           connectionStatus=${connectionStatus}
           activeModel=${activeModel}
+          agentModelsPayload=${agentModelsPayload}
           modelUsage=${activeModelUsage}
           thinkingLevel=${activeThinkingLevel}
           supportsThinking=${supportsThinking}


### PR DESCRIPTION
## Why
Follow-up to #42.

The timing work in #42 showed that passive model-state refreshes were still paying unnecessary latency on cold thread opens and thread switches. The main issue here was that `/agent/models` could cold-start an `AgentSession` just to render the model picker state, even when the UI only needed registry-backed model options.

That made routine UI refreshes block on runtime hydration work that was not actually required to paint the picker.

## What this changes
- avoid hydrating a cold runtime in `getAvailableModels()` when there is no cached session for the target chat
- return registry-backed model options immediately for cold chats
- keep session-specific values when a runtime is already cached
- return the last cached provider-usage snapshot immediately and refresh it in the background
- dedupe concurrent provider-usage refreshes so repeated passive refreshes do not stampede the usage endpoints

## Scope
This is intentionally limited to the model-refresh fast path.

It does not change:
- model selection behavior
- provider semantics
- session persistence rules
- queueing or thread-state refresh orchestration

## Validation
- `bun test runtime/test/agent-pool/provider-usage.test.ts runtime/test/agent-pool/runtime-facade.test.ts`

Signed-off-by: Pix (PiClaw, openai-codex/gpt-5.4)
