### PR TITLE
perf(agent): defer branch session seeding

### DIFF
--- a/runtime/src/agent-pool/branch-manager.ts
+++ b/runtime/src/agent-pool/branch-manager.ts
@@ -5,9 +5,7 @@
  * top-level AgentPool coordinator while preserving the existing branch semantics.
  */
 
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
-import type { ImageContent, Message, TextContent } from "@mariozechner/pi-ai";
-import type { AgentSession, AgentSessionRuntime, SessionEntry, SessionManager } from "@mariozechner/pi-coding-agent";
+import type { AgentSession, AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
 
 import { getIdentityConfig } from "../core/config.js";
 import {
@@ -22,7 +20,7 @@ import {
   type ChatBranchRecord,
 } from "../db.js";
 import { createUuid } from "../utils/ids.js";
-import { forcePersistSessionFile, seedRotatedSession } from "../session-rotation.js";
+import { createDeferredBranchSeed, writeDeferredBranchSeed } from "./branch-seeding.js";
 import type { PoolEntry } from "./session-manager.js";
 
 /** Active/known chat metadata surfaced by AgentPool. */
@@ -48,6 +46,8 @@ export interface AgentBranchManagerOptions {
   getOrCreateRuntime: (chatJid: string) => Promise<AgentSessionRuntime>;
   refreshRuntime: (chatJid: string, runtime: AgentSessionRuntime) => Promise<void>;
   isActive: (chatJid: string) => boolean;
+  scheduleSessionWarmup?: (chatJid: string) => void;
+  cancelSessionWarmup?: (chatJid: string) => void;
   onWarn?: (message: string, details: Record<string, unknown>) => void;
 }
 
@@ -93,132 +93,6 @@ function createVolatileBranchRecord(chatJid: string, session?: AgentSession | nu
     updated_at: new Date(0).toISOString(),
     archived_at: null,
   };
-}
-
-type LegacyCustomEntry = {
-  type: "custom_entry";
-  id?: string;
-  customType: string;
-  data?: unknown;
-};
-
-type SeedBranchEntry = SessionEntry | LegacyCustomEntry;
-
-type AppendableAgentMessage = Message | {
-  role: "bashExecution";
-  command: string;
-  output: string;
-  exitCode: number | undefined;
-  cancelled: boolean;
-  truncated: boolean;
-  fullOutputPath?: string;
-  timestamp: number;
-  excludeFromContext?: boolean;
-} | {
-  role: "custom";
-  customType: string;
-  content: string | (TextContent | ImageContent)[];
-  display: boolean;
-  details?: unknown;
-  timestamp: number;
-};
-
-type SeedSessionManager = Pick<
-  SessionManager,
-  | "appendMessage"
-  | "appendThinkingLevelChange"
-  | "appendModelChange"
-  | "appendCompaction"
-  | "appendSessionInfo"
-  | "appendCustomMessageEntry"
-  | "appendCustomEntry"
->;
-
-function normalizeThinkingLevel(value: string | null | undefined): ThinkingLevel | null {
-  return value === "off" || value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh"
-    ? value
-    : null;
-}
-
-function isAppendableAgentMessage(message: unknown): message is AppendableAgentMessage {
-  if (!message || typeof message !== "object") return false;
-  const role = (message as { role?: unknown }).role;
-  return role === "user"
-    || role === "assistant"
-    || role === "system"
-    || role === "tool"
-    || role === "bashExecution"
-    || role === "custom";
-}
-
-function getStableForkSeed(sourceSession: AgentSession, stableLeafId: string | null): {
-  branchEntries: SeedBranchEntry[];
-  model: { provider: string; modelId: string } | null;
-  thinkingLevel: ThinkingLevel | null;
-} {
-  const branchEntries = stableLeafId === null
-    ? []
-    : (typeof sourceSession.sessionManager?.getBranch === "function"
-        ? sourceSession.sessionManager.getBranch(stableLeafId)
-        : []);
-
-  let model: { provider: string; modelId: string } | null = null;
-  let thinkingLevel: ThinkingLevel | null = null;
-
-  for (const entry of branchEntries) {
-    if (entry?.type === "model_change" && typeof entry.provider === "string" && typeof entry.modelId === "string") {
-      model = { provider: entry.provider, modelId: entry.modelId };
-    } else if (entry?.type === "thinking_level_change" && typeof entry.thinkingLevel === "string") {
-      thinkingLevel = normalizeThinkingLevel(entry.thinkingLevel);
-    } else if (entry?.type === "message" && entry.message?.role === "assistant" && typeof entry.message?.provider === "string" && typeof entry.message?.model === "string") {
-      model = { provider: entry.message.provider, modelId: entry.message.model };
-    }
-  }
-
-  return { branchEntries, model, thinkingLevel };
-}
-
-function seedSessionManagerFromBranchEntries(
-  sessionManager: SeedSessionManager,
-  branchEntries: SeedBranchEntry[],
-  fallback: { sessionName?: string | null; model?: { provider: string; modelId: string } | null },
-): void {
-  if (!Array.isArray(branchEntries) || branchEntries.length === 0) {
-    if (fallback.sessionName?.trim()) {
-      sessionManager.appendSessionInfo(fallback.sessionName.trim());
-    }
-    if (fallback.model) {
-      sessionManager.appendModelChange(fallback.model.provider, fallback.model.modelId);
-    }
-    return;
-  }
-
-  const sourceToNewId = new Map<string, string>();
-  for (const entry of branchEntries) {
-    let newId: string | null = null;
-    if (entry?.type === "message" && isAppendableAgentMessage(entry.message)) {
-      newId = sessionManager.appendMessage(entry.message);
-    } else if (entry?.type === "thinking_level_change" && typeof entry.thinkingLevel === "string") {
-      newId = sessionManager.appendThinkingLevelChange(entry.thinkingLevel);
-    } else if (entry?.type === "model_change" && typeof entry.provider === "string" && typeof entry.modelId === "string") {
-      newId = sessionManager.appendModelChange(entry.provider, entry.modelId);
-    } else if (entry?.type === "compaction" && typeof entry.summary === "string") {
-      const firstKeptEntryId = sourceToNewId.get(entry.firstKeptEntryId)
-        ?? sourceToNewId.get(branchEntries[0]?.id ?? "")
-        ?? "rotated-context";
-      newId = sessionManager.appendCompaction(entry.summary, firstKeptEntryId, entry.tokensBefore ?? 0, entry.details, entry.fromHook);
-    } else if (entry?.type === "session_info" && typeof entry.name === "string" && entry.name.trim()) {
-      newId = sessionManager.appendSessionInfo(entry.name.trim());
-    } else if (entry?.type === "custom_message" && typeof entry.customType === "string") {
-      newId = sessionManager.appendCustomMessageEntry(entry.customType, entry.content, entry.display, entry.details);
-    } else if (entry?.type === "custom_entry" && typeof entry.customType === "string") {
-      newId = sessionManager.appendCustomEntry(entry.customType, entry.data);
-    }
-
-    if (entry?.id && newId) {
-      sourceToNewId.set(entry.id, newId);
-    }
-  }
 }
 
 function isSessionActive(session: AgentSession): boolean {
@@ -316,6 +190,13 @@ export class AgentBranchManager {
       this.options.sidePool.delete(chatJid);
     }
     this.options.activeForkBaseLeafByChat.delete(chatJid);
+    // Cancel any queued prewarm so a background realization does not
+    // materialize a blank runtime (or realize the deferred seed) for an
+    // archived chat between prune and restore.
+    this.options.cancelSessionWarmup?.(chatJid);
+    // NOTE: do not clearDeferredBranchSeed here — .branch-seed.json is the
+    // only persisted copy of the forked context until the session is realized,
+    // and a subsequent restoreChatBranch() must be able to pick it back up.
 
     return archived;
   }
@@ -368,75 +249,12 @@ export class AgentBranchManager {
       agent_name: requestedAgentName,
     });
 
