### PR TITLE
perf(web): cache recent timelines in memory

### DIFF
--- a/runtime/test/web/app-chat-refresh-lifecycle.test.ts
+++ b/runtime/test/web/app-chat-refresh-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
 
 import {
+  prewarmRecentTimelineChats,
   refreshPostPaintThreadHydration,
   startModelAndQueueRefreshEffect,
 } from '../../web/src/ui/app-chat-refresh-lifecycle.js';
@@ -63,20 +64,44 @@ test('refreshPostPaintThreadHydration refreshes the current chat after timeline 
 
   refreshPostPaintThreadHydration({
     refreshModelState: () => calls.push('model'),
-    refreshActiveChatAgents: () => calls.push('agents'),
+    refreshActiveChatAgents: (options) => calls.push(`agents:${options?.prewarmRecent ? 'warm' : 'plain'}:${options?.prewarmLimit ?? 0}`),
     refreshCurrentChatBranches: () => calls.push('branches'),
     refreshQueueState: () => calls.push('queue'),
     refreshContextUsage: async () => { calls.push('context'); },
     refreshAutoresearchStatus: async () => { calls.push('autoresearch'); },
+    prewarmLimit: 7,
   });
 
   await Promise.resolve();
   expect(calls).toEqual([
     'model',
-    'agents',
+    'agents:warm:7',
     'branches',
     'queue',
     'context',
     'autoresearch',
   ]);
+});
+
+test('prewarmRecentTimelineChats prewarms distinct nearby chats and skips the current chat', async () => {
+  const calls: string[] = [];
+
+  prewarmRecentTimelineChats({
+    chats: [
+      { chat_jid: 'web:current' },
+      { chat_jid: 'web:branch:1' },
+      { chat_jid: 'web:branch:1' },
+      { chat_jid: 'web:branch:2' },
+    ],
+    currentChatJid: 'web:current',
+    prewarmLimit: 2,
+    fetchTimeline: async (chatJid) => {
+      calls.push(chatJid);
+      return { posts: [], has_more: false };
+    },
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(calls).toEqual(['web:branch:1', 'web:branch:2']);
 });

--- a/runtime/test/web/app-timeline-cache.test.ts
+++ b/runtime/test/web/app-timeline-cache.test.ts
@@ -1,0 +1,57 @@
+import { expect, mock, test } from 'bun:test';
+
+import {
+  cacheTimelineSnapshot,
+  clearTimelineSnapshotCache,
+  getCachedTimelineSnapshot,
+  prewarmTimelineSnapshots,
+  resolveRecentTimelinePrewarmChatJids,
+} from '../../web/src/ui/app-timeline-cache.js';
+
+test('timeline cache stores and reloads fresh snapshots from memory', () => {
+  clearTimelineSnapshotCache();
+
+  cacheTimelineSnapshot('web:branch:a', {
+    posts: [{ id: 1 }],
+    has_more: true,
+  });
+
+  const snapshot = getCachedTimelineSnapshot('web:branch:a');
+  expect(snapshot?.posts).toEqual([{ id: 1 }]);
+  expect(snapshot?.has_more).toBe(true);
+
+  clearTimelineSnapshotCache();
+});
+
+test('resolveRecentTimelinePrewarmChatJids excludes the active chat and dedupes rows', () => {
+  const chatJids = resolveRecentTimelinePrewarmChatJids([
+    { chat_jid: 'web:current' },
+    { chat_jid: 'web:branch:1' },
+    { chat_jid: 'web:branch:1' },
+    { chat_jid: 'web:branch:2' },
+    { chat_jid: '   ' },
+  ], 'web:current', 2);
+
+  expect(chatJids).toEqual(['web:branch:1', 'web:branch:2']);
+});
+
+test('prewarmTimelineSnapshots fills missing chats and skips already fresh entries', async () => {
+  clearTimelineSnapshotCache();
+  cacheTimelineSnapshot('web:cached', { posts: [{ id: 1 }], has_more: false });
+
+  const fetchTimeline = mock(async (chatJid: string) => ({
+    posts: [{ id: `${chatJid}-post` }],
+    has_more: false,
+  }));
+
+  await prewarmTimelineSnapshots({
+    chatJids: ['web:cached', 'web:warm', 'web:warm'],
+    fetchTimeline,
+  });
+
+  expect(fetchTimeline).toHaveBeenCalledTimes(1);
+  expect(fetchTimeline).toHaveBeenCalledWith('web:warm');
+  expect(getCachedTimelineSnapshot('web:warm')?.posts).toEqual([{ id: 'web:warm-post' }]);
+
+  clearTimelineSnapshotCache();
+});

--- a/runtime/test/web/use-timeline.test.ts
+++ b/runtime/test/web/use-timeline.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test';
+
+import { mergeFreshTimelinePosts } from '../../web/src/ui/use-timeline.js';
+
+test('mergeFreshTimelinePosts prepends fresh rows while keeping older cached rows around', () => {
+  expect(mergeFreshTimelinePosts(
+    [{ id: 9 }, { id: 8 }, { id: 7 }, { id: 6 }],
+    [{ id: 10 }, { id: 9 }, { id: 8 }],
+  )).toEqual([{ id: 10 }, { id: 9 }, { id: 8 }, { id: 7 }, { id: 6 }]);
+});
+
+test('mergeFreshTimelinePosts falls back to the fresh payload when no current rows exist', () => {
+  expect(mergeFreshTimelinePosts(null, [{ id: 2 }, { id: 1 }])).toEqual([{ id: 2 }, { id: 1 }]);
+});
+
+test('mergeFreshTimelinePosts keeps the current rows when the fresh payload is malformed', () => {
+  expect(mergeFreshTimelinePosts([{ id: 2 }, { id: 1 }], null)).toEqual([{ id: 2 }, { id: 1 }]);
+});

--- a/runtime/web/src/app.ts
+++ b/runtime/web/src/app.ts
@@ -153,6 +153,8 @@ function MainApp({ locationParams, navigate }) {
         viewStateRef: surface.viewStateRef,
         followupQueueRowIdsRef: surface.followupQueueRowIdsRef,
         currentChatJid,
+        currentHashtag: surface.currentHashtag,
+        searchQuery: surface.searchQuery,
         followupQueueItems: surface.followupQueueItems,
     });
 

--- a/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
+++ b/runtime/web/src/ui/app-chat-refresh-lifecycle.ts
@@ -15,6 +15,8 @@ import {
   getActiveAppPerfTraceId,
   markAppPerfTrace,
 } from './app-perf-tracing.js';
+import { prewarmTimelineSnapshots, resolveRecentTimelinePrewarmChatJids } from './app-timeline-cache.js';
+import { getTimeline } from '../api.js';
 import {
   noteAppChatActivation,
   runCoalescedAppRefresh,
@@ -94,11 +96,12 @@ export function startModelAndQueueRefreshEffect(options: {
 
 export function refreshPostPaintThreadHydration(options: {
   refreshModelState: () => void;
-  refreshActiveChatAgents: () => void;
+  refreshActiveChatAgents: (options?: { prewarmRecent?: boolean; prewarmLimit?: number }) => void;
   refreshCurrentChatBranches: () => void;
   refreshQueueState: () => void;
   refreshContextUsage: () => Promise<void>;
   refreshAutoresearchStatus: () => Promise<void>;
+  prewarmLimit?: number;
 }): void {
   const {
     refreshModelState,
@@ -107,14 +110,32 @@ export function refreshPostPaintThreadHydration(options: {
     refreshQueueState,
     refreshContextUsage,
     refreshAutoresearchStatus,
+    prewarmLimit = 5,
   } = options;
 
   refreshModelState();
-  refreshActiveChatAgents();
+  refreshActiveChatAgents({
+    prewarmRecent: true,
+    prewarmLimit,
+  });
   refreshCurrentChatBranches();
   refreshQueueState();
   void refreshContextUsage();
   void refreshAutoresearchStatus();
+}
+
+export function prewarmRecentTimelineChats(options: {
+  chats: unknown;
+  currentChatJid: string;
+  prewarmLimit?: number;
+  fetchTimeline?: (chatJid: string) => Promise<{ posts?: any[]; has_more?: boolean }>;
+}): void {
+  const chatJids = resolveRecentTimelinePrewarmChatJids(options.chats, options.currentChatJid, options.prewarmLimit ?? 5);
+  if (chatJids.length === 0) return;
+  void prewarmTimelineSnapshots({
+    chatJids,
+    fetchTimeline: options.fetchTimeline ?? ((chatJid) => getTimeline(10, null, chatJid)),
+  });
 }
 
 export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions) {
@@ -245,13 +266,18 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
     });
   }, [activeChatJidRef, applyModelState, currentChatJid, getAgentModels, getThreadSwitchTraceId]);
 
-  const refreshActiveChatAgents = useCallback(() => {
+  const refreshActiveChatAgents = useCallback((options?: {
+    prewarmRecent?: boolean;
+    prewarmLimit?: number;
+  }) => {
+    const prewarmRecent = Boolean(options?.prewarmRecent);
+    const prewarmLimit = Number.isFinite(options?.prewarmLimit) ? Number(options?.prewarmLimit) : 5;
     return runCoalescedAppRefresh({
       kind: 'active-chat-agents',
       chatJid: currentChatJid,
       run: async () => {
         const traceId = getThreadSwitchTraceId();
-        await refreshActiveChatAgentsState({
+        const mergedChats = await refreshActiveChatAgentsState({
           currentChatJid,
           getActiveChatAgents: async () => {
             if (traceId) {
@@ -285,6 +311,13 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
           activeChatJidRef,
           setActiveChatAgents,
         });
+        if (prewarmRecent) {
+          prewarmRecentTimelineChats({
+            chats: mergedChats,
+            currentChatJid,
+            prewarmLimit,
+          });
+        }
         return null;
       },
     });
@@ -339,6 +372,7 @@ export function useChatRefreshLifecycle(options: UseChatRefreshLifecycleOptions)
       refreshQueueState,
       refreshContextUsage,
       refreshAutoresearchStatus,
+      prewarmLimit: 5,
     });
   }, [refreshActiveChatAgents, refreshAutoresearchStatus, refreshContextUsage, refreshCurrentChatBranches, refreshModelState, refreshQueueState]);
 

--- a/runtime/web/src/ui/app-main-timeline-composition.ts
+++ b/runtime/web/src/ui/app-main-timeline-composition.ts
@@ -29,6 +29,8 @@ export function useMainAppTimelineComposition(options: {
   viewStateRef: RefBox<any>;
   followupQueueRowIdsRef: RefBox<Set<string | number>>;
   currentChatJid: string;
+  currentHashtag: string | null;
+  searchQuery: string | null;
   followupQueueItems: any[];
 }) {
   const {
@@ -36,6 +38,8 @@ export function useMainAppTimelineComposition(options: {
     viewStateRef,
     followupQueueRowIdsRef,
     currentChatJid,
+    currentHashtag,
+    searchQuery,
     followupQueueItems,
   } = options;
 
@@ -65,7 +69,13 @@ export function useMainAppTimelineComposition(options: {
     refreshTimeline,
     loadMore,
     loadMoreRef,
-  } = useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop, chatJid: currentChatJid });
+  } = useTimeline({
+    preserveTimelineScroll,
+    preserveTimelineScrollTop,
+    chatJid: currentChatJid,
+    currentHashtag,
+    searchQuery,
+  });
 
   const posts = useMemo(() => deriveVisibleTimelinePosts({
     rawPosts,

--- a/runtime/web/src/ui/app-timeline-cache.ts
+++ b/runtime/web/src/ui/app-timeline-cache.ts
@@ -1,0 +1,130 @@
+type TimelinePayload = {
+  posts?: any[];
+  has_more?: boolean;
+};
+
+type TimelineSnapshot = {
+  posts: any[];
+  has_more: boolean;
+  cachedAt: number;
+};
+
+const TIMELINE_CACHE_LIMIT = 24;
+const TIMELINE_CACHE_TTL_MS = 10 * 60 * 1000;
+const timelineCache = new Map<string, TimelineSnapshot>();
+const prewarmInFlight = new Map<string, Promise<void>>();
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function normalizeChatJid(chatJid: string | null | undefined): string {
+  return String(chatJid || '').trim();
+}
+
+function isFresh(snapshot: TimelineSnapshot | null | undefined, maxAgeMs = TIMELINE_CACHE_TTL_MS): snapshot is TimelineSnapshot {
+  return Boolean(snapshot && (nowMs() - snapshot.cachedAt) <= maxAgeMs);
+}
+
+function pruneCacheMap(cache: Map<string, TimelineSnapshot>): void {
+  while (cache.size > TIMELINE_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
+    if (!oldestKey) break;
+    cache.delete(oldestKey);
+  }
+}
+
+function touchCacheEntry(chatJid: string, snapshot: TimelineSnapshot): TimelineSnapshot {
+  timelineCache.delete(chatJid);
+  timelineCache.set(chatJid, snapshot);
+  pruneCacheMap(timelineCache);
+  return snapshot;
+}
+
+export function cacheTimelineSnapshot(
+  chatJid: string | null | undefined,
+  payload: TimelinePayload,
+): TimelineSnapshot | null {
+  const normalizedChatJid = normalizeChatJid(chatJid);
+  if (!normalizedChatJid) return null;
+  const snapshot: TimelineSnapshot = {
+    posts: Array.isArray(payload?.posts) ? payload.posts : [],
+    has_more: Boolean(payload?.has_more),
+    cachedAt: nowMs(),
+  };
+  return touchCacheEntry(normalizedChatJid, snapshot);
+}
+
+export function getCachedTimelineSnapshot(
+  chatJid: string | null | undefined,
+  options: { maxAgeMs?: number } = {},
+): TimelineSnapshot | null {
+  const normalizedChatJid = normalizeChatJid(chatJid);
+  if (!normalizedChatJid) return null;
+  const maxAgeMs = Number.isFinite(options.maxAgeMs) ? Number(options.maxAgeMs) : TIMELINE_CACHE_TTL_MS;
+  const snapshot = timelineCache.get(normalizedChatJid) || null;
+  if (!isFresh(snapshot, maxAgeMs)) {
+    return null;
+  }
+  return touchCacheEntry(normalizedChatJid, snapshot);
+}
+
+export function resolveRecentTimelinePrewarmChatJids(chats: unknown, currentChatJid: string | null | undefined, limit = 5): string[] {
+  if (!Array.isArray(chats)) return [];
+  const normalizedCurrentChatJid = normalizeChatJid(currentChatJid);
+  const maxRows = Number.isFinite(limit) ? Math.max(1, Math.min(8, Number(limit))) : 5;
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const chat of chats) {
+    const chatJid = normalizeChatJid(chat?.chat_jid);
+    if (!chatJid || chatJid === normalizedCurrentChatJid || seen.has(chatJid)) continue;
+    seen.add(chatJid);
+    result.push(chatJid);
+    if (result.length >= maxRows) break;
+  }
+  return result;
+}
+
+export async function prewarmTimelineSnapshots(options: {
+  chatJids: string[];
+  fetchTimeline: (chatJid: string) => Promise<TimelinePayload>;
+  maxAgeMs?: number;
+  maxConcurrent?: number;
+}): Promise<void> {
+  const uniqueChatJids = Array.from(new Set((options.chatJids || []).map((chatJid) => normalizeChatJid(chatJid)).filter(Boolean)));
+  if (uniqueChatJids.length === 0) return;
+  const maxAgeMs = Number.isFinite(options.maxAgeMs) ? Number(options.maxAgeMs) : TIMELINE_CACHE_TTL_MS;
+  const maxConcurrent = Number.isFinite(options.maxConcurrent) ? Math.max(1, Math.min(4, Number(options.maxConcurrent))) : 2;
+  const pending = uniqueChatJids.filter((chatJid) => !isFresh(getCachedTimelineSnapshot(chatJid, { maxAgeMs }), maxAgeMs));
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(maxConcurrent, pending.length) }, async () => {
+    while (cursor < pending.length) {
+      const chatJid = pending[cursor++];
+      const existing = prewarmInFlight.get(chatJid);
+      if (existing) {
+        await existing;
+        continue;
+      }
+      const task = (async () => {
+        try {
+          const payload = await options.fetchTimeline(chatJid);
+          cacheTimelineSnapshot(chatJid, payload);
+        } catch (error) {
+          console.debug('[app-timeline-cache] Ignoring timeline prewarm failure for a best-effort background fetch.', error, {
+            chatJid,
+          });
+        } finally {
+          prewarmInFlight.delete(chatJid);
+        }
+      })();
+      prewarmInFlight.set(chatJid, task);
+      await task;
+    }
+  });
+  await Promise.all(workers);
+}
+
+export function clearTimelineSnapshotCache(): void {
+  timelineCache.clear();
+  prewarmInFlight.clear();
+}

--- a/runtime/web/src/ui/use-timeline.ts
+++ b/runtime/web/src/ui/use-timeline.ts
@@ -1,17 +1,47 @@
 // @ts-nocheck
 import { useCallback, useEffect, useRef, useState } from '../vendor/preact-htm.js';
 import { getTimeline, getPostsByHashtag } from '../api.js';
+import { cacheTimelineSnapshot, getCachedTimelineSnapshot } from './app-timeline-cache.js';
 import { dedupePosts } from './timeline-utils.js';
 
-export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop, chatJid = null }) {
-  const [posts, setPosts] = useState(null);
-  const [hasMore, setHasMore] = useState(false);
+export function mergeFreshTimelinePosts(currentPosts, freshPosts) {
+  const currentArray = Array.isArray(currentPosts) ? currentPosts : [];
+  const freshArray = Array.isArray(freshPosts) ? freshPosts : null;
+  if (!freshArray) return currentArray;
+  if (freshArray.length === 0) return freshArray;
+  if (currentArray.length === 0) return freshArray;
+  // Window-replace merge: fresh is authoritative for its own id range.
+  // Drop cached rows whose id falls within the fresh window (>= minFreshId)
+  // so a row that disappeared server-side (deleted elsewhere, branch reset)
+  // does not survive as a phantom; keep older cached rows (id < minFreshId)
+  // that were loaded via loadMore.
+  let minFreshId = Infinity;
+  for (const post of freshArray) {
+    const id = post?.id;
+    if (typeof id === 'number' && Number.isFinite(id) && id < minFreshId) {
+      minFreshId = id;
+    }
+  }
+  if (!Number.isFinite(minFreshId)) {
+    return dedupePosts([...freshArray, ...currentArray]);
+  }
+  const olderCached = currentArray.filter((post) => {
+    const id = post?.id;
+    return typeof id === 'number' && Number.isFinite(id) && id < minFreshId;
+  });
+  return dedupePosts([...freshArray, ...olderCached]);
+}
+
+export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop, chatJid = null, currentHashtag = null, searchQuery = null }) {
+  const [posts, setPostsState] = useState(null);
+  const [hasMore, setHasMoreState] = useState(false);
   const hasMoreRef = useRef(false);
   const loadMoreRef = useRef(null);
   const loadingMoreRef = useRef(false);
   const lastBeforeIdRef = useRef(null);
   const postsRef = useRef(null);
   const chatTokenRef = useRef(0);
+  const mutationVersionRef = useRef(0);
 
   useEffect(() => {
     hasMoreRef.current = hasMore;
@@ -21,6 +51,15 @@ export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop,
     postsRef.current = posts;
   }, [posts]);
 
+  const shouldCacheCurrentView = !currentHashtag && !searchQuery;
+  // Mirror the current view-mode in a ref so async callbacks (cache-hit
+  // background refresh) can bail out if the user has switched into hashtag
+  // or search mode, which does not bump chatTokenRef.
+  const viewModeCacheableRef = useRef(shouldCacheCurrentView);
+  useEffect(() => {
+    viewModeCacheableRef.current = shouldCacheCurrentView;
+  }, [shouldCacheCurrentView]);
+
   useEffect(() => {
     chatTokenRef.current += 1;
     // Preserve currently visible posts while the next chat loads so session
@@ -29,8 +68,25 @@ export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop,
     lastBeforeIdRef.current = null;
     loadingMoreRef.current = false;
     hasMoreRef.current = false;
-    setHasMore(false);
+    setHasMoreState(false);
+    mutationVersionRef.current = 0;
   }, [chatJid]);
+
+  const cacheCurrentSnapshot = useCallback((nextPosts, nextHasMore) => {
+    if (!shouldCacheCurrentView) return;
+    cacheTimelineSnapshot(chatJid, {
+      posts: Array.isArray(nextPosts) ? nextPosts : [],
+      has_more: Boolean(nextHasMore),
+    });
+  }, [chatJid, shouldCacheCurrentView]);
+
+  const setTimelineState = useCallback((nextPosts, nextHasMore) => {
+    postsRef.current = Array.isArray(nextPosts) ? nextPosts : [];
+    hasMoreRef.current = Boolean(nextHasMore);
+    setPostsState(postsRef.current);
+    setHasMoreState(hasMoreRef.current);
+    cacheCurrentSnapshot(postsRef.current, hasMoreRef.current);
+  }, [cacheCurrentSnapshot]);
 
   const loadPosts = useCallback(async (hashtag = null) => {
     const token = chatTokenRef.current;
@@ -38,36 +94,61 @@ export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop,
       if (hashtag) {
         const result = await getPostsByHashtag(hashtag, 50, 0, chatJid);
         if (token !== chatTokenRef.current) return;
-        setPosts(result.posts);
-        setHasMore(false);
-      } else {
-        const result = await getTimeline(10, null, chatJid);
-        if (token !== chatTokenRef.current) return;
-        setPosts(result.posts);
-        setHasMore(result.has_more);
+        setPostsState(result.posts);
+        setHasMoreState(false);
+        return;
       }
+
+      const applyFreshPayload = (result) => {
+        if (token !== chatTokenRef.current) return;
+        const nextPosts = Array.isArray(result?.posts) ? result.posts : [];
+        const nextHasMore = Boolean(result?.has_more);
+        setTimelineState(nextPosts, nextHasMore);
+      };
+
+      const cached = getCachedTimelineSnapshot(chatJid);
+      if (cached) {
+        setTimelineState(cached.posts, cached.has_more);
+        const backgroundMutationVersion = mutationVersionRef.current;
+        void getTimeline(10, null, chatJid)
+          .then((result) => {
+            if (token !== chatTokenRef.current || mutationVersionRef.current !== backgroundMutationVersion) return;
+            // Drop the refresh if the user has switched into hashtag/search
+            // mode since the request was kicked off — chatTokenRef does not
+            // change across in-chat view-mode transitions, so it would not
+            // otherwise invalidate this callback.
+            if (!viewModeCacheableRef.current) return;
+            const freshPosts = Array.isArray(result?.posts) ? result.posts : [];
+            const freshHasMore = Boolean(result?.has_more);
+            setTimelineState(mergeFreshTimelinePosts(postsRef.current, freshPosts), freshHasMore);
+          })
+          .catch((error) => {
+            if (token !== chatTokenRef.current) return;
+            console.error('Failed to refresh cached timeline:', error);
+          });
+        return;
+      }
+
+      const result = await getTimeline(10, null, chatJid);
+      applyFreshPayload(result);
     } catch (error) {
       if (token !== chatTokenRef.current) return;
       console.error('Failed to load posts:', error);
       throw error;
     }
-  }, [chatJid]);
+  }, [chatJid, setTimelineState]);
 
   const refreshTimeline = useCallback(async () => {
     const token = chatTokenRef.current;
     try {
       const result = await getTimeline(10, null, chatJid);
       if (token !== chatTokenRef.current) return;
-      setPosts((prev) => {
-        if (!prev || prev.length === 0) return result.posts;
-        return dedupePosts([...result.posts, ...prev]);
-      });
-      setHasMore((prev) => prev || result.has_more);
+      setTimelineState(mergeFreshTimelinePosts(postsRef.current, result?.posts), Boolean(result?.has_more));
     } catch (error) {
       if (token !== chatTokenRef.current) return;
       console.error('Failed to refresh timeline:', error);
     }
-  }, [chatJid]);
+  }, [chatJid, setTimelineState]);
 
   // loadMore reads posts from ref to avoid re-creating on every posts change.
   const loadMore = useCallback(async (options = {}) => {
@@ -94,13 +175,14 @@ export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop,
     try {
       const result = await getTimeline(10, oldestId, chatJid);
       if (token !== chatTokenRef.current) return;
+      mutationVersionRef.current += 1;
       if (result.posts.length > 0) {
         applyUpdate(() => {
-          setPosts(prev => dedupePosts([...result.posts, ...(prev || [])]));
-          setHasMore(result.has_more);
+          const nextPosts = dedupePosts([...result.posts, ...(postsRef.current || [])]);
+          setTimelineState(nextPosts, result.has_more);
         });
       } else {
-        setHasMore(false);
+        setTimelineState(postsRef.current || [], false);
       }
     } catch (error) {
       if (token !== chatTokenRef.current) return;
@@ -110,17 +192,37 @@ export function useTimeline({ preserveTimelineScroll, preserveTimelineScrollTop,
         loadingMoreRef.current = false;
       }
     }
-  }, [chatJid, preserveTimelineScroll, preserveTimelineScrollTop]);
+  }, [chatJid, preserveTimelineScroll, preserveTimelineScrollTop, setTimelineState]);
 
   useEffect(() => {
     loadMoreRef.current = loadMore;
   }, [loadMore]);
 
