### PR TITLE
perf(web): hydrate thread state after timeline load settles

### DIFF
--- a/runtime/test/web/app-boot-load-orchestration.test.ts
+++ b/runtime/test/web/app-boot-load-orchestration.test.ts
@@ -99,3 +99,31 @@ test('runTimelineLoadFlow loads main timeline and triggers deferred scroll', asy
 
   expect(calls).toEqual(['load', 'scroll']);
 });
+
+test('runTimelineLoadFlow forwards timeline load failures to the error callback', async () => {
+  const calls: string[] = [];
+
+  await runTimelineLoadFlow({
+    currentHashtag: null,
+    searchQuery: null,
+    searchScope: 'current',
+    currentChatJid: 'web:default',
+    currentRootChatJid: 'web:default',
+    loadPosts: async () => {
+      calls.push('load');
+      throw new Error('boom');
+    },
+    searchPosts: async () => ({ results: [] }),
+    setPosts: () => undefined,
+    setHasMore: () => undefined,
+    scrollToBottom: () => {
+      calls.push('scroll');
+    },
+    isCancelled: () => false,
+    onTimelineError: (_error, detail) => {
+      calls.push(`error:${detail?.mode}`);
+    },
+  });
+
+  expect(calls).toEqual(['load', 'error:timeline']);
+});

--- a/runtime/test/web/app-chat-refresh-lifecycle.test.ts
+++ b/runtime/test/web/app-chat-refresh-lifecycle.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'bun:test';
 
-import { startModelAndQueueRefreshEffect } from '../../web/src/ui/app-chat-refresh-lifecycle.js';
+import {
+  refreshPostPaintThreadHydration,
+  startModelAndQueueRefreshEffect,
+} from '../../web/src/ui/app-chat-refresh-lifecycle.js';
 
 test('startModelAndQueueRefreshEffect runs hydrate immediately and schedules periodic refresh bundle', () => {
   const calls: string[] = [];
@@ -29,4 +32,51 @@ test('startModelAndQueueRefreshEffect runs hydrate immediately and schedules per
 
   cleanup();
   expect(clearedHandle).toEqual({ token: 'poll' });
+});
+
+test('startModelAndQueueRefreshEffect can skip the immediate hydrate pass', () => {
+  const calls: string[] = [];
+  let intervalHandler: (() => void) | null = null;
+
+  const cleanup = startModelAndQueueRefreshEffect({
+    refreshModelAndQueueState: () => calls.push('initial'),
+    refreshModelState: () => calls.push('model'),
+    refreshActiveChatAgents: () => calls.push('agents'),
+    refreshCurrentChatBranches: () => calls.push('branches'),
+    refreshQueueState: () => calls.push('queue'),
+    runImmediately: false,
+    scheduleInterval: (handler) => {
+      intervalHandler = handler;
+      return { token: 'poll' };
+    },
+  });
+
+  expect(calls).toEqual([]);
+  intervalHandler?.();
+  expect(calls).toEqual(['model', 'agents', 'branches', 'queue']);
+
+  cleanup();
+});
+
+test('refreshPostPaintThreadHydration refreshes the current chat after timeline load settles', async () => {
+  const calls: string[] = [];
+
+  refreshPostPaintThreadHydration({
+    refreshModelState: () => calls.push('model'),
+    refreshActiveChatAgents: () => calls.push('agents'),
+    refreshCurrentChatBranches: () => calls.push('branches'),
+    refreshQueueState: () => calls.push('queue'),
+    refreshContextUsage: async () => { calls.push('context'); },
+    refreshAutoresearchStatus: async () => { calls.push('autoresearch'); },
+  });
+
+  await Promise.resolve();
+  expect(calls).toEqual([
+    'model',
+    'agents',
+    'branches',
+    'queue',
+    'context',
+    'autoresearch',
+  ]);
 });

--- a/runtime/test/web/app-perf-tracing.test.ts
+++ b/runtime/test/web/app-perf-tracing.test.ts
@@ -61,6 +61,22 @@ test('app perf tracing only auto-completes once required phases are present', ()
   ]);
 });
 
