### PR TITLE
perf(web): add web ui tracing hooks

### DIFF
--- a/runtime/test/web/app-boot-load-orchestration.test.ts
+++ b/runtime/test/web/app-boot-load-orchestration.test.ts
@@ -95,7 +95,10 @@ test('runTimelineLoadFlow loads main timeline and triggers deferred scroll', asy
     isCancelled: () => false,
     scheduleRaf: (callback) => callback(),
     scheduleTimeout: (callback) => callback(),
+    onTimelineLoadStart: () => calls.push('load-start'),
+    onTimelineDataReady: () => calls.push('data-ready'),
+    onTimelineFirstPaint: () => calls.push('first-paint'),
   });
 
-  expect(calls).toEqual(['load', 'scroll']);
+  expect(calls).toEqual(['load-start', 'load', 'data-ready', 'first-paint', 'scroll']);
 });

--- a/runtime/test/web/app-branch-pane-orchestration.test.ts
+++ b/runtime/test/web/app-branch-pane-orchestration.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test';
+import { afterEach, expect, test } from 'bun:test';
 
 import {
   applyStoredPaneLayout,
@@ -7,6 +7,11 @@ import {
   navigateToSelectedBranch,
   resolvePanePopoutTransfer,
 } from '../../web/src/ui/app-branch-pane-orchestration.js';
+import { getAppPerfTracing } from '../../web/src/ui/app-perf-tracing.js';
+
+afterEach(() => {
+  getAppPerfTracing().clear();
+});
 
 test('navigateToSelectedBranch ignores same/blank chats and navigates when selection changes', () => {
   const calls: string[] = [];
@@ -31,6 +36,12 @@ test('navigateToSelectedBranch ignores same/blank chats and navigates when selec
 
   expect(calls).toHaveLength(1);
   expect(calls[0]).toContain('chat_jid=web%3Abranch');
+
+  const traces = getAppPerfTracing().getTraces();
+  expect(traces).toHaveLength(1);
+  expect(traces[0]?.type).toBe('thread-switch');
+  expect(traces[0]?.chatJid).toBe('web:branch');
+  expect(traces[0]?.phases.map((phase) => phase.phase)).toEqual(['intent', 'navigation-dispatched']);
 });
 
 test('invokePaneBeforeDetachFromHost calls the pane detach lifecycle hook when present', async () => {

--- a/runtime/test/web/app-perf-tracing.test.ts
+++ b/runtime/test/web/app-perf-tracing.test.ts
@@ -61,6 +61,22 @@ test('app perf tracing only auto-completes once required phases are present', ()
   ]);
 });
 
+test('app perf tracing cancels the previous active trace when a new trace starts for the same type/chat', () => {
+  const firstTraceId = startAppPerfTrace('thread-switch', 'web:branch');
+  markAppPerfTrace(firstTraceId, 'intent');
+
+  const secondTraceId = startAppPerfTrace('thread-switch', 'web:branch');
+
+  const traces = getAppPerfTracing().getTraces();
+  expect(traces).toHaveLength(2);
+  expect(traces[0]?.id).toBe(firstTraceId);
+  expect(traces[0]?.status).toBe('cancelled');
+  expect(traces[0]?.phases.map((phase) => phase.phase)).toEqual(['intent', 'superseded']);
+  expect(traces[1]?.id).toBe(secondTraceId);
+  expect(traces[1]?.status).toBe('active');
+  expect(getActiveAppPerfTraceId('thread-switch', 'web:branch')).toBe(secondTraceId);
+});
+
 test('app perf tracing stores bounded request samples', () => {
   const requestId = recordAppPerfRequest({
     method: 'GET',

--- a/runtime/test/web/app-window-actions.test.ts
+++ b/runtime/test/web/app-window-actions.test.ts
@@ -5,10 +5,12 @@ import {
   popOutChat,
   popOutPane,
 } from '../../web/src/ui/app-window-actions.js';
+import { getAppPerfTracing } from '../../web/src/ui/app-perf-tracing.js';
 
 const originalWindow = globalThis.window;
 
 afterEach(() => {
+  getAppPerfTracing().clear();
   if (originalWindow === undefined) {
     delete globalThis.window;
   } else {
@@ -38,6 +40,17 @@ test('createSessionFromCompose refreshes branch state and navigates to the new c
   expect(refreshes.sort()).toEqual(['active', 'branches']);
   expect(toasts).toContainEqual(['New branch created', 'Switched to @feature.', 'info', 2500]);
   expect(navigateCalls[0]).toContain('chat_jid=web%3Anew');
+
+  const traces = getAppPerfTracing().getTraces();
+  expect(traces).toHaveLength(1);
+  expect(traces[0]?.type).toBe('branch-create');
+  expect(traces[0]?.chatJid).toBe('web:root');
+  expect(traces[0]?.phases.map((phase) => phase.phase)).toEqual([
+    'intent',
+    'fork-request-start',
+    'fork-request-ready',
+    'navigation-dispatched',
+  ]);
 });
 
 test('popOutPane transfers pane state and closes the source tab after navigation', async () => {

--- a/runtime/web/src/ui/app-boot-load-orchestration.ts
+++ b/runtime/web/src/ui/app-boot-load-orchestration.ts
@@ -58,6 +58,10 @@ export interface RunTimelineLoadFlowOptions {
   isCancelled: () => boolean;
   scheduleRaf?: RafLike;
   scheduleTimeout?: (callback: () => void, delayMs: number) => void;
+  onTimelineLoadStart?: (detail?: Record<string, unknown>) => void;
+  onTimelineDataReady?: (detail?: Record<string, unknown>) => void;
+  onTimelineFirstPaint?: (detail?: Record<string, unknown>) => void;
+  onTimelineError?: (error: unknown, detail?: Record<string, unknown>) => void;
 }
 
 /**
@@ -77,11 +81,32 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
     setHasMore,
     scrollToBottom,
     isCancelled,
-    scheduleRaf = (callback) => requestAnimationFrame(callback),
+    scheduleRaf = (callback) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(callback);
+        return;
+      }
+      setTimeout(callback, 0);
+    },
     scheduleTimeout = (callback, delayMs) => {
       setTimeout(callback, delayMs);
     },
+    onTimelineLoadStart,
+    onTimelineDataReady,
+    onTimelineFirstPaint,
+    onTimelineError,
   } = options;
+
+  const noteFirstPaint = (detail?: Record<string, unknown>) => {
+    if (isCancelled()) return;
+    scheduleRaf(() => {
+      if (isCancelled()) return;
+      scheduleRaf(() => {
+        if (isCancelled()) return;
+        onTimelineFirstPaint?.(detail);
+      });
+    });
+  };
 
   const safeScrollToBottom = () => {
     if (isCancelled()) return;
@@ -95,18 +120,32 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
   };
 
   if (currentHashtag) {
-    await loadPosts(currentHashtag);
+    onTimelineLoadStart?.({ mode: 'hashtag', hashtag: currentHashtag });
+    try {
+      await loadPosts(currentHashtag);
+      if (isCancelled()) return;
+      onTimelineDataReady?.({ mode: 'hashtag', hashtag: currentHashtag });
+      noteFirstPaint({ mode: 'hashtag' });
+    } catch (error) {
+      if (isCancelled()) return;
+      onTimelineError?.(error, { mode: 'hashtag', hashtag: currentHashtag });
+      throw error;
+    }
     return;
   }
 
   if (searchQuery) {
+    onTimelineLoadStart?.({ mode: 'search', searchQuery, searchScope });
     try {
       const result = await searchPosts(searchQuery, 50, 0, currentChatJid, searchScope, currentRootChatJid);
       if (isCancelled()) return;
       setPosts(Array.isArray(result?.results) ? result.results : []);
       setHasMore(false);
+      onTimelineDataReady?.({ mode: 'search', resultCount: Array.isArray(result?.results) ? result.results.length : 0 });
+      noteFirstPaint({ mode: 'search' });
     } catch (error) {
       if (isCancelled()) return;
+      onTimelineError?.(error, { mode: 'search', searchQuery, searchScope });
       console.error('Failed to search:', error);
       setPosts([]);
       setHasMore(false);
@@ -114,11 +153,16 @@ export async function runTimelineLoadFlow(options: RunTimelineLoadFlowOptions): 
     return;
   }
 
+  onTimelineLoadStart?.({ mode: 'timeline' });
   try {
     await loadPosts();
+    if (isCancelled()) return;
+    onTimelineDataReady?.({ mode: 'timeline' });
+    noteFirstPaint({ mode: 'timeline' });
     safeScrollToBottom();
   } catch (error) {
     if (isCancelled()) return;
+    onTimelineError?.(error, { mode: 'timeline' });
     console.error('Failed to load timeline:', error);
   }
 }

--- a/runtime/web/src/ui/app-branch-pane-orchestration.ts
+++ b/runtime/web/src/ui/app-branch-pane-orchestration.ts
@@ -1,4 +1,5 @@
 import { buildChatWindowUrl } from './chat-window.js';
+import { markAppPerfTrace, startAppPerfTrace } from './app-perf-tracing.js';
 
 interface RefBox<T> {
   current: T;
@@ -36,8 +37,18 @@ export function navigateToSelectedBranch(options: NavigateToSelectedBranchOption
   if (!hasWindow) return false;
   const normalized = typeof nextChatJid === 'string' ? nextChatJid.trim() : '';
   if (!normalized || normalized === currentChatJid) return false;
+  const traceId = startAppPerfTrace('thread-switch', normalized, {
+    sourceChatJid: currentChatJid,
+    trigger: 'branch-picker',
+  });
+  markAppPerfTrace(traceId, 'intent', {
+    sourceChatJid: currentChatJid,
+  });
   const url = buildChatWindowUrl(currentHref, normalized, { chatOnly: chatOnlyMode });
   navigate?.(url);
+  markAppPerfTrace(traceId, 'navigation-dispatched', {
+    url,
+  });
   return true;
 }
 

--- a/runtime/web/src/ui/app-perf-tracing.ts
+++ b/runtime/web/src/ui/app-perf-tracing.ts
@@ -103,7 +103,29 @@ function markPerformance(traceId: string, phase: string): void {
   }
 }
 
+function clearPerformanceMarks(traceId: string): void {
+  if (typeof performance === 'undefined' || typeof performance.clearMarks !== 'function') return;
+  try {
+    performance.clearMarks(`piclaw:${traceId}:start`);
+    const trace = findTrace(traceId);
+    if (!trace) return;
+    for (const phase of trace.phases) {
+      performance.clearMarks(`piclaw:${traceId}:${phase.phase}`);
+    }
+  } catch (error) {
+    debugSuppressedError(log, 'Ignoring performance.clearMarks failure.', error, { traceId });
+  }
+}
+
 function createTrace(type: string, chatJid: string, detail?: Record<string, unknown> | null): string {
+  const existingTraceId = activeTraceIds.get(buildTraceKey(type, chatJid));
+  if (existingTraceId && findTrace(existingTraceId)?.status === 'active') {
+    endTrace(existingTraceId, 'cancelled', 'superseded', {
+      replacementType: type,
+      replacementChatJid: chatJid,
+    });
+  }
+
   const traceId = nextId(type);
   const entry: TraceEntry = {
     id: traceId,
@@ -138,6 +160,7 @@ function endTrace(traceId: string | null | undefined, status: TraceStatus, phase
   if (activeTraceIds.get(key) === trace.id) {
     activeTraceIds.delete(key);
   }
+  clearPerformanceMarks(trace.id);
 }
 
 const perfApi: PerfApi = {
@@ -187,6 +210,7 @@ const perfApi: PerfApi = {
     return requests.map((entry) => ({ ...entry, detail: cloneDetail(entry.detail) }));
   },
   'clear'() {
+    traces.forEach((entry) => clearPerformanceMarks(entry.id));
     traces.splice(0, traces.length);
     requests.splice(0, requests.length);
     activeTraceIds.clear();

--- a/runtime/web/src/ui/app-perf-tracing.ts
+++ b/runtime/web/src/ui/app-perf-tracing.ts
@@ -1,3 +1,5 @@
+import { createLogger, debugSuppressedError } from '../../../src/utils/logger.js';
+
 type TraceStatus = 'active' | 'completed' | 'cancelled' | 'failed';
 
 type TracePhase = {
@@ -52,6 +54,7 @@ type PerfWindow = Window & typeof globalThis & Record<string, unknown>;
 const PERF_GLOBAL_KEY = '__PICLAW_PERF__';
 const TRACE_LIMIT = 100;
 const REQUEST_LIMIT = 300;
+const log = createLogger('web.app-perf-tracing');
 
 const traces: TraceEntry[] = [];
 const requests: RequestEntry[] = [];
@@ -96,7 +99,7 @@ function markPerformance(traceId: string, phase: string): void {
   try {
     performance.mark(`piclaw:${traceId}:${phase}`);
   } catch (error) {
-    console.debug('[app-perf] Ignoring performance.mark failure.', error, { traceId, phase });
+    debugSuppressedError(log, 'Ignoring performance.mark failure.', error, { traceId, phase });
   }
 }
 

--- a/runtime/web/src/ui/app-shell-bootstrap.ts
+++ b/runtime/web/src/ui/app-shell-bootstrap.ts
@@ -18,6 +18,7 @@ import {
   mindmapPaneExtension,
   kanbanPaneExtension,
 } from '../panes/index.js';
+import { installAppPerfTracing } from './app-perf-tracing.js';
 import { resolveOptionalApi } from './optional-api.js';
 
 interface AppApiSurface {
@@ -80,6 +81,7 @@ export function initializeAppShellRuntime(): void {
   configureMarked(markedInstance);
   installBrowserNoiseFilters(typeof window !== 'undefined' ? window : null);
   registerAppPaneExtensions();
+  installAppPerfTracing(typeof window !== 'undefined' ? window as any : null);
   initialized = true;
 }
 

--- a/runtime/web/src/ui/app-window-actions.ts
+++ b/runtime/web/src/ui/app-window-actions.ts
@@ -10,6 +10,7 @@ import {
   openProvisionalChatWindow,
   primeProvisionalChatWindow,
 } from './chat-window.js';
+import { failAppPerfTrace, markAppPerfTrace, startAppPerfTrace } from './app-perf-tracing.js';
 
 type ToastKind = 'info' | 'warning' | 'error' | 'success';
 type ToastFn = (title: string, message: string, kind: ToastKind, timeout: number) => void;
@@ -53,13 +54,26 @@ export async function createSessionFromCompose(options: CreateSessionFromCompose
     baseHref,
   } = options;
 
+  const traceId = startAppPerfTrace('branch-create', currentChatJid, {
+    trigger: 'compose',
+    chatOnlyMode: Boolean(chatOnlyMode),
+  });
+  markAppPerfTrace(traceId, 'intent', {
+    currentChatJid,
+  });
+
   try {
+    markAppPerfTrace(traceId, 'fork-request-start');
     const response = await forkChatBranch(currentChatJid);
     const branch = response?.branch;
     const nextChatJid = typeof branch?.chat_jid === 'string' && branch.chat_jid.trim() ? branch.chat_jid.trim() : null;
     if (!nextChatJid) {
       throw new Error('Branch fork did not return a chat id.');
     }
+
+    markAppPerfTrace(traceId, 'fork-request-ready', {
+      nextChatJid,
+    });
 
     await Promise.allSettled([
       refreshActiveChatAgents?.(),
@@ -70,8 +84,14 @@ export async function createSessionFromCompose(options: CreateSessionFromCompose
     showIntentToast?.('New branch created', `Switched to ${label}.`, 'info', 2500);
     const url = buildChatWindowUrl(baseHref, nextChatJid, { chatOnly: chatOnlyMode });
     navigate?.(url);
+    markAppPerfTrace(traceId, 'navigation-dispatched', {
+      mode: 'direct',
+      nextChatJid,
+      url,
+    });
     return true;
   } catch (error) {
+    failAppPerfTrace(traceId, error, 'fork-failed');
     showIntentToast?.('Could not create branch', describeBranchOpenError(error), 'warning', 5000);
     return false;
   }


### PR DESCRIPTION
## Why
The web refresh and branch-open perf work is hard to reason about without lightweight client-side phase markers.

We already have the core tracing store, but the relevant UI flows were not yet emitting the timeline and branch-navigation phases needed to correlate user-visible latency.

## What this changes
- adds timeline load start/data-ready/first-paint hooks to the boot load flow
- traces branch-picker thread switches
- traces compose-driven branch creation
- installs perf tracing during shell bootstrap
- makes browser `performance.mark` failures non-fatal in older browsers

## Scope
This is instrumentation only for the web UI perf lane.

It does not change:
- backend session behavior
- refresh coordination semantics
- branch creation semantics

## Validation
- `bun test runtime/test/web/app-boot-load-orchestration.test.ts runtime/test/web/app-branch-pane-orchestration.test.ts runtime/test/web/app-window-actions.test.ts runtime/test/web/app-perf-tracing.test.ts runtime/test/web/app-refresh-coordination.test.ts`

Signed-off-by: Pix (PiClaw, openai-codex/gpt-5.4)
