### PR TITLE
perf(web): coalesce cold-open reconnect refreshes

### DIFF
--- a/runtime/test/web/app-boot-load-orchestration.test.ts
+++ b/runtime/test/web/app-boot-load-orchestration.test.ts
@@ -99,3 +99,31 @@ test('runTimelineLoadFlow loads main timeline and triggers deferred scroll', asy
 
   expect(calls).toEqual(['load', 'scroll']);
 });
+
+test('runTimelineLoadFlow forwards timeline load failures to the error callback', async () => {
+  const calls: string[] = [];
+
+  await runTimelineLoadFlow({
+    currentHashtag: null,
+    searchQuery: null,
+    searchScope: 'current',
+    currentChatJid: 'web:default',
+    currentRootChatJid: 'web:default',
+    loadPosts: async () => {
+      calls.push('load');
+      throw new Error('boom');
+    },
+    searchPosts: async () => ({ results: [] }),
+    setPosts: () => undefined,
+    setHasMore: () => undefined,
+    scrollToBottom: () => {
+      calls.push('scroll');
+    },
+    isCancelled: () => false,
+    onTimelineError: (_error, detail) => {
+      calls.push(`error:${detail?.mode}`);
+    },
+  });
+
+  expect(calls).toEqual(['load', 'error:timeline']);
+});

--- a/runtime/test/web/app-connection-lifecycle.test.ts
+++ b/runtime/test/web/app-connection-lifecycle.test.ts
@@ -1,10 +1,18 @@
-import { expect, test } from 'bun:test';
+import { afterEach, expect, test } from 'bun:test';
 
 import {
   handleConnectionStatusChangeEvent,
   handleUiVersionDriftEvent,
   runBackstopRefreshTick,
 } from '../../web/src/ui/app-connection-lifecycle.js';
+import {
+  noteAppChatActivation,
+  resetAppRefreshCoordination,
+} from '../../web/src/ui/app-refresh-coordination.js';
+
+afterEach(() => {
+  resetAppRefreshCoordination();
+});
 
 test('handleUiVersionDriftEvent ignores missing/unchanged versions', () => {
   const staleUiVersionRef = { current: null as string | null };
@@ -52,6 +60,7 @@ test('handleConnectionStatusChangeEvent clears active agent state on disconnect'
   const pendingRequestRef = { current: { id: 1 } as unknown };
 
   handleConnectionStatusChangeEvent({
+    currentChatJid: 'chat:alpha',
     status: 'disconnected',
     setConnectionStatus: (status) => { calls.push(`conn:${status}`); },
     setAgentStatus: (status) => { calls.push(`status:${status === null ? 'null' : 'set'}`); },
@@ -79,6 +88,32 @@ test('handleConnectionStatusChangeEvent clears active agent state on disconnect'
     'clear',
   ]);
   expect(pendingRequestRef.current).toBeNull();
+});
+
+test('handleConnectionStatusChangeEvent skips the initial reconnect bundle during a fresh cold-open activation', () => {
+  noteAppChatActivation({ chatJid: 'chat:alpha' });
+  const calls: string[] = [];
+
+  handleConnectionStatusChangeEvent({
+    currentChatJid: 'chat:alpha',
+    status: 'connected',
+    setConnectionStatus: (status) => { calls.push(`conn:${status}`); },
+    setAgentStatus: () => { calls.push('status'); },
+    setAgentDraft: () => { calls.push('draft'); },
+    setAgentPlan: () => { calls.push('plan'); },
+    setAgentThought: () => { calls.push('thought'); },
+    setPendingRequest: () => { calls.push('pending'); },
+    pendingRequestRef: { current: null },
+    clearAgentRunState: () => { calls.push('clear'); },
+    hasConnectedOnceRef: { current: false },
+    viewStateRef: { current: { currentHashtag: null, searchQuery: null, searchOpen: false } },
+    refreshTimeline: () => { calls.push('timeline'); },
+    refreshAgentStatus: () => { calls.push('refresh-status'); },
+    refreshQueueState: () => { calls.push('refresh-queue'); },
+    refreshContextUsage: () => { calls.push('refresh-context'); },
+  });
+
+  expect(calls).toEqual(['conn:connected']);
 });
 
 test('runBackstopRefreshTick refreshes queue only when agent is active', () => {

--- a/runtime/test/web/app-connection-lifecycle.test.ts
+++ b/runtime/test/web/app-connection-lifecycle.test.ts
@@ -113,7 +113,15 @@ test('handleConnectionStatusChangeEvent skips the initial reconnect bundle durin
     refreshContextUsage: () => { calls.push('refresh-context'); },
   });
 
-  expect(calls).toEqual(['conn:connected']);
+  expect(calls).toEqual([
+    'conn:connected',
+    'status',
+    'draft',
+    'plan',
+    'thought',
+    'pending',
+    'clear',
+  ]);
 });
 
 test('runBackstopRefreshTick refreshes queue only when agent is active', () => {

--- a/runtime/test/web/app-perf-tracing.test.ts
+++ b/runtime/test/web/app-perf-tracing.test.ts
@@ -61,6 +61,22 @@ test('app perf tracing only auto-completes once required phases are present', ()
   ]);
 });
 