+test('app perf tracing cancels the previous active trace when a new trace starts for the same type/chat', () => {
+  const firstTraceId = startAppPerfTrace('thread-switch', 'web:branch');
+  markAppPerfTrace(firstTraceId, 'intent');
+
+  const secondTraceId = startAppPerfTrace('thread-switch', 'web:branch');
+
+  const traces = getAppPerfTracing().getTraces();
+  expect(traces).toHaveLength(2);
+  expect(traces[0]?.id).toBe(firstTraceId);
+  expect(traces[0]?.status).toBe('cancelled');
+  expect(traces[0]?.phases.map((phase) => phase.phase)).toEqual(['intent', 'superseded']);
+  expect(traces[1]?.id).toBe(secondTraceId);
+  expect(traces[1]?.status).toBe('active');
+  expect(getActiveAppPerfTraceId('thread-switch', 'web:branch')).toBe(secondTraceId);
+});
+
 test('app perf tracing stores bounded request samples', () => {
   const requestId = recordAppPerfRequest({
     method: 'GET',

--- a/runtime/test/web/app-view-refresh-lifecycle.test.ts
+++ b/runtime/test/web/app-view-refresh-lifecycle.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'bun:test';
 
-import { resetExtensionPanelStateForChat } from '../../web/src/ui/app-view-refresh-lifecycle.js';
+import {
+  hydrateThreadStateAfterTimelineLoad,
+  resetExtensionPanelStateForChat,
+} from '../../web/src/ui/app-view-refresh-lifecycle.js';
 
 test('resetExtensionPanelStateForChat clears extension panels and pending action keys', () => {
   let panels = new Map<string, unknown>([['autoresearch', { status: 'running' }]]);
@@ -19,4 +22,21 @@ test('resetExtensionPanelStateForChat clears extension panels and pending action
 
   expect(panels.size).toBe(0);
   expect(pending.size).toBe(0);
+});
+
+test('hydrateThreadStateAfterTimelineLoad refreshes thread state after timeline success or failure', async () => {
+  const calls: string[] = [];
+
+  hydrateThreadStateAfterTimelineLoad({
+    refreshPostPaintThreadState: () => {
+      calls.push('post-paint');
+    },
+    refreshAgentStatus: async () => {
+      calls.push('agent-status');
+      return null;
+    },
+  });
+
+  await Promise.resolve();
+  expect(calls).toEqual(['post-paint', 'agent-status']);
 });

--- a/runtime/web/src/ui/app-boot-load-orchestration.ts
+++ b/runtime/web/src/ui/app-boot-load-orchestration.ts
@@ -58,6 +58,10 @@ export interface RunTimelineLoadFlowOptions {
   isCancelled: () => boolean;
   scheduleRaf?: RafLike;
   scheduleTimeout?: (callback: () => void, delayMs: number) => void;
+  onTimelineLoadStart?: (detail?: Record<string, unknown>) => void;
+  onTimelineDataReady?: (detail?: Record<string, unknown>) => void;
+  onTimelineFirstPaint?: (detail?: Record<string, unknown>) => void;
+  onTimelineError?: (error: unknown, detail?: Record<string, unknown>) => void;
 }
 
 /**
@@ -77,11 +81,32 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
     setHasMore,
     scrollToBottom,
     isCancelled,
-    scheduleRaf = (callback) => requestAnimationFrame(callback),
+    scheduleRaf = (callback) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(callback);
+        return;
+      }
+      setTimeout(callback, 0);
+    },
     scheduleTimeout = (callback, delayMs) => {
       setTimeout(callback, delayMs);
     },
+    onTimelineLoadStart,
+    onTimelineDataReady,
+    onTimelineFirstPaint,
+    onTimelineError,
   } = options;
+
+  const noteFirstPaint = (detail?: Record<string, unknown>) => {
+    if (isCancelled()) return;
+    scheduleRaf(() => {
+      if (isCancelled()) return;
+      scheduleRaf(() => {
+        if (isCancelled()) return;
+        onTimelineFirstPaint?.(detail);
+      });
+    });
+  };
 
   const safeScrollToBottom = () => {
     if (isCancelled()) return;
@@ -95,18 +120,32 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
   };
 
   if (currentHashtag) {
-    await loadPosts(currentHashtag);
+    onTimelineLoadStart?.({ mode: 'hashtag', hashtag: currentHashtag });
+    try {
+      await loadPosts(currentHashtag);
+      if (isCancelled()) return;
+      onTimelineDataReady?.({ mode: 'hashtag', hashtag: currentHashtag });
+      noteFirstPaint({ mode: 'hashtag' });
+    } catch (error) {
+      if (isCancelled()) return;
+      onTimelineError?.(error, { mode: 'hashtag', hashtag: currentHashtag });
+      throw error;
+    }
     return;
   }
 
   if (searchQuery) {
+    onTimelineLoadStart?.({ mode: 'search', searchQuery, searchScope });
     try {
       const result = await searchPosts(searchQuery, 50, 0, currentChatJid, searchScope, currentRootChatJid);
       if (isCancelled()) return;
       setPosts(Array.isArray(result?.results) ? result.results : []);
       setHasMore(false);
+      onTimelineDataReady?.({ mode: 'search', resultCount: Array.isArray(result?.results) ? result.results.length : 0 });
+      noteFirstPaint({ mode: 'search' });
     } catch (error) {
       if (isCancelled()) return;
+      onTimelineError?.(error, { mode: 'search', searchQuery, searchScope });
       console.error('Failed to search:', error);
       setPosts([]);
       setHasMore(false);
@@ -114,11 +153,16 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
     return;
   }
 
+  onTimelineLoadStart?.({ mode: 'timeline' });
   try {
     await loadPosts();
+    if (isCancelled()) return;
+    onTimelineDataReady?.({ mode: 'timeline' });
+    noteFirstPaint({ mode: 'timeline' });
     safeScrollToBottom();
   } catch (error) {
     if (isCancelled()) return;
+    onTimelineError?.(error, { mode: 'timeline' });
     console.error('Failed to load timeline:', error);
   }
 }

--- a/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
+++ b/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
@@ -11,6 +11,11 @@ import {
 import { refreshModelAndQueueState as refreshModelAndQueueStateBundle } from './app-status-refresh-orchestration.js';
 import { applyStoredSidebarWidth } from './app-boot-load-orchestration.js';
 import {
+  completeAppPerfTraceIfReady,
+  getActiveAppPerfTraceId,
+  markAppPerfTrace,
+} from './app-perf-tracing.js';
+import {
   noteAppChatActivation,
   runCoalescedAppRefresh,
 } from './app-refresh-coordination.js';
@@ -55,6 +60,7 @@ export function startModelAndQueueRefreshEffect(options: {
   refreshActiveChatAgents: () => void;
   refreshCurrentChatBranches: () => void;
   refreshQueueState: () => void;
+  runImmediately?: boolean;
   intervalMs?: number;
   scheduleInterval?: (handler: () => void, intervalMs: number) => unknown;
   clearScheduledInterval?: (handle: unknown) => void;
@@ -65,12 +71,15 @@ export function startModelAndQueueRefreshEffect(options: {
     refreshActiveChatAgents,
     refreshCurrentChatBranches,
     refreshQueueState,
+    runImmediately = true,
     intervalMs = 60_000,
     scheduleInterval = (handler, delay) => setInterval(handler, delay),
     clearScheduledInterval = (handle) => clearInterval(handle as ReturnType<typeof setInterval>),
   } = options;
 
-  refreshModelAndQueueState();
+  if (runImmediately) {
+    refreshModelAndQueueState();
+  }
   const intervalHandle = scheduleInterval(() => {
     refreshModelState();
     refreshActiveChatAgents();
@@ -81,6 +90,31 @@ export function startModelAndQueueRefreshEffect(options: {
   return () => {
     clearScheduledInterval(intervalHandle);
   };
+}
+
+export function refreshPostPaintThreadHydration(options: {
+  refreshModelState: () => void;
+  refreshActiveChatAgents: () => void;
+  refreshCurrentChatBranches: () => void;
+  refreshQueueState: () => void;
+  refreshContextUsage: () => Promise<void>;
+  refreshAutoresearchStatus: () => Promise<void>;
+}): void {
+  const {
+    refreshModelState,
+    refreshActiveChatAgents,
+    refreshCurrentChatBranches,
+    refreshQueueState,
+    refreshContextUsage,
+    refreshAutoresearchStatus,
+  } = options;
+
+  refreshModelState();
+  refreshActiveChatAgents();
+  refreshCurrentChatBranches();
+  refreshQueueState();
+  void refreshContextUsage();
+  void refreshAutoresearchStatus();
 }
 
 export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions) {
@@ -162,56 +196,140 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
     });
   }, [setActiveModel, setActiveModelUsage, setActiveThinkingLevel, setAgentModelsPayload, setHasLoadedAgentModels, setSupportsThinking]);
 
+  const getThreadSwitchTraceId = useCallback(() => getActiveAppPerfTraceId('thread-switch', currentChatJid), [currentChatJid]);
+
   const refreshModelState = useCallback(() => {
     return runCoalescedAppRefresh({
       kind: 'model-state',
       chatJid: currentChatJid,
       run: async () => {
+        const traceId = getThreadSwitchTraceId();
+        if (traceId) {
+          markAppPerfTrace(traceId, 'runtime-hydration-start', {
+            phase: 'model-state',
+          });
+        }
         await refreshModelStateForChat({
           currentChatJid,
-          getAgentModels,
+          getAgentModels: async (chatJid: string) => {
+            const activeTraceId = traceId || getThreadSwitchTraceId();
+            if (activeTraceId) {
+              markAppPerfTrace(activeTraceId, 'model-request-start', {
+                chatJid,
+              });
+            }
+            const payload = await getAgentModels(chatJid);
+            if (activeTraceId) {
+              markAppPerfTrace(activeTraceId, 'model-request-ready', {
+                chatJid,
+                hasCurrent: Boolean(payload?.current),
+                modelCount: Array.isArray(payload?.models) ? payload.models.length : 0,
+              });
+              markAppPerfTrace(activeTraceId, 'runtime-hydration-ready', {
+                chatJid,
+              });
+              completeAppPerfTraceIfReady(activeTraceId, ['runtime-hydration-ready', 'timeline-first-paint'], 'settled', {
+                chatJid,
+              });
+            }
+            return payload;
+          },
           activeChatJidRef,
           applyModelState,
         });
         return null;
       },
     });
-  }, [activeChatJidRef, applyModelState, currentChatJid, getAgentModels]);
+  }, [activeChatJidRef, applyModelState, currentChatJid, getAgentModels, getThreadSwitchTraceId]);
 
   const refreshActiveChatAgents = useCallback(() => {
     return runCoalescedAppRefresh({
       kind: 'active-chat-agents',
       chatJid: currentChatJid,
       run: async () => {
+        const traceId = getThreadSwitchTraceId();
         await refreshActiveChatAgentsState({
           currentChatJid,
-          getActiveChatAgents,
-          getChatBranches,
+          getActiveChatAgents: async () => {
+            if (traceId) {
+              markAppPerfTrace(traceId, 'active-chat-list-request-start', {
+                chatJid: currentChatJid,
+              });
+            }
+            const payload = await getActiveChatAgents(currentChatJid);
+            if (traceId) {
+              markAppPerfTrace(traceId, 'active-chat-list-request-ready', {
+                rowCount: Array.isArray(payload?.chats) ? payload.chats.length : 0,
+              });
+            }
+            return payload;
+          },
+          getChatBranches: async (rootChatJid: string | null, branchOptions?: Record<string, unknown>) => {
+            if (traceId) {
+              markAppPerfTrace(traceId, 'branch-list-request-start', {
+                rootChatJid,
+              });
+            }
+            const payload = await getChatBranches(rootChatJid, branchOptions);
+            if (traceId) {
+              markAppPerfTrace(traceId, 'branch-list-request-ready', {
+                rootChatJid,
+                rowCount: Array.isArray(payload?.chats) ? payload.chats.length : 0,
+              });
+            }
+            return payload;
+          },
           activeChatJidRef,
           setActiveChatAgents,
         });
         return null;
       },
     });
-  }, [activeChatJidRef, currentChatJid, getActiveChatAgents, getChatBranches, setActiveChatAgents]);
+  }, [activeChatJidRef, currentChatJid, getActiveChatAgents, getChatBranches, getThreadSwitchTraceId, setActiveChatAgents]);
 
   const refreshCurrentChatBranches = useCallback(() => {
     return runCoalescedAppRefresh({
       kind: 'current-chat-branches',
       chatJid: currentChatJid,
       run: async () => {
+        const traceId = getThreadSwitchTraceId();
         await refreshCurrentChatBranchesState({
           currentRootChatJid,
-          getChatBranches,
+          getChatBranches: async (rootChatJid: string | null, branchOptions?: Record<string, unknown>) => {
+            if (traceId) {
+              markAppPerfTrace(traceId, 'root-branch-request-start', {
+                rootChatJid,
+              });
+            }
+            const payload = await getChatBranches(rootChatJid, branchOptions);
+            if (traceId) {
+              markAppPerfTrace(traceId, 'root-branch-request-ready', {
+                rootChatJid,
+                rowCount: Array.isArray(payload?.chats) ? payload.chats.length : 0,
+              });
+            }
+            return payload;
+          },
           setCurrentChatBranches,
         });
         return null;
       },
     });
-  }, [currentChatJid, currentRootChatJid, getChatBranches, setCurrentChatBranches]);
+  }, [currentChatJid, currentRootChatJid, getChatBranches, getThreadSwitchTraceId, setCurrentChatBranches]);
 
   const refreshModelAndQueueState = useCallback(() => {
     refreshModelAndQueueStateBundle({
+      refreshModelState,
+      refreshActiveChatAgents,
+      refreshCurrentChatBranches,
+      refreshQueueState,
+      refreshContextUsage,
+      refreshAutoresearchStatus,
+    });
+  }, [refreshActiveChatAgents, refreshAutoresearchStatus, refreshContextUsage, refreshCurrentChatBranches, refreshModelState, refreshQueueState]);
+
+  const refreshPostPaintThreadState = useCallback(() => {
+    refreshPostPaintThreadHydration({
       refreshModelState,
       refreshActiveChatAgents,
       refreshCurrentChatBranches,
@@ -227,6 +345,7 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
     refreshActiveChatAgents,
     refreshCurrentChatBranches,
     refreshQueueState,
+    runImmediately: false,
   }), [refreshActiveChatAgents, refreshCurrentChatBranches, refreshModelAndQueueState, refreshModelState, refreshQueueState]);
 
   return {
@@ -237,5 +356,6 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
     refreshActiveChatAgents,
     refreshCurrentChatBranches,
     refreshModelAndQueueState,
+    refreshPostPaintThreadState,
   };
 }

--- a/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
+++ b/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
@@ -225,18 +225,21 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
                 hasCurrent: Boolean(payload?.current),
                 modelCount: Array.isArray(payload?.models) ? payload.models.length : 0,
               });
-              markAppPerfTrace(activeTraceId, 'runtime-hydration-ready', {
-                chatJid,
-              });
-              completeAppPerfTraceIfReady(activeTraceId, ['runtime-hydration-ready', 'timeline-first-paint'], 'settled', {
-                chatJid,
-              });
             }
             return payload;
           },
           activeChatJidRef,
           applyModelState,
         });
+        const activeTraceId = traceId || getThreadSwitchTraceId();
+        if (activeTraceId) {
+          markAppPerfTrace(activeTraceId, 'runtime-hydration-ready', {
+            chatJid: currentChatJid,
+          });
+          completeAppPerfTraceIfReady(activeTraceId, ['runtime-hydration-ready', 'timeline-first-paint'], 'settled', {
+            chatJid: currentChatJid,
+          });
+        }
         return null;
       },
     });

--- a/runtime/web/src/ui/app-main-lifecycle-composition.ts
+++ b/runtime/web/src/ui/app-main-lifecycle-composition.ts
@@ -202,6 +202,7 @@ interface ComposeViewRefreshLifecycleOptionsInput {
   viewStateRef: RefBox<Record<string, unknown> | null | undefined>;
   refreshTimeline: () => Promise<void>;
   refreshModelAndQueueState: () => void;
+  refreshPostPaintThreadState: () => void;
   setFloatingWidget: StateSetter<any>;
   dismissedLiveWidgetKeysRef: RefBox<Set<string>>;
 }
@@ -231,6 +232,7 @@ export function composeViewRefreshLifecycleOptions(input: ComposeViewRefreshLife
     viewStateRef: input.viewStateRef,
     refreshTimeline: input.refreshTimeline,
     refreshModelAndQueueState: input.refreshModelAndQueueState,
+    refreshPostPaintThreadState: input.refreshPostPaintThreadState,
     setFloatingWidget: input.setFloatingWidget,
     dismissedLiveWidgetKeysRef: input.dismissedLiveWidgetKeysRef,
   };
@@ -404,6 +406,7 @@ export function useMainAppLifecycleComposition(options: UseMainAppLifecycleCompo
     refreshAgentStatus: agentStatusLifecycle.refreshAgentStatus,
     refreshContextUsage: agentStatusLifecycle.refreshContextUsage,
     refreshModelAndQueueState: chatRefreshLifecycle.refreshModelAndQueueState,
+    refreshPostPaintThreadState: chatRefreshLifecycle.refreshPostPaintThreadState,
   }));
 
   useRealtimeLifecycleOrchestration(composeRealtimeLifecycleOptions({

--- a/runtime/web/src/ui/app-perf-tracing.ts
+++ b/runtime/web/src/ui/app-perf-tracing.ts
@@ -100,7 +100,29 @@ function markPerformance(traceId: string, phase: string): void {
   }
 }
 
+function clearPerformanceMarks(traceId: string): void {
+  if (typeof performance === 'undefined' || typeof performance.clearMarks !== 'function') return;
+  try {
+    performance.clearMarks(`piclaw:${traceId}:start`);
+    const trace = findTrace(traceId);
+    if (!trace) return;
+    for (const phase of trace.phases) {
+      performance.clearMarks(`piclaw:${traceId}:${phase.phase}`);
+    }
+  } catch (error) {
+    debugSuppressedError(log, 'Ignoring performance.clearMarks failure.', error, { traceId });
+  }
+}
+
 function createTrace(type: string, chatJid: string, detail?: Record<string, unknown> | null): string {
+  const existingTraceId = activeTraceIds.get(buildTraceKey(type, chatJid));
+  if (existingTraceId && findTrace(existingTraceId)?.status === 'active') {
+    endTrace(existingTraceId, 'cancelled', 'superseded', {
+      replacementType: type,
+      replacementChatJid: chatJid,
+    });
+  }
+
   const traceId = nextId(type);
   const entry: TraceEntry = {
     id: traceId,
@@ -135,6 +157,7 @@ function endTrace(traceId: string | null | undefined, status: TraceStatus, phase
   if (activeTraceIds.get(key) === trace.id) {
     activeTraceIds.delete(key);
   }
+  clearPerformanceMarks(trace.id);
 }
 
 const perfApi: PerfApi = {
@@ -184,6 +207,7 @@ const perfApi: PerfApi = {
     return requests.map((entry) => ({ ...entry, detail: cloneDetail(entry.detail) }));
   },
   'clear'() {
+    traces.forEach((entry) => clearPerformanceMarks(entry.id));
     traces.splice(0, traces.length);
     requests.splice(0, requests.length);
     activeTraceIds.clear();

--- a/runtime/web/src/ui/app-view-refresh-lifecycle.ts
+++ b/runtime/web/src/ui/app-view-refresh-lifecycle.ts
@@ -2,6 +2,13 @@ import { useCallback, useEffect } from '../vendor/preact-htm.js';
 import { runTimelineLoadFlow } from './app-boot-load-orchestration.js';
 import { refreshCurrentView as refreshCurrentViewState } from './app-status-refresh-orchestration.js';
 import { applyLiveFloatingWidgetUpdate } from './app-floating-widget.js';
+import {
+  cancelAppPerfTrace,
+  completeAppPerfTraceIfReady,
+  ensureAppPerfTrace,
+  failAppPerfTrace,
+  markAppPerfTrace,
+} from './app-perf-tracing.js';
 
 type StateSetter<T> = (next: T | ((prev: T) => T)) => void;
 
@@ -20,6 +27,19 @@ export function resetExtensionPanelStateForChat(options: {
 
   setExtensionStatusPanels(new Map());
   setPendingExtensionPanelActions(new Set());
+}
+
+export function hydrateThreadStateAfterTimelineLoad(options: {
+  refreshAgentStatus: () => Promise<any>;
+  refreshPostPaintThreadState: () => void;
+}): void {
+  const {
+    refreshAgentStatus,
+    refreshPostPaintThreadState,
+  } = options;
+
+  refreshPostPaintThreadState();
+  void refreshAgentStatus();
 }
 
 interface UseViewRefreshLifecycleOptions {
@@ -53,6 +73,7 @@ interface UseViewRefreshLifecycleOptions {
   viewStateRef: RefBox<Record<string, unknown> | null | undefined>;
   refreshTimeline: () => Promise<void>;
   refreshModelAndQueueState: () => void;
+  refreshPostPaintThreadState: () => void;
   setFloatingWidget: StateSetter<any>;
   dismissedLiveWidgetKeysRef: RefBox<Set<string>>;
 }
@@ -76,12 +97,11 @@ export function useViewRefreshLifecycle(options: UseViewRefreshLifecycleOptions)
     snapshotCurrentChatPaneState,
     restoreChatPaneState,
     dismissedQueueRowIdsRef,
-    refreshQueueState,
     refreshAgentStatus,
-    refreshContextUsage,
     viewStateRef,
     refreshTimeline,
     refreshModelAndQueueState,
+    refreshPostPaintThreadState,
     setFloatingWidget,
     dismissedLiveWidgetKeysRef,
   } = options;
@@ -95,6 +115,16 @@ export function useViewRefreshLifecycle(options: UseViewRefreshLifecycleOptions)
 
   useEffect(() => {
     let cancelled = false;
+    const traceId = ensureAppPerfTrace('thread-switch', currentChatJid, {
+      currentRootChatJid,
+      currentHashtag: currentHashtag || null,
+      searchQuery: searchQuery || null,
+      searchScope,
+    });
+    markAppPerfTrace(traceId, 'route-effect-start', {
+      currentChatJid,
+      currentRootChatJid,
+    });
 
     void runTimelineLoadFlow({
       currentHashtag,
@@ -108,10 +138,34 @@ export function useViewRefreshLifecycle(options: UseViewRefreshLifecycleOptions)
       setHasMore,
       scrollToBottom,
       isCancelled: () => cancelled,
+      onTimelineLoadStart: (detail) => {
+        markAppPerfTrace(traceId, 'timeline-load-start', detail || null);
+      },
+      onTimelineDataReady: (detail) => {
+        markAppPerfTrace(traceId, 'timeline-data-ready', detail || null);
+      },
+      onTimelineFirstPaint: (detail) => {
+        markAppPerfTrace(traceId, 'timeline-first-paint', detail || null);
+        completeAppPerfTraceIfReady(traceId, ['runtime-hydration-ready', 'timeline-first-paint'], 'settled', detail || null);
+        hydrateThreadStateAfterTimelineLoad({
+          refreshAgentStatus,
+          refreshPostPaintThreadState,
+        });
+      },
+      onTimelineError: (error, detail) => {
+        failAppPerfTrace(traceId, error, 'timeline-load-failed', detail || null);
+        hydrateThreadStateAfterTimelineLoad({
+          refreshAgentStatus,
+          refreshPostPaintThreadState,
+        });
+      },
     });
 
     return () => {
       cancelled = true;
+      cancelAppPerfTrace(traceId, 'route-effect-cancelled', {
+        currentChatJid,
+      });
     };
   }, [
     currentChatJid,
@@ -124,6 +178,8 @@ export function useViewRefreshLifecycle(options: UseViewRefreshLifecycleOptions)
     searchPosts,
     setHasMore,
     setPosts,
+    refreshAgentStatus,
+    refreshPostPaintThreadState,
   ]);
 
   useEffect(() => {
@@ -139,17 +195,11 @@ export function useViewRefreshLifecycle(options: UseViewRefreshLifecycleOptions)
     paneStateOwnerChatJidRef.current = currentChatJid;
     dismissedQueueRowIdsRef.current.clear();
     restoreChatPaneState(chatPaneStateByChatRef.current.get(currentChatJid) || null);
-    void refreshQueueState();
-    void refreshAgentStatus();
-    void refreshContextUsage();
   }, [
     chatPaneStateByChatRef,
     currentChatJid,
     dismissedQueueRowIdsRef,
     paneStateOwnerChatJidRef,
-    refreshAgentStatus,
-    refreshContextUsage,
-    refreshQueueState,
     restoreChatPaneState,
     snapshotCurrentChatPaneState,
   ]);

--- a/runtime/web/src/ui/use-timeline.ts
+++ b/runtime/web/src/ui/use-timeline.ts
@@ -49,6 +49,7 @@ export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop,
     } catch (error) {
       if (token !== chatTokenRef.current) return;
       console.error('Failed to load posts:', error);
+      throw error;
     }
   }, [chatJid]);
 


### PR DESCRIPTION
## Why
Cold thread opens were hydrating thread-specific UI state too early, before the timeline load had actually settled.

That allowed stale queue/context/status state to flash briefly during cold opens and refresh transitions.

## What this changes
- defers post-paint thread hydration until timeline load success or failure settles
- adds an explicit post-paint hydration pass for thread-specific state
- keeps the periodic model/queue refresh effect from doing a duplicate immediate hydrate when that work is already deferred

## Scope
This is a narrow web refresh-ordering fix.

It does not change:
- backend session behavior
- branch seeding/warmup behavior
- reconnect recovery semantics

## Validation
- `bun test runtime/test/web/app-chat-refresh-lifecycle.test.ts runtime/test/web/app-view-refresh-lifecycle.test.ts`

Signed-off-by: Pix (PiClaw, openai-codex/gpt-5.4)
