### PR TITLE
perf(web): route compose branch creation through branch loader

### DIFF
--- a/runtime/test/web/app-window-actions.test.ts
+++ b/runtime/test/web/app-window-actions.test.ts
@@ -16,15 +16,19 @@ afterEach(() => {
   }
 });
 
-test('createSessionFromCompose refreshes branch state and navigates to the new chat', async () => {
+test('createSessionFromCompose navigates immediately to the branch-loader route', async () => {
   const toasts: Array<[string, string, string, number]> = [];
   const navigateCalls: string[] = [];
   const refreshes: string[] = [];
+  let forkCalls = 0;
 
   const created = await createSessionFromCompose({
     currentChatJid: 'web:root',
     chatOnlyMode: true,
-    forkChatBranch: async () => ({ branch: { chat_jid: 'web:new', agent_name: 'feature' } }),
+    forkChatBranch: async () => {
+      forkCalls += 1;
+      return { branch: { chat_jid: 'web:new', agent_name: 'feature' } };
+    },
     refreshActiveChatAgents: async () => { refreshes.push('active'); },
     refreshCurrentChatBranches: async () => { refreshes.push('branches'); },
     showIntentToast: (title: string, message: string, kind: string, timeout: number) => {
@@ -35,9 +39,11 @@ test('createSessionFromCompose refreshes branch state and navigates to the new c
   });
 
   expect(created).toBe(true);
-  expect(refreshes.sort()).toEqual(['active', 'branches']);
-  expect(toasts).toContainEqual(['New branch created', 'Switched to @feature.', 'info', 2500]);
-  expect(navigateCalls[0]).toContain('chat_jid=web%3Anew');
+  expect(forkCalls).toBe(0);
+  expect(refreshes).toEqual([]);
+  expect(toasts).toEqual([]);
+  expect(navigateCalls[0]).toContain('branch_loader=1');
+  expect(navigateCalls[0]).toContain('branch_source_chat_jid=web%3Aroot');
 });
 
 test('popOutPane transfers pane state and closes the source tab after navigation', async () => {

--- a/runtime/web/src/ui/app-window-actions.ts
+++ b/runtime/web/src/ui/app-window-actions.ts
@@ -53,6 +53,17 @@ export async function createSessionFromCompose(options: CreateSessionFromCompose
     baseHref,
   } = options;
 
+  if (typeof navigate === 'function') {
+    try {
+      const loaderUrl = buildBranchLoaderUrl(baseHref, currentChatJid, { chatOnly: chatOnlyMode });
+      navigate(loaderUrl);
+      return true;
+    } catch (error) {
+      showIntentToast?.('Could not create branch', describeBranchOpenError(error), 'warning', 5000);
+      return false;
+    }
+  }
+
   try {
     const response = await forkChatBranch(currentChatJid);
     const branch = response?.branch;


### PR DESCRIPTION
## Why
Compose-triggered branch creation was waiting on fork hydration before navigation, which made the branch-open path feel slower than necessary.

## What this changes
- routes compose-triggered branch creation through the existing branch-loader route
- navigates immediately when a web navigation handler is available
- preserves the existing direct fork fallback when no navigation handler exists

## Scope
This is a narrow web navigation-path optimization.

It does not change:
- branch fork semantics
- backend warmup behavior
- model/provider behavior

## Validation
- `bun test runtime/test/web/app-window-actions.test.ts`

Signed-off-by: Pix (PiClaw, openai-codex/gpt-5.4)
