### PR TITLE
perf(agent): prioritize startup session warmup

### DIFF
--- a/runtime/src/agent-pool.ts
+++ b/runtime/src/agent-pool.ts
@@ -258,6 +258,10 @@ export class AgentPool {
     return this.runtimeFacade.getContextUsageForChat(chatJid);
   }
 
+  scheduleChatWarmup(chatJid: string, options: { priority?: boolean } = {}): boolean {
+    return this.sessionManager.prewarm(chatJid, options);
+  }
+
   getSessionTreeForChat(chatJid: string): { leafId: string | null; nodes: unknown[]; flat?: boolean; total?: number; capped?: boolean } | null {
     return this.runtimeFacade.getSessionTreeForChat(chatJid);
   }

--- a/runtime/src/agent-pool/session-manager.ts
+++ b/runtime/src/agent-pool/session-manager.ts
@@ -39,6 +39,11 @@ export interface AgentSessionManagerOptions {
  * Handles lifecycle operations for main and auxiliary AgentSession instances.
  */
 export class AgentSessionManager {
+  private readonly prewarmInFlight = new Set<string>();
+  private readonly queuedPrewarms = new Set<string>();
+  private readonly prewarmQueue: string[] = [];
+  private prewarmLoopActive = false;
+
   constructor(private readonly options: AgentSessionManagerOptions) {}
 
   async refreshRuntime(chatJid: string, runtime: AgentSessionRuntime): Promise<void> {
@@ -171,6 +176,22 @@ export class AgentSessionManager {
     await this.disposeEntry(this.options.sidePool, chatJid, "recreate.dispose_side_session", true);
   }
 
+  prewarm(chatJid: string, options: { priority?: boolean } = {}): boolean {
+    const normalizedChatJid = String(chatJid || "").trim();
+    if (!normalizedChatJid) return false;
+    if (this.options.pool.has(normalizedChatJid)) return false;
+    if (this.prewarmInFlight.has(normalizedChatJid) || this.queuedPrewarms.has(normalizedChatJid)) return false;
+
+    this.queuedPrewarms.add(normalizedChatJid);
+    if (options.priority) {
+      this.prewarmQueue.unshift(normalizedChatJid);
+    } else {
+      this.prewarmQueue.push(normalizedChatJid);
+    }
+    this.drainPrewarmQueue();
+    return true;
+  }
+
   async shutdown(): Promise<void> {
     for (const jid of [...this.options.pool.keys()]) {
       await this.disposeEntry(this.options.pool, jid, "shutdown.dispose_main_session");
@@ -277,5 +298,43 @@ export class AgentSessionManager {
         err,
       });
     }
+  }
+
+  private drainPrewarmQueue(): void {
+    if (this.prewarmLoopActive) return;
+    this.prewarmLoopActive = true;
+
+    void (async () => {
+      try {
+        while (this.prewarmQueue.length > 0) {
+          const chatJid = this.prewarmQueue.shift();
+          if (!chatJid) continue;
+          this.queuedPrewarms.delete(chatJid);
+          if (this.prewarmInFlight.has(chatJid) || this.options.pool.has(chatJid)) continue;
+
+          this.prewarmInFlight.add(chatJid);
+          try {
+            await this.getOrCreate(chatJid);
+            this.options.onInfo?.("Prewarmed chat session", {
+              operation: "prewarm_session",
+              chatJid,
+            });
+          } catch (err) {
+            this.options.onWarn?.("Failed to prewarm chat session", {
+              operation: "prewarm_session",
+              chatJid,
+              err,
+            });
+          } finally {
+            this.prewarmInFlight.delete(chatJid);
+          }
+        }
+      } finally {
+        this.prewarmLoopActive = false;
+        if (this.prewarmQueue.length > 0) {
+          this.drainPrewarmQueue();
+        }
+      }
+    })();
   }
 }

--- a/runtime/src/agent-pool/session-manager.ts
+++ b/runtime/src/agent-pool/session-manager.ts
@@ -39,6 +39,7 @@ export interface AgentSessionManagerOptions {
  * Handles lifecycle operations for main and auxiliary AgentSession instances.
  */
 export class AgentSessionManager {
+  private readonly createInFlight = new Map<string, Promise<AgentSessionRuntime>>();
   private readonly prewarmInFlight = new Set<string>();
   private readonly queuedPrewarms = new Set<string>();
   private readonly prewarmQueue: string[] = [];
@@ -56,39 +57,56 @@ export class AgentSessionManager {
   }
 
   async getOrCreate(chatJid: string): Promise<AgentSessionRuntime> {
+    const pendingCreate = this.createInFlight.get(chatJid);
+    if (pendingCreate) {
+      return await pendingCreate;
+    }
+
     const existing = this.options.pool.get(chatJid);
     if (existing) {
       existing.lastUsed = Date.now();
       return existing.runtime;
     }
 
-    this.options.onInfo?.("Creating new session", {
-      operation: "get_or_create.create_main_session",
-      chatJid,
-    });
+    const task = (async () => {
+      this.options.onInfo?.("Creating new session", {
+        operation: "get_or_create.create_main_session",
+        chatJid,
+      });
 
-    const chatSessionDir = ensureSessionDir(chatJid);
+      const chatSessionDir = ensureSessionDir(chatJid);
 
-    const extensionFactories = await this.options.getSessionExtensionFactories?.(chatJid) ?? [];
-    const runtime = this.options.createSession
-      ? await this.options.createSession(chatJid, chatSessionDir)
-      : await createDefaultSession(chatJid, {
-          authStorage: this.options.authStorage,
-          modelRegistry: this.options.modelRegistry,
-          settingsManager: this.options.settingsManager,
-          tools: this.options.createDefaultTools(),
-          extensionFactories,
+      const extensionFactories = await this.options.getSessionExtensionFactories?.(chatJid) ?? [];
+      const runtime = this.options.createSession
+        ? await this.options.createSession(chatJid, chatSessionDir)
+        : await createDefaultSession(chatJid, {
+            authStorage: this.options.authStorage,
+            modelRegistry: this.options.modelRegistry,
+            settingsManager: this.options.settingsManager,
+            tools: this.options.createDefaultTools(),
+            extensionFactories,
+          });
+
+      this.options.pool.set(chatJid, { runtime, lastUsed: Date.now() });
+      try {
+        await this.applyDefaultModel(runtime.session);
+        await this.refreshRuntime(chatJid, runtime);
+        this.options.onInfo?.("Session ready", {
+          operation: this.options.createSession ? "get_or_create.create_main_session" : "get_or_create.create_default_session",
+          chatJid,
+          poolSize: this.options.pool.size,
         });
-
-    this.options.pool.set(chatJid, { runtime, lastUsed: Date.now() });
-    await this.applyDefaultModel(runtime.session);
-    await this.refreshRuntime(chatJid, runtime);
-    this.options.onInfo?.("Session ready", {
-      operation: this.options.createSession ? "get_or_create.create_main_session" : "get_or_create.create_default_session",
-      chatJid,
-      poolSize: this.options.pool.size,
+        return runtime;
+      } catch (err) {
+        await this.disposeMainRuntimeAfterError(chatJid, runtime, "get_or_create.dispose_after_error");
+        throw err;
+      }
+    })().finally(() => {
+      this.createInFlight.delete(chatJid);
     });
-    return runtime;
+
+    this.createInFlight.set(chatJid, task);
+    return await task;
   }
 
   async getOrCreateSide(chatJid: string): Promise<AgentSessionRuntime> {
@@ -336,5 +354,20 @@ export class AgentSessionManager {
         }
       }
     })();
+  }
+
+  private async disposeMainRuntimeAfterError(chatJid: string, runtime: AgentSessionRuntime, operation: string): Promise<void> {
+    if (this.options.pool.get(chatJid)?.runtime === runtime) {
+      this.options.pool.delete(chatJid);
+    }
+    try {
+      await runtime.dispose();
+    } catch (disposeErr) {
+      this.options.onWarn?.("Failed to dispose session after initialization error", {
+        operation,
+        chatJid,
+        err: disposeErr,
+      });
+    }
   }
 }

--- a/runtime/src/runtime/startup.ts
+++ b/runtime/src/runtime/startup.ts
@@ -80,10 +80,32 @@ export function initializeRuntimeEnvironment(state: RuntimeState): void {
   state.loadChats();
 }
 
+export function queueStartupSessionWarmup(
+  agentPool: AgentPool & {
+    scheduleChatWarmup?: (chatJid: string, options?: { priority?: boolean }) => boolean;
+    scheduleRecentChatWarmup?: (options?: { limit?: number; excludeChatJids?: string[] }) => string[];
+  },
+  options: { defaultChatJid?: string; recentLimit?: number } = {},
+): void {
+  const defaultChatJid = typeof options.defaultChatJid === "string" && options.defaultChatJid.trim()
+    ? options.defaultChatJid.trim()
+    : "web:default";
+  const recentLimit = Math.max(0, Math.min(8, Math.trunc(options.recentLimit ?? 5) || 5));
+
+  agentPool.scheduleChatWarmup?.(defaultChatJid, { priority: true });
+  if (recentLimit > 0) {
+    agentPool.scheduleRecentChatWarmup?.({
+      limit: recentLimit,
+      excludeChatJids: [defaultChatJid],
+    });
+  }
+}
+
 /** Start web channel and run immediate crash-recovery bootstrap. */
 export async function startWebChannel(queue: AgentQueue, agentPool: AgentPool): Promise<WebChannel> {
   const web = new WebChannel({ queue, agentPool });
   await web.start();
+  queueStartupSessionWarmup(agentPool);
   web.recoverInflightRuns();
   // Run an immediate pending-resume scan at startup so deferred queued
   // follow-ups are picked up even before IPC workers process resume tasks.

--- a/runtime/test/agent-pool/session-manager.test.ts
+++ b/runtime/test/agent-pool/session-manager.test.ts
@@ -79,6 +79,32 @@ test("AgentSessionManager creates, caches, and binds main sessions", async () =>
   expect(fixture.pool.get("web:default")?.runtime.session).toBe(session);
 });
 
+test("AgentSessionManager singleflights concurrent main-session creation for the same chat", async () => {
+  let createCalls = 0;
+  let releaseCreate!: () => void;
+  const waitForCreate = new Promise<void>((resolve) => {
+    releaseCreate = resolve;
+  });
+  const session = {
+    dispose() {},
+  };
+  const fixture = createManager({
+    createSession: async () => {
+      createCalls += 1;
+      await waitForCreate;
+      return createRuntime(session) as any;
+    },
+  });
+
+  const first = fixture.manager.getOrCreate("web:default");
+  const second = fixture.manager.getOrCreate("web:default");
+  releaseCreate();
+
+  expect(await first).toBe(await second);
+  expect(createCalls).toBe(1);
+  expect(fixture.state.bound).toEqual(["web:default"]);
+});
+
 test("AgentSessionManager recreates cached main and side sessions", async () => {
   let disposed = 0;
   const mainSession = {

--- a/runtime/test/agent-pool/session-manager.test.ts
+++ b/runtime/test/agent-pool/session-manager.test.ts
@@ -143,3 +143,32 @@ test("AgentSessionManager evicts idle sessions and shuts down remaining sessions
   expect(fixture.sidePool.size).toBe(0);
   expect(disposed).toBe(2);
 });
+
+test("AgentSessionManager serializes queued prewarms and honors priority ordering", async () => {
+  const created: string[] = [];
+  let activeCreates = 0;
+  let maxConcurrentCreates = 0;
+
+  const fixture = createManager({
+    createSession: async (chatJid: string) => {
+      created.push(chatJid);
+      activeCreates += 1;
+      maxConcurrentCreates = Math.max(maxConcurrentCreates, activeCreates);
+      await Bun.sleep(10);
+      activeCreates -= 1;
+      return createRuntime({ dispose() {} }) as any;
+    },
+  });
+
+  expect(fixture.manager.prewarm("web:older")).toBe(true);
+  expect(fixture.manager.prewarm("web:newer")).toBe(true);
+  expect(fixture.manager.prewarm("web:priority", { priority: true })).toBe(true);
+  expect(fixture.manager.prewarm("web:older")).toBe(false);
+
+  await Bun.sleep(50);
+
+  expect(created).toEqual(["web:older", "web:priority", "web:newer"]);
+  expect(maxConcurrentCreates).toBe(1);
+
+  await fixture.manager.shutdown();
+});

--- a/runtime/test/runtime/startup.test.ts
+++ b/runtime/test/runtime/startup.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import { queueStartupSessionWarmup } from "../../src/runtime/startup.js";
 import { createTempWorkspace } from "../helpers.js";
+
+const TEST_SHELL = process.env.SHELL || "bash";
+const RUNTIME_DIR = join(import.meta.dir, "../..");
 
 describe("runtime startup helpers", () => {
   test("initializeRuntimeEnvironment seeds workspace skel files for direct installs", () => {
@@ -10,11 +14,11 @@ describe("runtime startup helpers", () => {
     try {
       const run = Bun.spawnSync({
         cmd: [
-          "bun",
-          "-e",
-          'import { initializeRuntimeEnvironment } from "./src/runtime/startup.js"; initializeRuntimeEnvironment({ loadTimestamps() {}, loadChats() {} });',
+          TEST_SHELL,
+          "-lc",
+          "bun -e \"import { initializeRuntimeEnvironment } from './src/runtime/startup.js'; initializeRuntimeEnvironment({ loadTimestamps() {}, loadChats() {} });\"",
         ],
-        cwd: "/workspace/piclaw/runtime",
+        cwd: RUNTIME_DIR,
         env: {
           ...process.env,
           PICLAW_WORKSPACE: ws.workspace,
@@ -43,11 +47,11 @@ describe("runtime startup helpers", () => {
     try {
       const run = Bun.spawnSync({
         cmd: [
-          "bun",
-          "-e",
-          'import { queueStartupResumePendingIpc } from "./src/runtime/startup.js"; queueStartupResumePendingIpc();',
+          TEST_SHELL,
+          "-lc",
+          "bun -e \"import { queueStartupResumePendingIpc } from './src/runtime/startup.js'; queueStartupResumePendingIpc();\"",
         ],
-        cwd: "/workspace/piclaw/runtime",
+        cwd: RUNTIME_DIR,
         env: {
           ...process.env,
           PICLAW_WORKSPACE: ws.workspace,
@@ -82,11 +86,11 @@ describe("runtime startup helpers", () => {
 
       const run = Bun.spawnSync({
         cmd: [
-          "bun",
-          "-e",
-          'import { queueStartupResumePendingIpc } from "./src/runtime/startup.js"; queueStartupResumePendingIpc();',
+          TEST_SHELL,
+          "-lc",
+          "bun -e \"import { queueStartupResumePendingIpc } from './src/runtime/startup.js'; queueStartupResumePendingIpc();\"",
         ],
-        cwd: "/workspace/piclaw/runtime",
+        cwd: RUNTIME_DIR,
         env: {
           ...process.env,
           PICLAW_WORKSPACE: ws.workspace,
@@ -106,5 +110,24 @@ describe("runtime startup helpers", () => {
     } finally {
       ws.cleanup();
     }
+  });
+
+  test("queueStartupSessionWarmup prioritizes the default chat and queues five recent chats by default", () => {
+    const scheduled: Array<{ chatJid: string; priority?: boolean }> = [];
+    const recentCalls: Array<{ limit?: number; excludeChatJids?: string[] }> = [];
+
+    queueStartupSessionWarmup({
+      scheduleChatWarmup: (chatJid: string, options?: { priority?: boolean }) => {
+        scheduled.push({ chatJid, priority: options?.priority });
+        return true;
+      },
+      scheduleRecentChatWarmup: (options?: { limit?: number; excludeChatJids?: string[] }) => {
+        recentCalls.push(options || {});
+        return [];
+      },
+    } as any);
+
+    expect(scheduled).toEqual([{ chatJid: "web:default", priority: true }]);
+    expect(recentCalls).toEqual([{ limit: 5, excludeChatJids: ["web:default"] }]);
   });
 });


### PR DESCRIPTION
## Why
Background session warmup is only useful if the most likely next chat gets warmed first and the warmup worker does not stampede multiple session creations at once.

## What this changes
- adds a queued session prewarm lane with `priority` support
- serializes queued prewarms instead of running them concurrently
- prioritizes the default chat at startup
- keeps optional recent-chat startup warmup hooks available when present

## Scope
This is a backend startup/warmup scheduling change.

It does not change:
- branch semantics
- model/provider behavior
- web navigation behavior

## Validation
- `bun test runtime/test/agent-pool/session-manager.test.ts runtime/test/runtime/startup.test.ts`

Signed-off-by: Pix (PiClaw, openai-codex/gpt-5.4)