-    const targetRuntime = await this.options.getOrCreateRuntime(nextChatJid);
-    const stableSeed = sourceIsActive
-      ? getStableForkSeed(sourceSession, stableForkLeafId)
-      : null;
-    const sourceContext = sourceSession.sessionManager.buildSessionContext();
-    const parentSession = sourceSession.sessionFile?.trim() || undefined;
-    const setupName = nextBranch.agent_name;
-    const sourceModel = stableSeed?.model || sourceContext.model || (sourceSession.model
-      ? { provider: sourceSession.model.provider, modelId: sourceSession.model.id }
-      : null);
-
-    const result = await targetRuntime.newSession({
-      ...(parentSession ? { parentSession } : {}),
-      setup: async (sessionManager) => {
-        if (stableSeed) {
-          seedSessionManagerFromBranchEntries(sessionManager, stableSeed.branchEntries, {
-            sessionName: setupName,
-            model: sourceModel,
-          });
-          return;
-        }
-        seedRotatedSession(sessionManager, sourceContext, {
-          sessionName: setupName,
-          model: sourceModel,
-        });
-      },
-    });
-    if (result.cancelled) {
-      throw new Error("Branch fork was cancelled.");
-    }
-
-    await this.options.refreshRuntime(nextChatJid, targetRuntime);
-    const activeTargetSession = targetRuntime.session;
-
-    if (sourceSession.model) {
-      try {
-        await activeTargetSession.setModel(sourceSession.model);
-      } catch (err) {
-        this.options.onWarn?.("Failed to copy model to forked branch", {
-          operation: "create_forked_chat_branch.copy_model",
-          chatJid: nextChatJid,
-          err,
-        });
-      }
-    }
-    try {
-      const nextThinkingLevel = normalizeThinkingLevel(
-        stableSeed?.thinkingLevel || sourceContext.thinkingLevel || sourceSession.thinkingLevel,
-      );
-      if (nextThinkingLevel) {
-        activeTargetSession.setThinkingLevel(nextThinkingLevel);
-      }
-    } catch (err) {
-      this.options.onWarn?.("Failed to copy thinking level to forked branch", {
-        operation: "create_forked_chat_branch.copy_thinking_level",
-        chatJid: nextChatJid,
-        err,
-      });
-    }
-    try {
-      activeTargetSession.setSessionName(setupName);
-    } catch (err) {
-      this.options.onWarn?.("Failed to copy session name to forked branch", {
-        operation: "create_forked_chat_branch.copy_session_name",
-        chatJid: nextChatJid,
-        err,
-      });
-    }
-    forcePersistSessionFile(activeTargetSession);
+    writeDeferredBranchSeed(nextChatJid, createDeferredBranchSeed(sourceSession, {
+      stableLeafId: stableForkLeafId,
+      sessionName: nextBranch.agent_name,
+      sourceIsActive,
+    }));
+    this.options.scheduleSessionWarmup?.(nextChatJid);
 
     return ensureChatBranch({
       chat_jid: nextChatJid,

--- a/runtime/src/agent-pool/branch-seeding.ts
+++ b/runtime/src/agent-pool/branch-seeding.ts
@@ -1,0 +1,324 @@
+/**
+ * agent-pool/branch-seeding.ts – Deferred branch seed persistence and replay.
+ *
+ * Lets branch creation stay lightweight by persisting enough fork context to
+ * seed the target session later, either on first use or during background
+ * prewarm.
+ */
+
+import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { ImageContent, Message, TextContent } from "@mariozechner/pi-ai";
+import type { AgentSession, SessionContext, SessionEntry, SessionManager } from "@mariozechner/pi-coding-agent";
+
+import { seedRotatedSession } from "../session-rotation.js";
+import { ensureSessionDir } from "./session.js";
+
+type LegacyCustomEntry = {
+  type: "custom_entry";
+  id?: string;
+  customType: string;
+  data?: unknown;
+};
+
+export type SeedBranchEntry = SessionEntry | LegacyCustomEntry;
+
+export interface DeferredBranchSeed {
+  version: 1;
+  parentSession: string | null;
+  sessionName: string | null;
+  model: { provider: string; modelId: string } | null;
+  thinkingLevel: ThinkingLevel | null;
+  mode: "stable_branch" | "rotated_context";
+  branchEntries?: SeedBranchEntry[];
+  context?: SessionContext;
+}
+
+type AppendableAgentMessage = Message | {
+  role: "bashExecution";
+  command: string;
+  output: string;
+  exitCode: number | undefined;
+  cancelled: boolean;
+  truncated: boolean;
+  fullOutputPath?: string;
+  timestamp: number;
+  excludeFromContext?: boolean;
+} | {
+  role: "custom";
+  customType: string;
+  content: string | (TextContent | ImageContent)[];
+  display: boolean;
+  details?: unknown;
+  timestamp: number;
+};
+
+type SeedSessionManager = Pick<
+  SessionManager,
+  | "appendMessage"
+  | "appendThinkingLevelChange"
+  | "appendModelChange"
+  | "appendCompaction"
+  | "appendSessionInfo"
+  | "appendCustomMessageEntry"
+  | "appendCustomEntry"
+>;
+
+const DEFERRED_BRANCH_SEED_FILE = ".branch-seed.json";
+const CLAIMED_DEFERRED_BRANCH_SEED_FILE = ".branch-seed.claimed.json";
+
+function createInvalidDeferredBranchSeedError(chatJid: string, reason: string, cause?: unknown): Error {
+  return new Error(`Invalid deferred branch seed for ${chatJid}: ${reason}`, cause ? { cause } : undefined);
+}
+
+export function normalizeThinkingLevel(value: string | null | undefined): ThinkingLevel | null {
+  return value === "off" || value === "minimal" || value === "low" || value === "medium" || value === "high" || value === "xhigh"
+    ? value
+    : null;
+}
+
+function isAppendableAgentMessage(message: unknown): message is AppendableAgentMessage {
+  if (!message || typeof message !== "object") return false;
+  const role = (message as { role?: unknown }).role;
+  return role === "user"
+    || role === "assistant"
+    || role === "system"
+    || role === "tool"
+    || role === "bashExecution"
+    || role === "custom";
+}
+
+function getStableForkSeed(sourceSession: AgentSession, stableLeafId: string | null): {
+  branchEntries: SeedBranchEntry[];
+  model: { provider: string; modelId: string } | null;
+  thinkingLevel: ThinkingLevel | null;
+} {
+  const branchEntries = stableLeafId === null
+    ? []
+    : (typeof sourceSession.sessionManager?.getBranch === "function"
+        ? sourceSession.sessionManager.getBranch(stableLeafId)
+        : []);
+
+  let model: { provider: string; modelId: string } | null = null;
+  let thinkingLevel: ThinkingLevel | null = null;
+
+  for (const entry of branchEntries) {
+    if (entry?.type === "model_change" && typeof entry.provider === "string" && typeof entry.modelId === "string") {
+      model = { provider: entry.provider, modelId: entry.modelId };
+    } else if (entry?.type === "thinking_level_change" && typeof entry.thinkingLevel === "string") {
+      thinkingLevel = normalizeThinkingLevel(entry.thinkingLevel);
+    } else if (entry?.type === "message" && entry.message?.role === "assistant" && typeof entry.message?.provider === "string" && typeof entry.message?.model === "string") {
+      model = { provider: entry.message.provider, modelId: entry.message.model };
+    }
+  }
+
+  return { branchEntries, model, thinkingLevel };
+}
+
+function cloneSeedValue<T>(value: T): T {
+  if (value === null || value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function createDeferredBranchSeed(
+  sourceSession: AgentSession,
+  options: { stableLeafId: string | null; sessionName?: string | null; sourceIsActive: boolean },
+): DeferredBranchSeed {
+  const stableSeed = options.sourceIsActive
+    ? getStableForkSeed(sourceSession, options.stableLeafId)
+    : null;
+  const sourceContext = stableSeed
+    ? null
+    : sourceSession.sessionManager.buildSessionContext();
+  const model = stableSeed?.model || sourceContext?.model || (sourceSession.model
+    ? { provider: sourceSession.model.provider, modelId: sourceSession.model.id }
+    : null);
+  const thinkingLevel = normalizeThinkingLevel(
+    stableSeed?.thinkingLevel || sourceContext?.thinkingLevel || sourceSession.thinkingLevel,
+  );
+
+  return {
+    version: 1,
+    parentSession: sourceSession.sessionFile?.trim() || null,
+    sessionName: options.sessionName?.trim() || null,
+    model,
+    thinkingLevel,
+    mode: stableSeed ? "stable_branch" : "rotated_context",
+    ...(stableSeed ? { branchEntries: cloneSeedValue(stableSeed.branchEntries) } : { context: cloneSeedValue(sourceContext ?? undefined) }),
+  };
+}
+
+function seedSessionManagerFromBranchEntries(
+  sessionManager: SeedSessionManager,
+  branchEntries: SeedBranchEntry[],
+  fallback: { sessionName?: string | null; model?: { provider: string; modelId: string } | null },
+): void {
+  if (!Array.isArray(branchEntries) || branchEntries.length === 0) {
+    if (fallback.sessionName?.trim()) {
+      sessionManager.appendSessionInfo(fallback.sessionName.trim());
+    }
+    if (fallback.model) {
+      sessionManager.appendModelChange(fallback.model.provider, fallback.model.modelId);
+    }
+    return;
+  }
+
+  const sourceToNewId = new Map<string, string>();
+  for (const entry of branchEntries) {
+    let newId: string | null = null;
+    if (entry?.type === "message" && isAppendableAgentMessage(entry.message)) {
+      newId = sessionManager.appendMessage(entry.message);
+    } else if (entry?.type === "thinking_level_change" && typeof entry.thinkingLevel === "string") {
+      newId = sessionManager.appendThinkingLevelChange(entry.thinkingLevel);
+    } else if (entry?.type === "model_change" && typeof entry.provider === "string" && typeof entry.modelId === "string") {
+      newId = sessionManager.appendModelChange(entry.provider, entry.modelId);
+    } else if (entry?.type === "compaction" && typeof entry.summary === "string") {
+      const firstKeptEntryId = sourceToNewId.get(entry.firstKeptEntryId)
+        ?? sourceToNewId.get(branchEntries[0]?.id ?? "")
+        ?? "rotated-context";
+      newId = sessionManager.appendCompaction(entry.summary, firstKeptEntryId, entry.tokensBefore ?? 0, entry.details, entry.fromHook);
+    } else if (entry?.type === "session_info" && typeof entry.name === "string" && entry.name.trim()) {
+      newId = sessionManager.appendSessionInfo(entry.name.trim());
+    } else if (entry?.type === "custom_message" && typeof entry.customType === "string") {
+      newId = sessionManager.appendCustomMessageEntry(entry.customType, entry.content, entry.display, entry.details);
+    } else if (entry?.type === "custom_entry" && typeof entry.customType === "string") {
+      newId = sessionManager.appendCustomEntry(entry.customType, entry.data);
+    }
+
+    if (entry?.id && newId) {
+      sourceToNewId.set(entry.id, newId);
+    }
+  }
+}
+
+export function seedSessionManagerFromDeferredBranchSeed(
+  sessionManager: SeedSessionManager,
+  seed: DeferredBranchSeed,
+): void {
+  if (seed.mode === "stable_branch") {
+    seedSessionManagerFromBranchEntries(sessionManager, seed.branchEntries ?? [], {
+      sessionName: seed.sessionName,
+      model: seed.model,
+    });
+    return;
+  }
+
+  if (seed.context) {
+    seedRotatedSession(sessionManager as SessionManager, seed.context, {
+      sessionName: seed.sessionName || undefined,
+      model: seed.model,
+    });
+    return;
+  }
+
+  if (seed.sessionName?.trim()) {
+    sessionManager.appendSessionInfo(seed.sessionName.trim());
+  }
+  if (seed.model) {
+    sessionManager.appendModelChange(seed.model.provider, seed.model.modelId);
+  }
+}
+
+function getDeferredBranchSeedPath(chatJid: string): string {
+  return join(ensureSessionDir(chatJid), DEFERRED_BRANCH_SEED_FILE);
+}
+
+function getClaimedDeferredBranchSeedPath(chatJid: string): string {
+  return join(ensureSessionDir(chatJid), CLAIMED_DEFERRED_BRANCH_SEED_FILE);
+}
+
+function readDeferredBranchSeedFromPath(chatJid: string, path: string): DeferredBranchSeed | null {
+  if (!existsSync(path)) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw createInvalidDeferredBranchSeedError(chatJid, "malformed JSON", error);
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw createInvalidDeferredBranchSeedError(chatJid, "seed payload must be an object");
+  }
+
+  const seed = parsed as Partial<DeferredBranchSeed>;
+  if (seed.version !== 1) {
+    throw createInvalidDeferredBranchSeedError(chatJid, "unsupported version");
+  }
+  if (seed.mode !== "stable_branch" && seed.mode !== "rotated_context") {
+    throw createInvalidDeferredBranchSeedError(chatJid, "unsupported seed mode");
+  }
+  return seed as DeferredBranchSeed;
+}
+
+function getExistingDeferredBranchSeedPath(chatJid: string): string | null {
+  const primaryPath = getDeferredBranchSeedPath(chatJid);
+  if (existsSync(primaryPath)) return primaryPath;
+  const claimedPath = getClaimedDeferredBranchSeedPath(chatJid);
+  return existsSync(claimedPath) ? claimedPath : null;
+}
+
+export function hasDeferredBranchSeed(chatJid: string): boolean {
+  return getExistingDeferredBranchSeedPath(chatJid) !== null;
+}
+
+export function getDeferredBranchSeedFingerprint(chatJid: string): string | null {
+  const path = getExistingDeferredBranchSeedPath(chatJid);
+  if (!path) return null;
+  try {
+    const stat = statSync(path);
+    return `${path}:${stat.size}:${stat.mtimeMs}`;
+  } catch {
+    return null;
+  }
+}
+
+export function writeDeferredBranchSeed(chatJid: string, seed: DeferredBranchSeed): void {
+  const targetPath = getDeferredBranchSeedPath(chatJid);
+  const tempPath = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    writeFileSync(tempPath, JSON.stringify(seed), "utf8");
+    renameSync(tempPath, targetPath);
+    rmSync(getClaimedDeferredBranchSeedPath(chatJid), { force: true });
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
+  }
+}
+
+export function readDeferredBranchSeed(chatJid: string): DeferredBranchSeed | null {
+  const path = getExistingDeferredBranchSeedPath(chatJid);
+  if (!path) return null;
+  return readDeferredBranchSeedFromPath(chatJid, path);
+}
+
+export function claimDeferredBranchSeed(chatJid: string): DeferredBranchSeed | null {
+  const primaryPath = getDeferredBranchSeedPath(chatJid);
+  const claimedPath = getClaimedDeferredBranchSeedPath(chatJid);
+  if (existsSync(primaryPath)) {
+    renameSync(primaryPath, claimedPath);
+  }
+  if (!existsSync(claimedPath)) return null;
+  return readDeferredBranchSeedFromPath(chatJid, claimedPath);
+}
+
+export function restoreClaimedDeferredBranchSeed(chatJid: string): void {
+  const primaryPath = getDeferredBranchSeedPath(chatJid);
+  const claimedPath = getClaimedDeferredBranchSeedPath(chatJid);
+  if (!existsSync(claimedPath)) return;
+  if (existsSync(primaryPath)) {
+    rmSync(claimedPath, { force: true });
+    return;
+  }
+  renameSync(claimedPath, primaryPath);
+}
+
+export function finalizeClaimedDeferredBranchSeed(chatJid: string): void {
+  rmSync(getClaimedDeferredBranchSeedPath(chatJid), { force: true });
+}
+
+export function clearDeferredBranchSeed(chatJid: string): void {
+  rmSync(getDeferredBranchSeedPath(chatJid), { force: true });
+  rmSync(getClaimedDeferredBranchSeedPath(chatJid), { force: true });
+}

--- a/runtime/src/agent-pool/service-factory.ts
+++ b/runtime/src/agent-pool/service-factory.ts
@@ -107,6 +107,8 @@ export function createAgentPoolServices(options: AgentPoolServiceFactoryOptions)
     getOrCreateRuntime: (chatJid) => sessionManager.getOrCreate(chatJid),
     refreshRuntime: (chatJid, runtime) => sessionManager.refreshRuntime(chatJid, runtime),
     isActive: (chatJid) => runtimeFacade.isActive(chatJid),
+    scheduleSessionWarmup: (chatJid) => sessionManager.prewarm(chatJid),
+    cancelSessionWarmup: (chatJid) => sessionManager.cancelPrewarm(chatJid),
     onWarn: options.onWarn,
   });
   sessionManager = new AgentSessionManager({

--- a/runtime/src/agent-pool/session-manager.ts
+++ b/runtime/src/agent-pool/session-manager.ts
@@ -8,8 +8,17 @@
 
 import type { AgentSession, AgentSessionRuntime, ExtensionFactory, ModelRegistry, SettingsManager, AuthStorage } from "@mariozechner/pi-coding-agent";
 
+import {
+  claimDeferredBranchSeed,
+  finalizeClaimedDeferredBranchSeed,
+  getDeferredBranchSeedFingerprint,
+  hasDeferredBranchSeed,
+  restoreClaimedDeferredBranchSeed,
+  seedSessionManagerFromDeferredBranchSeed,
+} from "./branch-seeding.js";
+import { getChatBranchByChatJid } from "../db.js";
 import { createDefaultSession, createSessionInDir, ensureNamedSessionDir, ensureSessionDir } from "./session.js";
-import { seedRotatedSession } from "../session-rotation.js";
+import { forcePersistSessionFile, seedRotatedSession } from "../session-rotation.js";
 
 /** Cached session entry stored for each chat JID. */
 export interface PoolEntry {
@@ -39,13 +48,35 @@ export interface AgentSessionManagerOptions {
  * Handles lifecycle operations for main and auxiliary AgentSession instances.
  */
 export class AgentSessionManager {
+  private readonly branchSeedRealizationInFlight = new Map<string, Promise<boolean>>();
   private readonly createInFlight = new Map<string, Promise<AgentSessionRuntime>>();
+  private readonly invalidDeferredBranchSeedErrors = new Map<string, { error: Error; fingerprint: string | null }>();
+  private readonly runtimeDisposeInFlight = new WeakMap<AgentSessionRuntime, Promise<void>>();
   private readonly prewarmInFlight = new Set<string>();
   private readonly queuedPrewarms = new Set<string>();
   private readonly prewarmQueue: string[] = [];
+  private readonly prewarmCooldownByChat = new Map<string, number>();
   private prewarmLoopActive = false;
 
   constructor(private readonly options: AgentSessionManagerOptions) {}
+
+  private getBlockingInvalidSeedError(chatJid: string): Error | null {
+    const knownInvalidSeedState = this.invalidDeferredBranchSeedErrors.get(chatJid);
+    if (!knownInvalidSeedState) return null;
+    if (knownInvalidSeedState.fingerprint === getDeferredBranchSeedFingerprint(chatJid)) {
+      return knownInvalidSeedState.error;
+    }
+    this.invalidDeferredBranchSeedErrors.delete(chatJid);
+    return null;
+  }
+
+  private prunePrewarmCooldownEntries(now: number): void {
+    for (const [chatJid, lastQueuedAt] of this.prewarmCooldownByChat) {
+      if (now - lastQueuedAt >= 30_000) {
+        this.prewarmCooldownByChat.delete(chatJid);
+      }
+    }
+  }
 
   async refreshRuntime(chatJid: string, runtime: AgentSessionRuntime): Promise<void> {
     const entry = this.options.pool.get(chatJid);
@@ -57,6 +88,11 @@ export class AgentSessionManager {
   }
 
   async getOrCreate(chatJid: string): Promise<AgentSessionRuntime> {
+    const knownInvalidSeedError = this.getBlockingInvalidSeedError(chatJid);
+    if (knownInvalidSeedError) {
+      throw knownInvalidSeedError;
+    }
+
     const pendingCreate = this.createInFlight.get(chatJid);
     if (pendingCreate) {
       return await pendingCreate;
@@ -65,7 +101,13 @@ export class AgentSessionManager {
     const existing = this.options.pool.get(chatJid);
     if (existing) {
       existing.lastUsed = Date.now();
-      return existing.runtime;
+      try {
+        await this.realizeDeferredBranchSeed(chatJid, existing.runtime);
+        return existing.runtime;
+      } catch (error) {
+        await this.disposeMainRuntimeAfterError(chatJid, existing.runtime, "get_or_create.realize_existing_after_error");
+        throw error;
+      }
     }
 
     const task = (async () => {
@@ -89,7 +131,10 @@ export class AgentSessionManager {
 
       this.options.pool.set(chatJid, { runtime, lastUsed: Date.now() });
       try {
-        await this.applyDefaultModel(runtime.session);
+        const realizedDeferredSeed = await this.realizeDeferredBranchSeed(chatJid, runtime);
+        if (!realizedDeferredSeed) {
+          await this.applyDefaultModel(runtime.session);
+        }
         await this.refreshRuntime(chatJid, runtime);
         this.options.onInfo?.("Session ready", {
           operation: this.options.createSession ? "get_or_create.create_main_session" : "get_or_create.create_default_session",
@@ -194,13 +239,32 @@ export class AgentSessionManager {
     await this.disposeEntry(this.options.sidePool, chatJid, "recreate.dispose_side_session", true);
   }
 
+  /**
+   * Remove any pending (not-yet-realized) prewarm for a chat. Used by
+   * branch prune so a queued warmup cannot materialize a blank runtime
+   * (or realize the deferred seed) for an archived chat.
+   */
+  cancelPrewarm(chatJid: string): void {
+    const normalized = String(chatJid || "").trim();
+    if (!normalized) return;
+    this.queuedPrewarms.delete(normalized);
+    const idx = this.prewarmQueue.indexOf(normalized);
+    if (idx >= 0) this.prewarmQueue.splice(idx, 1);
+  }
+
   prewarm(chatJid: string, options: { priority?: boolean } = {}): boolean {
     const normalizedChatJid = String(chatJid || "").trim();
     if (!normalizedChatJid) return false;
-    if (this.options.pool.has(normalizedChatJid)) return false;
+    if (this.getBlockingInvalidSeedError(normalizedChatJid)) return false;
+    if (this.options.pool.has(normalizedChatJid) && !hasDeferredBranchSeed(normalizedChatJid)) return false;
     if (this.prewarmInFlight.has(normalizedChatJid) || this.queuedPrewarms.has(normalizedChatJid)) return false;
+    const now = Date.now();
+    this.prunePrewarmCooldownEntries(now);
+    const lastQueuedAt = this.prewarmCooldownByChat.get(normalizedChatJid) ?? 0;
+    if (!options.priority && now - lastQueuedAt < 30_000) return false;
 
     this.queuedPrewarms.add(normalizedChatJid);
+    this.prewarmCooldownByChat.set(normalizedChatJid, now);
     if (options.priority) {
       this.prewarmQueue.unshift(normalizedChatJid);
     } else {
@@ -297,11 +361,98 @@ export class AgentSessionManager {
     const modelId = this.options.settingsManager.getDefaultModel();
     if (!provider || !modelId) return;
 
+    await this.applyResolvedModel(session, { provider, modelId }, "apply_default_model");
+  }
+
+  private async realizeDeferredBranchSeed(chatJid: string, runtime: AgentSessionRuntime): Promise<boolean> {
+    const pending = this.branchSeedRealizationInFlight.get(chatJid);
+    if (pending) return await pending;
+
+    const task = (async () => {
+      let seed;
+      try {
+        seed = claimDeferredBranchSeed(chatJid);
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("Invalid deferred branch seed for ")) {
+          this.invalidDeferredBranchSeedErrors.set(chatJid, {
+            error,
+            fingerprint: getDeferredBranchSeedFingerprint(chatJid),
+          });
+        }
+        throw error;
+      }
+      if (!seed) return false;
+
+      try {
+        const result = await runtime.newSession({
+          ...(seed.parentSession ? { parentSession: seed.parentSession } : {}),
+          setup: async (sessionManager) => {
+            seedSessionManagerFromDeferredBranchSeed(sessionManager, seed);
+          },
+        });
+        if (result.cancelled) {
+          throw new Error("Deferred branch seed was cancelled.");
+        }
+
+        const session = runtime.session;
+        await this.applyResolvedModel(session, seed.model, "realize_deferred_branch_seed");
+        try {
+          if (seed.thinkingLevel) {
+            session.setThinkingLevel(seed.thinkingLevel);
+          }
+        } catch (err) {
+          this.options.onWarn?.("Failed to restore deferred branch thinking level", {
+            operation: "realize_deferred_branch_seed.thinking_level",
+            chatJid,
+            err,
+          });
+        }
+        try {
+          // Prefer the current branch record's agent_name over the seed's
+          // captured sessionName: if the user renamed the branch between fork
+          // and realization, the DB has the new name and applying the stale
+          // seed value would overwrite the rename on first warmup.
+          const liveAgentName = getChatBranchByChatJid(chatJid)?.agent_name?.trim() || "";
+          const sessionNameToApply = liveAgentName || seed.sessionName?.trim() || "";
+          if (sessionNameToApply) {
+            session.setSessionName(sessionNameToApply);
+          }
+        } catch (err) {
+          this.options.onWarn?.("Failed to restore deferred branch session name", {
+            operation: "realize_deferred_branch_seed.session_name",
+            chatJid,
+            err,
+          });
+        }
+
+        forcePersistSessionFile(session);
+        finalizeClaimedDeferredBranchSeed(chatJid);
+        this.invalidDeferredBranchSeedErrors.delete(chatJid);
+        return true;
+      } catch (error) {
+        restoreClaimedDeferredBranchSeed(chatJid);
+        throw error;
+      }
+    })().finally(() => {
+      this.branchSeedRealizationInFlight.delete(chatJid);
+    });
+
+    this.branchSeedRealizationInFlight.set(chatJid, task);
+    return await task;
+  }
+
+  private async applyResolvedModel(
+    session: AgentSession,
+    model: { provider: string; modelId: string } | null,
+    operation: string,
+  ): Promise<void> {
+    if (!model) return;
+
     const current = session.model;
-    if (current) return;
+    if (current && current.provider === model.provider && current.id === model.modelId) return;
 
     const sessionRegistry = (session as AgentSession & { modelRegistry?: ModelRegistry }).modelRegistry ?? this.options.modelRegistry;
-    const resolved = sessionRegistry.find(provider, modelId);
+    const resolved = sessionRegistry.find(model.provider, model.modelId);
     if (!resolved) return;
 
     const setModel = (session as { setModel?: (model: typeof resolved) => Promise<void> }).setModel;
@@ -311,8 +462,8 @@ export class AgentSessionManager {
       await setModel.call(session, resolved);
     } catch (err) {
       this.options.onWarn?.("Failed to restore model", {
-        operation: "apply_default_model",
-        model: `${provider}/${modelId}`,
+        operation,
+        model: `${model.provider}/${model.modelId}`,
         err,
       });
     }
@@ -328,7 +479,8 @@ export class AgentSessionManager {
           const chatJid = this.prewarmQueue.shift();
           if (!chatJid) continue;
           this.queuedPrewarms.delete(chatJid);
-          if (this.prewarmInFlight.has(chatJid) || this.options.pool.has(chatJid)) continue;
+          if (this.prewarmInFlight.has(chatJid)) continue;
+          if (this.options.pool.has(chatJid) && !hasDeferredBranchSeed(chatJid)) continue;
 
           this.prewarmInFlight.add(chatJid);
           try {
@@ -360,14 +512,24 @@ export class AgentSessionManager {
     if (this.options.pool.get(chatJid)?.runtime === runtime) {
       this.options.pool.delete(chatJid);
     }
-    try {
-      await runtime.dispose();
-    } catch (disposeErr) {
-      this.options.onWarn?.("Failed to dispose session after initialization error", {
-        operation,
-        chatJid,
-        err: disposeErr,
-      });
+    const pendingDispose = this.runtimeDisposeInFlight.get(runtime);
+    if (pendingDispose) {
+      await pendingDispose;
+      return;
     }
+
+    const task = (async () => {
+      try {
+        await runtime.dispose();
+      } catch (disposeErr) {
+        this.options.onWarn?.("Failed to dispose session after initialization error", {
+          operation,
+          chatJid,
+          err: disposeErr,
+        });
+      }
+    })();
+    this.runtimeDisposeInFlight.set(runtime, task);
+    await task;
   }
 }

--- a/runtime/test/agent-pool/agent-pool.test.ts
+++ b/runtime/test/agent-pool/agent-pool.test.ts
@@ -535,6 +535,7 @@ test("agent pool forks active chats from the previous stable turn boundary", asy
 
   const branch = await (pool as any).createForkedChatBranch(sourceChatJid);
   expect(branch.chat_jid).not.toBe(sourceChatJid);
+  await (pool as any).getSessionForIntrospection(branch.chat_jid);
   const forkedSession = created[branch.chat_jid];
   const forkedMessages = forkedSession.sessionManager.buildSessionContext().messages;
   const serialized = JSON.stringify(forkedMessages);

--- a/runtime/test/agent-pool/branch-lifecycle-audit.test.ts
+++ b/runtime/test/agent-pool/branch-lifecycle-audit.test.ts
@@ -123,6 +123,7 @@ test("agent pool audit: forks active chats from the previous stable turn boundar
 
   const branch = await (pool as any).createForkedChatBranch(sourceChatJid);
   expect(branch.chat_jid).not.toBe(sourceChatJid);
+  await (pool as any).getSessionForIntrospection(branch.chat_jid);
   const forkedSession = created[branch.chat_jid];
   const forkedMessages = forkedSession.sessionManager.buildSessionContext().messages;
   const serialized = JSON.stringify(forkedMessages);

--- a/runtime/test/agent-pool/branch-manager.test.ts
+++ b/runtime/test/agent-pool/branch-manager.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, expect, test } from "bun:test";
+import { writeFileSync } from "fs";
 
 import type { AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { join } from "path";
+import { ensureSessionDir } from "../../src/agent-pool/session.js";
 import { AgentBranchManager } from "../../src/agent-pool/branch-manager.js";
+import { hasDeferredBranchSeed, readDeferredBranchSeed } from "../../src/agent-pool/branch-seeding.js";
 import { createTempWorkspace, importFresh, setEnv } from "../helpers.js";
 
 let restoreEnv: (() => void) | null = null;
@@ -44,6 +49,7 @@ function createManager(overrides: Partial<ConstructorParameters<typeof AgentBran
       const session = pool.get(chatJid)?.runtime.session;
       return Boolean(session?.isStreaming || session?.isCompacting || session?.isRetrying || session?.isBashRunning);
     },
+    scheduleSessionWarmup: () => {},
     onWarn: (message) => warns.push(message),
     ...overrides,
   });
@@ -89,6 +95,74 @@ test("AgentBranchManager registers active chats and resolves agent handles", asy
   ws.cleanup();
 });
 
+test("AgentBranchManager writes a deferred fork seed and schedules branch warmup without hydrating the target runtime", async () => {
+  const ws = createTempWorkspace("piclaw-branch-seed-");
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  const db = await importFresh<typeof import("../src/db.js")>("../src/db.js");
+  db.initDatabase();
+
+  const sourceManager = SessionManager.create(ws.workspace, join(ws.workspace, "source-session"));
+  sourceManager.appendSessionInfo("Research");
+  sourceManager.appendModelChange("openai", "gpt-test");
+  sourceManager.appendMessage({ role: "user", content: "stable user", timestamp: Date.now() } as const);
+  sourceManager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text: "stable assistant" }],
+    provider: "openai",
+    model: "gpt-test",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  } as const);
+
+  const scheduled: string[] = [];
+  let getOrCreateCalls = 0;
+  const sourceSession = {
+    sessionManager: sourceManager,
+    sessionFile: sourceManager.getSessionFile(),
+    sessionName: "Research",
+    model: { provider: "openai", id: "gpt-test", reasoning: true },
+    thinkingLevel: "high",
+    isStreaming: false,
+    isCompacting: false,
+    isRetrying: false,
+    isBashRunning: false,
+  };
+
+  const fixture = createManager({
+    getOrCreateRuntime: async (chatJid) => {
+      getOrCreateCalls += 1;
+      if (chatJid !== "web:default") throw new Error(`unexpected runtime hydration for ${chatJid}`);
+      return fixture.pool.get(chatJid)?.runtime;
+    },
+    scheduleSessionWarmup: (chatJid) => {
+      scheduled.push(chatJid);
+    },
+  });
+  fixture.pool.set("web:default", { runtime: createRuntime(sourceSession), lastUsed: Date.now() });
+
+  const branch = await fixture.manager.createForkedChatBranch("web:default");
+  expect(branch.chat_jid).not.toBe("web:default");
+  expect(getOrCreateCalls).toBe(1);
+  expect(scheduled).toEqual([branch.chat_jid]);
+
+  const seed = readDeferredBranchSeed(branch.chat_jid);
+  expect(seed?.version).toBe(1);
+  expect(seed?.sessionName).toBe(branch.agent_name);
+  expect(seed?.model).toEqual({ provider: "openai", modelId: "gpt-test" });
+  expect(seed?.mode).toBe("rotated_context");
+
+  ws.cleanup();
+});
+
 test("AgentBranchManager prunes inactive branches and disposes cached sessions", async () => {
   const ws = createTempWorkspace("piclaw-branch-prune-");
   restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
@@ -117,16 +191,36 @@ test("AgentBranchManager prunes inactive branches and disposes cached sessions",
     },
   };
 
-  const fixture = createManager();
+  const cancelled: string[] = [];
+  const fixture = createManager({
+    cancelSessionWarmup: (chatJid) => {
+      cancelled.push(chatJid);
+    },
+  });
   fixture.pool.set("web:default:branch:prune", { runtime: createRuntime(session), lastUsed: Date.now() });
   fixture.sidePool.set("web:default:branch:prune", { runtime: createRuntime(session), lastUsed: Date.now() });
   fixture.activeForkBaseLeafByChat.set("web:default:branch:prune", "leaf-1");
+  writeFileSync(join(ensureSessionDir("web:default:branch:prune"), ".branch-seed.json"), JSON.stringify({
+    version: 1,
+    parentSession: null,
+    sessionName: "Prune Me",
+    model: null,
+    thinkingLevel: null,
+    mode: "rotated_context",
+  }), "utf8");
 
   const archived = await fixture.manager.pruneChatBranch("web:default:branch:prune");
   expect(archived.archived_at).toBeTruthy();
   expect(fixture.pool.has("web:default:branch:prune")).toBe(false);
   expect(fixture.sidePool.has("web:default:branch:prune")).toBe(false);
   expect(fixture.activeForkBaseLeafByChat.has("web:default:branch:prune")).toBe(false);
+  // The deferred seed must survive prune — it is the only persisted copy of
+  // the forked context until the session is realized, and restoreChatBranch()
+  // must be able to pick it back up.
+  expect(hasDeferredBranchSeed("web:default:branch:prune")).toBe(true);
+  // Prune must also cancel any queued prewarm so a background realization
+  // cannot materialize a runtime for an archived chat.
+  expect(cancelled).toEqual(["web:default:branch:prune"]);
   expect(disposed).toBe(2);
 
   ws.cleanup();

--- a/runtime/test/agent-pool/session-manager.test.ts
+++ b/runtime/test/agent-pool/session-manager.test.ts
@@ -1,7 +1,22 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import { renameSync, writeFileSync } from "fs";
+import { join } from "path";
 
 import type { AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
+import { readDeferredBranchSeed, restoreClaimedDeferredBranchSeed, writeDeferredBranchSeed } from "../../src/agent-pool/branch-seeding.js";
+import { ensureSessionDir } from "../../src/agent-pool/session.js";
 import { AgentSessionManager } from "../../src/agent-pool/session-manager.js";
+import { createTempWorkspace, setEnv } from "../helpers.js";
+
+let restoreEnv: (() => void) | null = null;
+let cleanupWorkspace: (() => void) | null = null;
+
+afterEach(() => {
+  restoreEnv?.();
+  cleanupWorkspace?.();
+  restoreEnv = null;
+  cleanupWorkspace = null;
+});
 
 function createRuntime(session: any): AgentSessionRuntime {
   return {
@@ -197,4 +212,198 @@ test("AgentSessionManager serializes queued prewarms and honors priority orderin
   expect(maxConcurrentCreates).toBe(1);
 
   await fixture.manager.shutdown();
+});
+
+test("AgentSessionManager fails loudly and clears the cache when a deferred branch seed is invalid", async () => {
+  const ws = createTempWorkspace("piclaw-session-manager-invalid-seed-");
+  cleanupWorkspace = ws.cleanup;
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  let createCalls = 0;
+  let disposed = 0;
+  const fixture = createManager({
+    createSession: async () => {
+      createCalls += 1;
+      return createRuntime({
+        dispose() {
+          disposed += 1;
+        },
+      });
+    },
+  });
+
+  const chatJid = "web:broken-branch";
+  writeFileSync(join(ensureSessionDir(chatJid), ".branch-seed.json"), "{not-json", "utf8");
+
+  await expect(fixture.manager.getOrCreate(chatJid)).rejects.toThrow("Invalid deferred branch seed");
+  await expect(fixture.manager.getOrCreate(chatJid)).rejects.toThrow("Invalid deferred branch seed");
+  expect(fixture.pool.has(chatJid)).toBe(false);
+  expect(createCalls).toBe(1);
+  expect(disposed).toBe(1);
+  fixture.manager.prewarm(chatJid);
+  expect(createCalls).toBe(1);
+});
+
+test("AgentSessionManager disposes an existing runtime and restores its deferred seed when realization fails", async () => {
+  const ws = createTempWorkspace("piclaw-session-manager-broken-realize-");
+  cleanupWorkspace = ws.cleanup;
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  let disposed = 0;
+  const runtime = createRuntime({
+    dispose() {
+      disposed += 1;
+    },
+  });
+  runtime.newSession = async () => {
+    throw new Error("seed replay failed");
+  };
+
+  const fixture = createManager();
+  const chatJid = "web:seeded-branch";
+  fixture.pool.set(chatJid, { runtime, lastUsed: Date.now() });
+  writeFileSync(join(ensureSessionDir(chatJid), ".branch-seed.json"), JSON.stringify({
+    version: 1,
+    parentSession: null,
+    sessionName: "Seeded",
+    model: null,
+    thinkingLevel: null,
+    mode: "rotated_context",
+  }), "utf8");
+
+  await expect(fixture.manager.getOrCreate(chatJid)).rejects.toThrow("seed replay failed");
+  expect(fixture.pool.has(chatJid)).toBe(false);
+  expect(disposed).toBe(1);
+  expect(readDeferredBranchSeed(chatJid)?.sessionName).toBe("Seeded");
+});
+
+test("AgentSessionManager clears cached invalid-seed errors after the seed file is rewritten", async () => {
+  const ws = createTempWorkspace("piclaw-session-manager-invalid-seed-rewrite-");
+  cleanupWorkspace = ws.cleanup;
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  let createCalls = 0;
+  const fixture = createManager({
+    createSession: async (_chatJid: string, sessionDir: string) => {
+      createCalls += 1;
+      return createRuntime({
+        sessionFile: join(sessionDir, "session.jsonl"),
+        sessionManager: {
+          getHeader: () => ({ type: "session_header" }),
+          getEntries: () => [],
+        },
+        setSessionName() {},
+        dispose() {},
+      });
+    },
+  });
+
+  const chatJid = "web:rewritten-branch";
+  writeFileSync(join(ensureSessionDir(chatJid), ".branch-seed.json"), "{not-json", "utf8");
+  await expect(fixture.manager.getOrCreate(chatJid)).rejects.toThrow("Invalid deferred branch seed");
+
+  writeDeferredBranchSeed(chatJid, {
+    version: 1,
+    parentSession: null,
+    sessionName: "Recovered",
+    model: null,
+    thinkingLevel: null,
+    mode: "rotated_context",
+  });
+
+  await expect(fixture.manager.getOrCreate(chatJid)).resolves.toBeTruthy();
+  expect(createCalls).toBe(2);
+});
+
+test("AgentSessionManager disposes a broken existing runtime only once across concurrent callers", async () => {
+  const ws = createTempWorkspace("piclaw-session-manager-single-dispose-");
+  cleanupWorkspace = ws.cleanup;
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  let disposed = 0;
+  const runtime = createRuntime({
+    dispose() {
+      disposed += 1;
+    },
+  });
+  runtime.newSession = async () => {
+    throw new Error("seed replay failed");
+  };
+
+  const fixture = createManager();
+  const chatJid = "web:concurrent-broken-branch";
+  fixture.pool.set(chatJid, { runtime, lastUsed: Date.now() });
+  writeDeferredBranchSeed(chatJid, {
+    version: 1,
+    parentSession: null,
+    sessionName: "Broken",
+    model: null,
+    thinkingLevel: null,
+    mode: "rotated_context",
+  });
+
+  const [first, second] = await Promise.allSettled([
+    fixture.manager.getOrCreate(chatJid),
+    fixture.manager.getOrCreate(chatJid),
+  ]);
+
+  expect(first.status).toBe("rejected");
+  expect(second.status).toBe("rejected");
+  expect(disposed).toBe(1);
+});
+
+test("AgentSessionManager priority prewarms bypass the recent-chat cooldown and prune expired entries", async () => {
+  const fixture = createManager({
+    createSession: async () => createRuntime({ dispose() {} }),
+  });
+  const originalDateNow = Date.now;
+  Date.now = () => 100_000;
+
+  try {
+    (fixture.manager as any).prewarmCooldownByChat.set("web:recent", 99_500);
+    expect(fixture.manager.prewarm("web:recent")).toBe(false);
+    expect(fixture.manager.prewarm("web:recent", { priority: true })).toBe(true);
+
+    (fixture.manager as any).queuedPrewarms.clear();
+    (fixture.manager as any).prewarmQueue.length = 0;
+    (fixture.manager as any).prewarmCooldownByChat.set("web:stale", 69_000);
+    expect(fixture.manager.prewarm("web:fresh")).toBe(true);
+    expect((fixture.manager as any).prewarmCooldownByChat.has("web:stale")).toBe(false);
+  } finally {
+    Date.now = originalDateNow;
+    await fixture.manager.shutdown();
+  }
+});
+
+test("restoreClaimedDeferredBranchSeed preserves a newer primary seed written after claim", () => {
+  const ws = createTempWorkspace("piclaw-restore-claimed-seed-");
+  cleanupWorkspace = ws.cleanup;
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  const chatJid = "web:claimed-seed";
+  const sessionDir = ensureSessionDir(chatJid);
+  const primaryPath = join(sessionDir, ".branch-seed.json");
+  const claimedPath = join(sessionDir, ".branch-seed.claimed.json");
+
+  writeDeferredBranchSeed(chatJid, {
+    version: 1,
+    parentSession: null,
+    sessionName: "Older",
+    model: null,
+    thinkingLevel: null,
+    mode: "rotated_context",
+  });
+  renameSync(primaryPath, claimedPath);
+  writeDeferredBranchSeed(chatJid, {
+    version: 1,
+    parentSession: null,
+    sessionName: "Newer",
+    model: null,
+    thinkingLevel: null,
+    mode: "rotated_context",
+  });
+
+  restoreClaimedDeferredBranchSeed(chatJid);
+
+  expect(readDeferredBranchSeed(chatJid)?.sessionName).toBe("Newer");
 });


### PR DESCRIPTION
Refresh of #51 with reviewer feedback addressed:

- **Preserve deferred fork seed across prune.** `pruneChatBranch` no longer calls `clearDeferredBranchSeed`. `.branch-seed.json` is the only persisted copy of the forked context until realization, so a later `restoreChatBranch()` must be able to pick it back up.
- **Cancel queued warmup on prune.** New `AgentSessionManager.cancelPrewarm()` is invoked from `pruneChatBranch` via a new `cancelSessionWarmup` option on `AgentBranchManagerOptions`. Without this, a queued prewarm could realize the seed for an archived chat after the user pruned it.
- **Prefer live branch name over seed's captured name at realization.** If the user renames a forked branch before its deferred seed has been realized, `seed.sessionName` is stale. The realization now reads `getChatBranchByChatJid(chatJid).agent_name` first and only falls back to the seed.

Tests: `AgentBranchManager prunes inactive branches…` now asserts the seed survives and that `cancelSessionWarmup` is invoked. Full agent-pool/runtime/db test suite passes.