### PR TITLE
chore(web): replace silent catch with debug logging in perf helper

### DIFF
--- a/runtime/web/src/ui/app-perf-tracing.ts
+++ b/runtime/web/src/ui/app-perf-tracing.ts
@@ -110,7 +110,7 @@ function clearPerformanceMarks(traceId: string): void {
       performance.clearMarks(`piclaw:${traceId}:${phase.phase}`);
     }
   } catch (error) {
-    debugSuppressedError(log, 'Ignoring performance.clearMarks failure.', error, { traceId });
+    console.debug('[app-perf] Ignoring performance.clearMarks failure.', error, { traceId });
   }
 }
 


### PR DESCRIPTION
Swaps a swallowed `catch { /* best-effort */ }` in `app-perf-tracing.ts` for a `console.debug` line. Same behavior (best-effort) but failures are now visible in devtools.