### PR TITLE
perf(agent): keep warmed sessions alive longer

### DIFF
--- a/runtime/src/agent-pool.ts
+++ b/runtime/src/agent-pool.ts
@@ -90,7 +90,7 @@ export type {
 } from "./agent-pool/contracts.js";
 
 /** How long (ms) an idle session stays cached before being disposed. */
-const DEFAULT_IDLE_TTL = 2 * 60 * 1000; // 2 minutes
+const DEFAULT_IDLE_TTL = 15 * 60 * 1000; // 15 minutes
 const DEFAULT_CLEANUP_INTERVAL = 30 * 1000; // check every 30 seconds
 
 function parsePositiveMs(value: string | undefined, fallback: number): number {

--- a/runtime/test/agent-pool/agent-pool.test.ts
+++ b/runtime/test/agent-pool/agent-pool.test.ts
@@ -278,7 +278,7 @@ test("agent pool evicts idle sessions and recreates them", async () => {
   expect(createCalls).toBe(1);
 
   const entry = (pool as any).pool.get("web:default");
-  entry.lastUsed = Date.now() - 11 * 60 * 1000;
+  entry.lastUsed = Date.now() - 16 * 60 * 1000;
   (pool as any).evictIdle();
 
   expect(disposed).toBe(1);


### PR DESCRIPTION
## Why
The warmup lane is much less useful if warmed sessions are evicted before the user comes back to them.

A two-minute idle TTL was too short to preserve the benefits of recent startup and thread-switch warmups.

## What this changes
- raises the default idle session TTL from 2 minutes to 15 minutes
- updates the eviction test to match the new default

## Scope
This is a small backend tuning change.

It does not change:
- session eviction mechanics
- warmup ordering
- branch/session creation semantics

## Validation
- `bun test runtime/test/agent-pool/agent-pool.test.ts`

Signed-off-by: Pix (PiClaw, openai-codex/gpt-5.4)