+test('app perf tracing cancels the previous active trace when a new trace starts for the same type/chat', () => {
+  const firstTraceId = startAppPerfTrace('thread-switch', 'web:branch');
+  markAppPerfTrace(firstTraceId, 'intent');
+
+  const secondTraceId = startAppPerfTrace('thread-switch', 'web:branch');
+
+  const traces = getAppPerfTracing().getTraces();
+  expect(traces).toHaveLength(2);
+  expect(traces[0]?.id).toBe(firstTraceId);
+  expect(traces[0]?.status).toBe('cancelled');
+  expect(traces[0]?.phases.map((phase) => phase.phase)).toEqual(['intent', 'superseded']);
+  expect(traces[1]?.id).toBe(secondTraceId);
+  expect(traces[1]?.status).toBe('active');
+  expect(getActiveAppPerfTraceId('thread-switch', 'web:branch')).toBe(secondTraceId);
+});
+
 test('app perf tracing stores bounded request samples', () => {
   const requestId = recordAppPerfRequest({
     method: 'GET',

--- a/runtime/test/web/app-sse-events.test.ts
+++ b/runtime/test/web/app-sse-events.test.ts
@@ -1,6 +1,14 @@
-import { expect, test } from 'bun:test';
+import { afterEach, expect, test } from 'bun:test';
 
 import { handleAppSseEvent, type HandleAppSseEventDependencies } from '../../web/src/ui/app-sse-events.js';
+import {
+  noteAppChatActivation,
+  resetAppRefreshCoordination,
+} from '../../web/src/ui/app-refresh-coordination.js';
+
+afterEach(() => {
+  resetAppRefreshCoordination();
+});
 
 function applyUpdate<T>(current: T, next: T | ((prev: T) => T)): T {
   return typeof next === 'function' ? (next as (prev: T) => T)(current) : next;
@@ -160,6 +168,31 @@ test('handleAppSseEvent restores active agent status on reconnect', async () => 
     turn_id: 'turn-42',
     started_at: '2026-03-30T21:00:00.000Z',
   });
+});
+
+test('handleAppSseEvent skips duplicate reconnect recovery during a fresh cold-open activation', async () => {
+  noteAppChatActivation({ chatJid: 'chat:alpha' });
+  const state = createDeps();
+  let agentStatusCalls = 0;
+  let timelineCalls = 0;
+  let bundleCalls = 0;
+  state.deps.getAgentStatus = async () => {
+    agentStatusCalls += 1;
+    return null;
+  };
+  state.deps.refreshTimeline = () => {
+    timelineCalls += 1;
+  };
+  state.deps.refreshModelAndQueueState = () => {
+    bundleCalls += 1;
+  };
+
+  handleAppSseEvent('connected', { app_asset_version: 'test' }, state.deps);
+  await Promise.resolve();
+
+  expect(agentStatusCalls).toBe(0);
+  expect(timelineCalls).toBe(0);
+  expect(bundleCalls).toBe(0);
 });
 
 test('handleAppSseEvent refreshes compaction status metadata even when title stays the same', () => {

--- a/runtime/test/web/app-sse-events.test.ts
+++ b/runtime/test/web/app-sse-events.test.ts
@@ -176,9 +176,28 @@ test('handleAppSseEvent skips duplicate reconnect recovery during a fresh cold-o
   let agentStatusCalls = 0;
   let timelineCalls = 0;
   let bundleCalls = 0;
+  const resetCalls: string[] = [];
   state.deps.getAgentStatus = async () => {
     agentStatusCalls += 1;
     return null;
+  };
+  state.deps.setAgentStatus = () => {
+    resetCalls.push('status');
+  };
+  state.deps.setAgentDraft = () => {
+    resetCalls.push('draft');
+  };
+  state.deps.setAgentPlan = () => {
+    resetCalls.push('plan');
+  };
+  state.deps.setAgentThought = () => {
+    resetCalls.push('thought');
+  };
+  state.deps.setPendingRequest = () => {
+    resetCalls.push('pending');
+  };
+  state.deps.clearAgentRunState = () => {
+    resetCalls.push('clear');
   };
   state.deps.refreshTimeline = () => {
     timelineCalls += 1;
@@ -193,6 +212,7 @@ test('handleAppSseEvent skips duplicate reconnect recovery during a fresh cold-o
   expect(agentStatusCalls).toBe(0);
   expect(timelineCalls).toBe(0);
   expect(bundleCalls).toBe(0);
+  expect(resetCalls).toEqual(['status', 'draft', 'plan', 'thought', 'pending', 'clear']);
 });
 
 test('handleAppSseEvent refreshes compaction status metadata even when title stays the same', () => {

--- a/runtime/web/src/ui/app-agent-status-lifecycle.ts
+++ b/runtime/web/src/ui/app-agent-status-lifecycle.ts
@@ -13,6 +13,7 @@ import {
   handleConnectionStatusChangeEvent,
   handleUiVersionDriftEvent,
 } from './app-connection-lifecycle.js';
+import { runCoalescedAppRefresh } from './app-refresh-coordination.js';
 
 interface RefBox<T> {
   current: T;
@@ -129,57 +130,84 @@ export function useAgentStatusLifecycle(options: UseAgentStatusLifecycleOptions)
   } = options;
 
   const refreshQueueState = useCallback(() => {
-    refreshQueueStateForChat({
-      currentChatJid,
-      queueRefreshGenRef,
-      activeChatJidRef,
-      dismissedQueueRowIdsRef,
-      getAgentQueueState,
-      setFollowupQueueItems,
-      clearQueuedSteerStateIfStale,
+    return runCoalescedAppRefresh({
+      kind: 'queue-state',
+      chatJid: currentChatJid,
+      run: async () => {
+        await refreshQueueStateForChat({
+          currentChatJid,
+          queueRefreshGenRef,
+          activeChatJidRef,
+          dismissedQueueRowIdsRef,
+          getAgentQueueState,
+          setFollowupQueueItems,
+          clearQueuedSteerStateIfStale,
+        });
+        return null;
+      },
     });
   }, [activeChatJidRef, clearQueuedSteerStateIfStale, currentChatJid, dismissedQueueRowIdsRef, getAgentQueueState, queueRefreshGenRef, setFollowupQueueItems]);
 
   const refreshContextUsage = useCallback(async () => {
-    await refreshContextUsageForChat({
-      currentChatJid,
-      activeChatJidRef,
-      getAgentContext,
-      setContextUsage,
+    await runCoalescedAppRefresh({
+      kind: 'context-usage',
+      chatJid: currentChatJid,
+      run: async () => {
+        await refreshContextUsageForChat({
+          currentChatJid,
+          activeChatJidRef,
+          getAgentContext,
+          setContextUsage,
+        });
+        return null;
+      },
     });
   }, [activeChatJidRef, currentChatJid, getAgentContext, setContextUsage]);
 
   const refreshAutoresearchStatus = useCallback(async () => {
-    await refreshAutoresearchStatusForChat({
-      currentChatJid,
-      activeChatJidRef,
-      getAutoresearchStatus,
-      setExtensionStatusPanels,
-      setPendingExtensionPanelActions,
+    await runCoalescedAppRefresh({
+      kind: 'autoresearch-status',
+      chatJid: currentChatJid,
+      run: async () => {
+        await refreshAutoresearchStatusForChat({
+          currentChatJid,
+          activeChatJidRef,
+          getAutoresearchStatus,
+          setExtensionStatusPanels,
+          setPendingExtensionPanelActions,
+        });
+        return null;
+      },
     });
   }, [activeChatJidRef, currentChatJid, getAutoresearchStatus, setExtensionStatusPanels, setPendingExtensionPanelActions]);
 
   const refreshAgentStatus = useCallback(async () => {
-    return await refreshAgentStatusForChat({
-      currentChatJid,
-      getAgentStatus,
-      activeChatJidRef,
-      wasAgentActiveRef,
-      viewStateRef,
-      refreshTimeline,
-      clearAgentRunState,
-      agentStatusRef,
-      pendingRequestRef,
-      thoughtBufferRef,
-      draftBufferRef,
-      setAgentStatus,
-      setAgentDraft,
-      setAgentPlan,
-      setAgentThought,
-      setPendingRequest,
-      setActiveTurn,
-      noteAgentActivity,
-      clearLastActivityFlag,
+    return await runCoalescedAppRefresh({
+      kind: 'agent-status',
+      chatJid: currentChatJid,
+      run: async () => {
+        return await refreshAgentStatusForChat({
+          currentChatJid,
+          getAgentStatus,
+          activeChatJidRef,
+          wasAgentActiveRef,
+          viewStateRef,
+          refreshTimeline,
+          clearAgentRunState,
+          agentStatusRef,
+          pendingRequestRef,
+          thoughtBufferRef,
+          draftBufferRef,
+          setAgentStatus,
+          setAgentDraft,
+          setAgentPlan,
+          setAgentThought,
+          setPendingRequest,
+          setActiveTurn,
+          noteAgentActivity,
+          clearLastActivityFlag,
+        });
+      },
     });
   }, [activeChatJidRef, agentStatusRef, clearAgentRunState, clearLastActivityFlag, currentChatJid, draftBufferRef, getAgentStatus, noteAgentActivity, pendingRequestRef, refreshTimeline, setActiveTurn, setAgentDraft, setAgentPlan, setAgentStatus, setAgentThought, setPendingRequest, thoughtBufferRef, viewStateRef, wasAgentActiveRef]);
 
@@ -227,6 +255,7 @@ export function useAgentStatusLifecycle(options: UseAgentStatusLifecycleOptions)
 
   const handleConnectionStatusChange = useCallback((status: string) => {
     handleConnectionStatusChangeEvent({
+      currentChatJid,
       status,
       setConnectionStatus,
       setAgentStatus,
@@ -243,7 +272,7 @@ export function useAgentStatusLifecycle(options: UseAgentStatusLifecycleOptions)
       refreshQueueState,
       refreshContextUsage,
     });
-  }, [clearAgentRunState, hasConnectedOnceRef, pendingRequestRef, refreshAgentStatus, refreshContextUsage, refreshQueueState, refreshTimeline, setAgentDraft, setAgentPlan, setAgentStatus, setAgentThought, setConnectionStatus, setPendingRequestForConnection, viewStateRef]);
+  }, [clearAgentRunState, currentChatJid, hasConnectedOnceRef, pendingRequestRef, refreshAgentStatus, refreshContextUsage, refreshQueueState, refreshTimeline, setAgentDraft, setAgentPlan, setAgentStatus, setAgentThought, setConnectionStatus, setPendingRequestForConnection, viewStateRef]);
 
   return {
     refreshQueueState,

--- a/runtime/web/src/ui/app-auth-bootstrap.ts
+++ b/runtime/web/src/ui/app-auth-bootstrap.ts
@@ -130,7 +130,7 @@ export interface RefreshModelStateOptions {
   applyModelState: (payload: Record<string, unknown> | null | undefined) => void;
 }
 
-export function refreshModelState(options: RefreshModelStateOptions): void {
+export async function refreshModelState(options: RefreshModelStateOptions): Promise<void> {
   const {
     currentChatJid,
     getAgentModels,
@@ -139,15 +139,14 @@ export function refreshModelState(options: RefreshModelStateOptions): void {
   } = options;
 
   const targetChatJid = currentChatJid;
-  getAgentModels(targetChatJid)
-    .then((payload) => {
-      if (activeChatJidRef.current && activeChatJidRef.current !== targetChatJid) return;
-      if (payload) applyModelState(payload);
-    })
-    .catch(() => {
-      if (activeChatJidRef.current && activeChatJidRef.current !== targetChatJid) return;
-      applyModelState(null);
-    });
+  try {
+    const payload = await getAgentModels(targetChatJid);
+    if (activeChatJidRef.current && activeChatJidRef.current !== targetChatJid) return;
+    if (payload) applyModelState(payload);
+  } catch {
+    if (activeChatJidRef.current && activeChatJidRef.current !== targetChatJid) return;
+    applyModelState(null);
+  }
 }
 
 export interface RefreshActiveChatAgentsOptions {
@@ -158,7 +157,7 @@ export interface RefreshActiveChatAgentsOptions {
   setActiveChatAgents: StateSetter<any[]>;
 }
 
-export function refreshActiveChatAgents(options: RefreshActiveChatAgentsOptions): void {
+export async function refreshActiveChatAgents(options: RefreshActiveChatAgentsOptions): Promise<any[]> {
   const {
     currentChatJid,
     getActiveChatAgents,
@@ -169,21 +168,24 @@ export function refreshActiveChatAgents(options: RefreshActiveChatAgentsOptions)
 
   const targetChatJid = currentChatJid;
 
-  Promise.all([
-    getActiveChatAgents().catch(() => ({ chats: [] /* expected: active-agent refresh is best-effort. */ })),
-    getChatBranches(null, { includeArchived: true }).catch(() => ({ chats: [] /* expected: archived-branch refresh is best-effort. */ })),
-  ])
-    .then(([activePayload, branchPayload]) => {
-      if (activeChatJidRef.current !== targetChatJid) return;
+  try {
+    const [activePayload, branchPayload] = await Promise.all([
+      getActiveChatAgents().catch(() => ({ chats: [] /* expected: active-agent refresh is best-effort. */ })),
+      getChatBranches(null, { includeArchived: true }).catch(() => ({ chats: [] /* expected: archived-branch refresh is best-effort. */ })),
+    ]);
 
-      const activeChats = normalizeActiveChatRows(activePayload?.chats);
-      const branchChats = normalizeActiveChatRows(branchPayload?.chats);
-      setActiveChatAgents(mergeActiveAndBranchChats(activeChats, branchChats, targetChatJid));
-    })
-    .catch(() => {
-      if (activeChatJidRef.current !== targetChatJid) return;
-      setActiveChatAgents([]);
-    });
+    if (activeChatJidRef.current !== targetChatJid) return [];
+
+    const activeChats = normalizeActiveChatRows(activePayload?.chats);
+    const branchChats = normalizeActiveChatRows(branchPayload?.chats);
+    const mergedChats = mergeActiveAndBranchChats(activeChats, branchChats, targetChatJid);
+    setActiveChatAgents(mergedChats);
+    return mergedChats;
+  } catch {
+    if (activeChatJidRef.current !== targetChatJid) return [];
+    setActiveChatAgents([]);
+    return [];
+  }
 }
 
 export interface RefreshCurrentChatBranchesOptions {
@@ -192,20 +194,19 @@ export interface RefreshCurrentChatBranchesOptions {
   setCurrentChatBranches: StateSetter<any[]>;
 }
 
-export function refreshCurrentChatBranches(options: RefreshCurrentChatBranchesOptions): void {
+export async function refreshCurrentChatBranches(options: RefreshCurrentChatBranchesOptions): Promise<void> {
   const {
     currentRootChatJid,
     getChatBranches,
     setCurrentChatBranches,
   } = options;
 
-  getChatBranches(currentRootChatJid)
-    .then((payload) => {
-      setCurrentChatBranches(normalizeCurrentRootBranchRows(payload?.chats));
-    })
-    .catch(() => {
-      setCurrentChatBranches([]);
-    });
+  try {
+    const payload = await getChatBranches(currentRootChatJid);
+    setCurrentChatBranches(normalizeCurrentRootBranchRows(payload?.chats));
+  } catch {
+    setCurrentChatBranches([]);
+  }
 }
 
 export interface HandleMessageResponseOptions {

--- a/runtime/web/src/ui/app-boot-load-orchestration.ts
+++ b/runtime/web/src/ui/app-boot-load-orchestration.ts
@@ -58,6 +58,10 @@ export interface RunTimelineLoadFlowOptions {
   isCancelled: () => boolean;
   scheduleRaf?: RafLike;
   scheduleTimeout?: (callback: () => void, delayMs: number) => void;
+  onTimelineLoadStart?: (detail?: Record<string, unknown>) => void;
+  onTimelineDataReady?: (detail?: Record<string, unknown>) => void;
+  onTimelineFirstPaint?: (detail?: Record<string, unknown>) => void;
+  onTimelineError?: (error: unknown, detail?: Record<string, unknown>) => void;
 }
 
 /**
@@ -77,11 +81,32 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
     setHasMore,
     scrollToBottom,
     isCancelled,
-    scheduleRaf = (callback) => requestAnimationFrame(callback),
+    scheduleRaf = (callback) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(callback);
+        return;
+      }
+      setTimeout(callback, 0);
+    },
     scheduleTimeout = (callback, delayMs) => {
       setTimeout(callback, delayMs);
     },
+    onTimelineLoadStart,
+    onTimelineDataReady,
+    onTimelineFirstPaint,
+    onTimelineError,
   } = options;
+
+  const noteFirstPaint = (detail?: Record<string, unknown>) => {
+    if (isCancelled()) return;
+    scheduleRaf(() => {
+      if (isCancelled()) return;
+      scheduleRaf(() => {
+        if (isCancelled()) return;
+        onTimelineFirstPaint?.(detail);
+      });
+    });
+  };
 
   const safeScrollToBottom = () => {
     if (isCancelled()) return;
@@ -95,18 +120,32 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
   };
 
   if (currentHashtag) {
-    await loadPosts(currentHashtag);
+    onTimelineLoadStart?.({ mode: 'hashtag', hashtag: currentHashtag });
+    try {
+      await loadPosts(currentHashtag);
+      if (isCancelled()) return;
+      onTimelineDataReady?.({ mode: 'hashtag', hashtag: currentHashtag });
+      noteFirstPaint({ mode: 'hashtag' });
+    } catch (error) {
+      if (isCancelled()) return;
+      onTimelineError?.(error, { mode: 'hashtag', hashtag: currentHashtag });
+      throw error;
+    }
     return;
   }
 
   if (searchQuery) {
+    onTimelineLoadStart?.({ mode: 'search', searchQuery, searchScope });
     try {
       const result = await searchPosts(searchQuery, 50, 0, currentChatJid, searchScope, currentRootChatJid);
       if (isCancelled()) return;
       setPosts(Array.isArray(result?.results) ? result.results : []);
       setHasMore(false);
+      onTimelineDataReady?.({ mode: 'search', resultCount: Array.isArray(result?.results) ? result.results.length : 0 });
+      noteFirstPaint({ mode: 'search' });
     } catch (error) {
       if (isCancelled()) return;
+      onTimelineError?.(error, { mode: 'search', searchQuery, searchScope });
       console.error('Failed to search:', error);
       setPosts([]);
       setHasMore(false);
@@ -114,11 +153,16 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
     return;
   }
 
+  onTimelineLoadStart?.({ mode: 'timeline' });
   try {
     await loadPosts();
+    if (isCancelled()) return;
+    onTimelineDataReady?.({ mode: 'timeline' });
+    noteFirstPaint({ mode: 'timeline' });
     safeScrollToBottom();
   } catch (error) {
     if (isCancelled()) return;
+    onTimelineError?.(error, { mode: 'timeline' });
     console.error('Failed to load timeline:', error);
   }
 }

--- a/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
+++ b/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
@@ -11,6 +11,11 @@ import {
 import { refreshModelAndQueueState as refreshModelAndQueueStateBundle } from './app-status-refresh-orchestration.js';
 import { applyStoredSidebarWidth } from './app-boot-load-orchestration.js';
 import {
+  completeAppPerfTraceIfReady,
+  getActiveAppPerfTraceId,
+  markAppPerfTrace,
+} from './app-perf-tracing.js';
+import {
   noteAppChatActivation,
   runCoalescedAppRefresh,
 } from './app-refresh-coordination.js';
@@ -162,21 +167,54 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
     });
   }, [setActiveModel, setActiveModelUsage, setActiveThinkingLevel, setAgentModelsPayload, setHasLoadedAgentModels, setSupportsThinking]);
 
+  const getThreadSwitchTraceId = useCallback(() => getActiveAppPerfTraceId('thread-switch', currentChatJid), [currentChatJid]);
+
   const refreshModelState = useCallback(() => {
     return runCoalescedAppRefresh({
       kind: 'model-state',
       chatJid: currentChatJid,
       run: async () => {
+        const traceId = getThreadSwitchTraceId();
+        if (traceId) {
+          markAppPerfTrace(traceId, 'runtime-hydration-start', {
+            phase: 'model-state',
+          });
+        }
         await refreshModelStateForChat({
           currentChatJid,
-          getAgentModels,
+          getAgentModels: async (chatJid: string) => {
+            const activeTraceId = traceId || getThreadSwitchTraceId();
+            if (activeTraceId) {
+              markAppPerfTrace(activeTraceId, 'model-request-start', {
+                chatJid,
+              });
+            }
+            const payload = await getAgentModels(chatJid);
+            if (activeTraceId) {
+              markAppPerfTrace(activeTraceId, 'model-request-ready', {
+                chatJid,
+                hasCurrent: Boolean(payload?.current),
+                modelCount: Array.isArray(payload?.models) ? payload.models.length : 0,
+              });
+            }
+            return payload;
+          },
           activeChatJidRef,
           applyModelState,
         });
+        const activeTraceId = traceId || getThreadSwitchTraceId();
+        if (activeTraceId) {
+          markAppPerfTrace(activeTraceId, 'runtime-hydration-ready', {
+            chatJid: currentChatJid,
+          });
+          completeAppPerfTraceIfReady(activeTraceId, ['runtime-hydration-ready', 'timeline-first-paint'], 'settled', {
+            chatJid: currentChatJid,
+          });
+        }
         return null;
       },
     });
-  }, [activeChatJidRef, applyModelState, currentChatJid, getAgentModels]);
+  }, [activeChatJidRef, applyModelState, currentChatJid, getAgentModels, getThreadSwitchTraceId]);
 
   const refreshActiveChatAgents = useCallback(() => {
     return runCoalescedAppRefresh({

--- a/runtime/web/src/ui/app-connection-lifecycle.ts
+++ b/runtime/web/src/ui/app-connection-lifecycle.ts
@@ -1,3 +1,5 @@
+import { isAppChatActivationRecent } from './app-refresh-coordination.js';
+
 type ViewStateLike = {
   currentHashtag?: unknown;
   searchQuery?: unknown;
@@ -64,6 +66,7 @@ export function handleUiVersionDriftEvent(options: HandleUiVersionDriftOptions):
 }
 
 export interface HandleConnectionStatusChangeOptions {
+  currentChatJid: string;
   status: string;
   setConnectionStatus: (status: string) => void;
   setAgentStatus: (status: Record<string, unknown> | null) => void;
@@ -92,6 +95,7 @@ function shouldRefreshMainTimeline(viewState: ViewStateLike | null | undefined):
 
 export function handleConnectionStatusChangeEvent(options: HandleConnectionStatusChangeOptions): void {
   const {
+    currentChatJid,
     status,
     setConnectionStatus,
     setAgentStatus,
@@ -123,6 +127,9 @@ export function handleConnectionStatusChangeEvent(options: HandleConnectionStatu
 
   if (!hasConnectedOnceRef.current) {
     hasConnectedOnceRef.current = true;
+    if (isAppChatActivationRecent(currentChatJid)) {
+      return;
+    }
     if (shouldRefreshMainTimeline(viewStateRef.current)) {
       refreshTimeline();
     }

--- a/runtime/web/src/ui/app-connection-lifecycle.ts
+++ b/runtime/web/src/ui/app-connection-lifecycle.ts
@@ -127,9 +127,14 @@ export function handleConnectionStatusChangeEvent(options: HandleConnectionStatu
 
   if (!hasConnectedOnceRef.current) {
     hasConnectedOnceRef.current = true;
-    if (isAppChatActivationRecent(currentChatJid)) {
-      return;
-    }
+    setAgentStatus(null);
+    setAgentDraft({ text: '', totalLines: 0 });
+    setAgentPlan('');
+    setAgentThought({ text: '', totalLines: 0 });
+    setPendingRequest(null);
+    pendingRequestRef.current = null;
+    clearAgentRunState();
+    if (isAppChatActivationRecent(currentChatJid)) return;
     if (shouldRefreshMainTimeline(viewStateRef.current)) {
       refreshTimeline();
     }

--- a/runtime/web/src/ui/app-perf-tracing.ts
+++ b/runtime/web/src/ui/app-perf-tracing.ts
@@ -100,7 +100,29 @@ function markPerformance(traceId: string, phase: string): void {
   }
 }
 
+function clearPerformanceMarks(traceId: string): void {
+  if (typeof performance === 'undefined' || typeof performance.clearMarks !== 'function') return;
+  try {
+    performance.clearMarks(`piclaw:${traceId}:start`);
+    const trace = findTrace(traceId);
+    if (!trace) return;
+    for (const phase of trace.phases) {
+      performance.clearMarks(`piclaw:${traceId}:${phase.phase}`);
+    }
+  } catch (error) {
+    debugSuppressedError(log, 'Ignoring performance.clearMarks failure.', error, { traceId });
+  }
+}
+
 function createTrace(type: string, chatJid: string, detail?: Record<string, unknown> | null): string {
+  const existingTraceId = activeTraceIds.get(buildTraceKey(type, chatJid));
+  if (existingTraceId && findTrace(existingTraceId)?.status === 'active') {
+    endTrace(existingTraceId, 'cancelled', 'superseded', {
+      replacementType: type,
+      replacementChatJid: chatJid,
+    });
+  }
+
   const traceId = nextId(type);
   const entry: TraceEntry = {
     id: traceId,
@@ -135,6 +157,7 @@ function endTrace(traceId: string | null | undefined, status: TraceStatus, phase
   if (activeTraceIds.get(key) === trace.id) {
     activeTraceIds.delete(key);
   }
+  clearPerformanceMarks(trace.id);
 }
 
 const perfApi: PerfApi = {
@@ -184,6 +207,7 @@ const perfApi: PerfApi = {
     return requests.map((entry) => ({ ...entry, detail: cloneDetail(entry.detail) }));
   },
   'clear'() {
+    traces.forEach((entry) => clearPerformanceMarks(entry.id));
     traces.splice(0, traces.length);
     requests.splice(0, requests.length);
     activeTraceIds.clear();

--- a/runtime/web/src/ui/app-sse-events.ts
+++ b/runtime/web/src/ui/app-sse-events.ts
@@ -39,6 +39,7 @@ import {
   isNoisyAgentSseEvent,
   resolveSseEventRoutingContext,
 } from './app-sse-event-routing.js';
+import { isAppChatActivationRecent } from './app-refresh-coordination.js';
 
 type StateSetter<T> = (next: T | ((prev: T) => T)) => void;
 
@@ -213,6 +214,9 @@ export function handleAppSseEvent(
 
   if (eventType === 'connected') {
     if (handleUiVersionDrift(data?.app_asset_version)) {
+      return;
+    }
+    if (isAppChatActivationRecent(currentChatJid)) {
       return;
     }
     setAgentStatus(null);

--- a/runtime/web/src/ui/app-sse-events.ts
+++ b/runtime/web/src/ui/app-sse-events.ts
@@ -216,9 +216,6 @@ export function handleAppSseEvent(
     if (handleUiVersionDrift(data?.app_asset_version)) {
       return;
     }
-    if (isAppChatActivationRecent(currentChatJid)) {
-      return;
-    }
     setAgentStatus(null);
     setAgentDraft({ text: '', totalLines: 0 });
     setAgentPlan('');
@@ -226,6 +223,9 @@ export function handleAppSseEvent(
     setPendingRequest(null);
     pendingRequestRef.current = null;
     clearAgentRunState();
+    if (isAppChatActivationRecent(currentChatJid)) {
+      return;
+    }
 
     const targetChatJid = currentChatJid;
     getAgentStatus(targetChatJid)

--- a/runtime/web/src/ui/app-status-refresh-orchestration.ts
+++ b/runtime/web/src/ui/app-status-refresh-orchestration.ts
@@ -28,9 +28,9 @@ export interface RefreshQueueStateForChatOptions<TItem extends FollowupQueueItem
 /**
  * Refresh follow-up queue state for the active chat, dropping stale responses.
  */
-export function refreshQueueStateForChat<TItem extends FollowupQueueItemLike = FollowupQueueItemLike>(
+export async function refreshQueueStateForChat<TItem extends FollowupQueueItemLike = FollowupQueueItemLike>(
   options: RefreshQueueStateForChatOptions<TItem>,
-): void {
+): Promise<void> {
   const {
     currentChatJid,
     queueRefreshGenRef,
@@ -44,32 +44,31 @@ export function refreshQueueStateForChat<TItem extends FollowupQueueItemLike = F
   const gen = ++queueRefreshGenRef.current;
   const targetChatJid = currentChatJid;
 
-  getAgentQueueState(targetChatJid)
-    .then((payload) => {
-      if (gen !== queueRefreshGenRef.current) return;
-      if (activeChatJidRef.current !== targetChatJid) return;
+  try {
+    const payload = await getAgentQueueState(targetChatJid);
+    if (gen !== queueRefreshGenRef.current) return;
+    if (activeChatJidRef.current !== targetChatJid) return;
 
-      const dismissed = dismissedQueueRowIdsRef.current;
-      const rawItems = Array.isArray(payload?.items) ? payload.items : [];
-      const items = normalizeFollowupQueueItems(rawItems, dismissed);
-      if (items.length) {
-        setFollowupQueueItems((prev) => (haveSameFollowupQueueRows(prev, items) ? prev : items));
-        return;
-      }
+    const dismissed = dismissedQueueRowIdsRef.current;
+    const rawItems = Array.isArray(payload?.items) ? payload.items : [];
+    const items = normalizeFollowupQueueItems(rawItems, dismissed);
+    if (items.length) {
+      setFollowupQueueItems((prev) => (haveSameFollowupQueueRows(prev, items) ? prev : items));
+      return;
+    }
 
-      if (rawItems.length > 0) {
-        return;
-      }
+    if (rawItems.length > 0) {
+      return;
+    }
 
-      dismissed.clear();
-      clearQueuedSteerStateIfStale(0);
-      setFollowupQueueItems((prev) => (prev.length === 0 ? prev : []));
-    })
-    .catch(() => {
-      if (gen !== queueRefreshGenRef.current) return;
-      if (activeChatJidRef.current !== targetChatJid) return;
-      setFollowupQueueItems((prev) => (prev.length === 0 ? prev : []));
-    });
+    dismissed.clear();
+    clearQueuedSteerStateIfStale(0);
+    setFollowupQueueItems((prev) => (prev.length === 0 ? prev : []));
+  } catch {
+    if (gen !== queueRefreshGenRef.current) return;
+    if (activeChatJidRef.current !== targetChatJid) return;
+    setFollowupQueueItems((prev) => (prev.length === 0 ? prev : []));
+  }
 }
 
 export interface RefreshContextUsageForChatOptions {

--- a/runtime/web/src/ui/use-timeline.ts
+++ b/runtime/web/src/ui/use-timeline.ts
@@ -49,6 +49,7 @@ export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop,
     } catch (error) {
       if (token !== chatTokenRef.current) return;
       console.error('Failed to load posts:', error);
+      throw error;
     }
   }, [chatJid]);
 


### PR DESCRIPTION
## Why
On cold opens, the initial foreground hydration path and reconnect/SSE recovery could both try to refresh the same thread state at nearly the same time.

That produced duplicate work right at connection time.

## What this changes
- coalesces cold-open reconnect recovery with the existing refresh coordination lane
- skips the duplicate reconnect bundle during a fresh activation window
- routes queue/context/autoresearch refreshes through the shared coalescing path

## Scope
This is a narrow refresh-coordination fix for cold-open and reconnect behavior.

It does not change:
- model/provider selection behavior
- timeline cache behavior
- backend warmup behavior

## Validation
- `bun test runtime/test/web/app-connection-lifecycle.test.ts runtime/test/web/app-sse-events.test.ts`

Signed-off-by: Pix (PiClaw, openai-codex/gpt-5.4)
