### PR TITLE
types: include reorderQueuedFollowupItems in control-plane Pick

### DIFF
--- a/runtime/src/channels/web/agent/agent-control-plane-service.ts
+++ b/runtime/src/channels/web/agent/agent-control-plane-service.ts
@@ -43,7 +43,11 @@ type ControlPlaneAgentPool = AgentPool & {
 
 type ControlPlaneQueuedLifecycle = Pick<
   QueuedFollowupLifecycleService,
-  "getQueuedFollowupCount" | "listQueuedStateItems" | "prependQueuedFollowupItem" | "removeQueuedFollowupForAction"
+  | "getQueuedFollowupCount"
+  | "listQueuedStateItems"
+  | "prependQueuedFollowupItem"
+  | "removeQueuedFollowupForAction"
+  | "reorderQueuedFollowupItems"
 >;
 
 export interface WebAgentControlPlaneServiceOptions {


### PR DESCRIPTION
Tightens the `ControlPlaneChatSession` Pick type in the facade to include `reorderQueuedFollowupItems` — the method the facade was already invoking via `handleAgentQueueReorder`. The concrete lifecycle service already implements it; this just aligns the type.

No behavior change beyond making the TypeScript surface honest.