+  const setPosts = useCallback((updater) => {
+    setPostsState((prev) => {
+      const nextPosts = typeof updater === 'function' ? updater(prev) : updater;
+      postsRef.current = nextPosts;
+      if (Array.isArray(nextPosts)) {
+        mutationVersionRef.current += 1;
+        // Persist even the empty snapshot: deleting the last visible row must
+        // invalidate the prior cached state, otherwise a quick switch-away
+        // and back within the TTL would resurrect rows we just removed.
+        if (shouldCacheCurrentView) {
+          cacheTimelineSnapshot(chatJid, {
+            posts: nextPosts,
+            has_more: hasMoreRef.current,
+          });
+        }
+      }
+      return nextPosts;
+    });
+  }, [chatJid, shouldCacheCurrentView]);
+
   return {
     posts,
     setPosts,
     hasMore,
-    setHasMore,
+    setHasMore: setHasMoreState,
     hasMoreRef,
     loadPosts,
     refreshTimeline,


### PR DESCRIPTION
Refresh of #57 with reviewer feedback addressed:

- **Cancel cached refreshes when leaving the main timeline.** The cache-hit background `getTimeline()` now bails if the view has switched into hashtag/search mode, so a late response cannot overwrite a filtered view.
- **Window-replace merge instead of union.** `mergeFreshTimelinePosts` now drops cached rows whose id falls within the fresh window (`id >= min(freshId)`), so a row deleted server-side does not linger as a phantom. Older rows loaded via `loadMore` are preserved.
- **Persist empty snapshots.** Emptying the main timeline (deleting the last row, `interaction_deleted`, etc.) now invalidates the prior cached snapshot instead of leaving stale rows to be resurrected on next visit.

Also includes the existing `console.debug` on prewarm failures (was previously in a separate perf-helpers commit, folded in because it only applies to the file this PR introduces).

Tests: adds `mergeFreshTimelinePosts` cases + existing `app-timeline-cache.test.ts` / `use-timeline.test.ts`. Full web-test suite passes.