### PR TITLE
perf(agent): warm recent chats from branch refreshes

### DIFF
--- a/runtime/src/agent-pool.ts
+++ b/runtime/src/agent-pool.ts
@@ -56,6 +56,7 @@ import {
   type SshConfigSetResult,
   deleteSshConfig,
   getSshConfig,
+  listRecentChatJids,
   upsertSshConfig,
 } from "./db.js";
 import { setSshToolHandlers } from "./extensions/ssh.js";
@@ -115,6 +116,7 @@ export class AgentPool {
   private sidePool = new Map<string, PoolEntry>();
   private activeForkBaseLeafByChat = new Map<string, string | null>();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+  private shuttingDown = false;
 
   // Shared across all sessions (expensive to create, safe to reuse)
   private authStorage: AuthStorage;
@@ -256,6 +258,66 @@ export class AgentPool {
     percent: number | null;
   } | null> {
     return this.runtimeFacade.getContextUsageForChat(chatJid);
+  }
+
+  scheduleRecentChatWarmup(options: { limit?: number; excludeChatJids?: string[] } = {}): string[] {
+    if (this.shuttingDown) return [];
+    const targetCount = Math.max(1, Math.min(8, Math.trunc(options.limit ?? 3) || 3));
+    const excluded = new Set(
+      Array.isArray(options.excludeChatJids)
+        ? options.excludeChatJids.map((jid) => String(jid || "").trim()).filter(Boolean)
+        : [],
+    );
+    const cooldownByChat = ((this as any).__piclawRecentWarmupCooldownByChat ||= new Map<string, number>()) as Map<string, number>;
+    const now = Date.now();
+    for (const [chatJid, lastQueuedAt] of cooldownByChat) {
+      if (now - lastQueuedAt >= 30_000) {
+        cooldownByChat.delete(chatJid);
+      }
+    }
+
+    const scheduled: string[] = [];
+    const seen = new Set<string>();
+    let fetchLimit = Math.min(100, Math.max(targetCount * 4, targetCount));
+
+    while (scheduled.length < targetCount) {
+      const candidates = listRecentChatJids(fetchLimit, {
+        excludeChatJids: [...excluded, ...seen],
+      });
+      for (const chatJid of candidates) {
+        if (seen.has(chatJid)) continue;
+        seen.add(chatJid);
+        if (excluded.has(chatJid)) continue;
+        if (this.pool.has(chatJid)) continue;
+        if (now - (cooldownByChat.get(chatJid) ?? 0) < 30_000) continue;
+        scheduled.push(chatJid);
+        if (scheduled.length >= targetCount) break;
+      }
+
+      if (scheduled.length >= targetCount || fetchLimit >= 100 || candidates.length < fetchLimit) {
+        break;
+      }
+
+      const nextFetchLimit = Math.min(100, fetchLimit * 2);
+      if (nextFetchLimit === fetchLimit) {
+        break;
+      }
+      fetchLimit = nextFetchLimit;
+    }
+
+    // Only record a cooldown / return chats that actually entered the prewarm
+    // queue. prewarm() may reject a candidate (already queued, in flight, or
+    // within its per-chat cooldown) and we must not consume a slot or suppress
+    // backfill for those.
+    const actuallyScheduled: string[] = [];
+    for (const chatJid of scheduled) {
+      if (this.sessionManager.prewarm(chatJid)) {
+        cooldownByChat.set(chatJid, now);
+        actuallyScheduled.push(chatJid);
+      }
+    }
+
+    return actuallyScheduled;
   }
 
   scheduleChatWarmup(chatJid: string, options: { priority?: boolean } = {}): boolean {
@@ -406,6 +468,7 @@ export class AgentPool {
 
   /** Gracefully shut down all sessions. */
   async shutdown(): Promise<void> {
+    this.shuttingDown = true;
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;

--- a/runtime/src/channels/web/endpoints/channel-endpoint-facade-service.ts
+++ b/runtime/src/channels/web/endpoints/channel-endpoint-facade-service.ts
@@ -194,9 +194,47 @@ export class WebChannelEndpointFacadeService {
       const includeArchived = ["1", "true", "yes", "on"].includes(
         String(url.searchParams.get("include_archived") || "").trim().toLowerCase(),
       );
+      const prewarmRecent = ["1", "true", "yes", "on"].includes(
+        String(url.searchParams.get("prewarm_recent") || "").trim().toLowerCase(),
+      );
+      const prewarmLimitRaw = Number.parseInt(String(url.searchParams.get("prewarm_limit") || "").trim(), 10);
+      const prewarmLimit = Number.isFinite(prewarmLimitRaw)
+        ? Math.max(1, Math.min(8, prewarmLimitRaw))
+        : 3;
+      const excludeChatJid = typeof url.searchParams.get("exclude_chat_jid") === "string"
+        ? url.searchParams.get("exclude_chat_jid")!.trim()
+        : "";
+      const prewarmChatJid = typeof url.searchParams.get("prewarm_chat_jid") === "string"
+        ? url.searchParams.get("prewarm_chat_jid")!.trim()
+        : "";
+
       const chats = typeof this.options.listKnownChats === "function"
         ? this.options.listKnownChats(rootChatJid || null, { includeArchived })
         : this.options.listActiveChats();
+      const knownChatJids = typeof this.options.listKnownChats === "function"
+        ? new Set(
+            chats
+              .map((chat) => (typeof (chat as { chat_jid?: unknown })?.chat_jid === "string" ? (chat as { chat_jid: string }).chat_jid.trim() : ""))
+              .filter(Boolean),
+          )
+        : null;
+
+      // Reserve the priority warmup slot before queueing the recent batch so the
+      // explicit `prewarm_chat_jid` is not shadowed by an earlier recent enqueue
+      // (AgentSessionManager.prewarm rejects a later priority call for a chat
+      // that is already queued as a normal warmup).
+      if (prewarmChatJid && knownChatJids?.has(prewarmChatJid)) {
+        this.options.agentPool.scheduleChatWarmup(prewarmChatJid, { priority: true });
+      }
+      if (!rootChatJid && prewarmRecent) {
+        this.options.agentPool.scheduleRecentChatWarmup({
+          limit: prewarmLimit,
+          excludeChatJids: [
+            ...(excludeChatJid ? [excludeChatJid] : []),
+            ...(prewarmChatJid ? [prewarmChatJid] : []),
+          ],
+        });
+      }
       return this.options.json({ chats }, 200);
     });
     return appendServerTiming(result, {

--- a/runtime/src/db.ts
+++ b/runtime/src/db.ts
@@ -21,6 +21,7 @@ export {
 } from "./db/chat-branches.js";
 export {
   storeChatMetadata,
+  listRecentChatJids,
   storeMessage,
   getMessageByRowId,
   getMessageByAnyRowId,

--- a/runtime/src/db/messages.ts
+++ b/runtime/src/db/messages.ts
@@ -130,6 +130,29 @@ export function storeChatMetadata(chatJid: string, timestamp: string, name?: str
   });
 }
 
+export function listRecentChatJids(limit = 10, options?: { excludeChatJids?: string[] }): string[] {
+  const maxRows = Math.max(1, Math.min(100, Math.trunc(limit) || 10));
+  const excluded = Array.isArray(options?.excludeChatJids)
+    ? options.excludeChatJids.map((jid) => String(jid || "").trim()).filter(Boolean).slice(0, 900)
+    : [];
+  const db = getDb();
+  const exclusionSql = excluded.length > 0
+    ? ` AND c.jid NOT IN (${excluded.map(() => "?").join(", ")})`
+    : "";
+  const rows = db.prepare(
+    `SELECT c.jid AS chat_jid
+       FROM chats c
+       LEFT JOIN chat_branches b ON b.chat_jid = c.jid
+      WHERE (b.chat_jid IS NULL OR b.archived_at IS NULL)${exclusionSql}
+      ORDER BY c.last_message_time DESC, c.jid ASC
+      LIMIT ?`
+  ).all(...excluded, maxRows) as Array<{ chat_jid: string | null | undefined }>;
+
+  return rows
+    .map((row) => (typeof row.chat_jid === "string" ? row.chat_jid.trim() : ""))
+    .filter(Boolean);
+}
+
 /**
  * Persist a message into the `messages` table (INSERT OR REPLACE).
  * Returns the SQLite rowid of the inserted row (used as the interaction id

--- a/runtime/test/agent-pool/agent-pool.test.ts
+++ b/runtime/test/agent-pool/agent-pool.test.ts
@@ -290,6 +290,97 @@ test("agent pool evicts idle sessions and recreates them", async () => {
   await pool.shutdown();
 });
 
+test("agent pool schedules warmup for the most recent inactive chats", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  const db = await importFresh<typeof import("../src/db.js")>("../src/db.js");
+  db.initDatabase();
+  db.storeChatMetadata("web:older", "2026-04-14T10:00:00.000Z", "Older");
+  db.storeChatMetadata("web:newer", "2026-04-14T11:00:00.000Z", "Newer");
+  db.storeChatMetadata("web:newest", "2026-04-14T12:00:00.000Z", "Newest");
+
+  const { AgentPool } = await importFresh<typeof import("../src/agent-pool.js")>("../src/agent-pool.js");
+
+  const created: string[] = [];
+  class StubSession {
+    subscribe(_listener: (event: any) => void) {
+      return () => {};
+    }
+    async prompt(_prompt: string) {}
+    async abort() {}
+    dispose() {}
+  }
+
+  const pool = new AgentPool({
+    createSession: async (chatJid: string) => {
+      created.push(chatJid);
+      return createRuntime(new StubSession()) as any;
+    },
+  });
+
+  const scheduled = (pool as any).scheduleRecentChatWarmup({
+    limit: 2,
+    excludeChatJids: ["web:default", "web:newest"],
+  });
+  expect(scheduled).toEqual(["web:newer", "web:older"]);
+
+  await Bun.sleep(20);
+  expect(created).toEqual(["web:newer", "web:older"]);
+
+  await pool.shutdown();
+});
+
+test("agent pool keeps expanding recent-chat warmup past already-warm top rows", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  const db = await importFresh<typeof import("../src/db.js")>("../src/db.js");
+  db.initDatabase();
+  const baseTimeMs = Date.parse("2026-04-14T23:59:00.000Z");
+  for (let index = 0; index < 101; index += 1) {
+    const chatJid = `web:chat-${String(index).padStart(3, "0")}`;
+    db.storeChatMetadata(chatJid, new Date(baseTimeMs - index * 60_000).toISOString(), `Chat ${index}`);
+  }
+
+  const { AgentPool } = await importFresh<typeof import("../src/agent-pool.js")>("../src/agent-pool.js");
+  const pool = new AgentPool({
+    createSession: async () => createRuntime({ subscribe: () => () => {}, prompt: async () => {}, abort: async () => {}, dispose() {} }) as any,
+  });
+
+  for (let index = 0; index < 100; index += 1) {
+    const chatJid = `web:chat-${String(index).padStart(3, "0")}`;
+    (pool as any).pool.set(chatJid, { runtime: createRuntime({ dispose() {} }), lastUsed: Date.now() });
+  }
+
+  const scheduled = (pool as any).scheduleRecentChatWarmup({ limit: 1, excludeChatJids: ["web:default"] });
+  expect(scheduled).toEqual(["web:chat-100"]);
+
+  await pool.shutdown();
+});
+
+test("agent pool rate-limits repeated recent-chat warmup for the same chat", async () => {
+  const ws = createTempWorkspace("piclaw-recent-warmup-cooldown-");
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  const db = await importFresh<typeof import("../src/db.js")>("../src/db.js");
+  db.initDatabase();
+  db.storeChatMetadata("web:only", "2026-04-14T12:00:00.000Z", "Only");
+
+  const { AgentPool } = await importFresh<typeof import("../src/agent-pool.js")>("../src/agent-pool.js");
+  const pool = new AgentPool({
+    createSession: async () => createRuntime({ subscribe: () => () => {}, prompt: async () => {}, abort: async () => {}, dispose() {} }) as any,
+  });
+
+  const first = (pool as any).scheduleRecentChatWarmup({ limit: 1, excludeChatJids: ["web:default"] });
+  const second = (pool as any).scheduleRecentChatWarmup({ limit: 1, excludeChatJids: ["web:default"] });
+
+  expect(first).toEqual(["web:only"]);
+  expect(second).toEqual([]);
+
+  await pool.shutdown();
+});
+
 test("agent pool can run a side prompt with the current model and thinking level", async () => {
   const ws = getTestWorkspace();
   restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });

--- a/runtime/test/channels/web/endpoints/channel-endpoint-facade-service.test.ts
+++ b/runtime/test/channels/web/endpoints/channel-endpoint-facade-service.test.ts
@@ -71,11 +71,23 @@ function createFacade(getIdentitySnapshot: () => WebChannelIdentitySnapshot) {
 
   const ensureCalls: string[] = [];
   const postCalls: Array<{ isReply: boolean; chatJid: string }> = [];
+  const scheduledWarmups: Array<{ limit?: number; excludeChatJids?: string[] }> = [];
+  const scheduledPriorityWarmups: string[] = [];
   const activeChats = [{ chat_jid: "web:default", agent_name: "Pi" }];
   const knownChats = [{ chat_jid: "web:branch", agent_name: "Branch" }];
   const options: WebChannelEndpointFacadeOptions = {
     endpointContexts: contexts,
     defaultChatJid: "web:default",
+    agentPool: {
+      scheduleRecentChatWarmup: (input: { limit?: number; excludeChatJids?: string[] }) => {
+        scheduledWarmups.push(input);
+        return [];
+      },
+      scheduleChatWarmup: (chatJid: string) => {
+        scheduledPriorityWarmups.push(chatJid);
+        return true;
+      },
+    } as unknown as AgentPool,
     getIdentitySnapshot,
     ensureAvatarCache: async (_kind, source) => {
       ensureCalls.push(source);
@@ -95,6 +107,8 @@ function createFacade(getIdentitySnapshot: () => WebChannelIdentitySnapshot) {
     facade: new WebChannelEndpointFacadeService(options),
     ensureCalls,
     postCalls,
+    scheduledWarmups,
+    scheduledPriorityWarmups,
     activeChats,
     knownChats,
   };
@@ -178,5 +192,28 @@ describe("web channel endpoint facade service", () => {
     );
     expect(branchesResponse.status).toBe(200);
     expect(await branchesResponse.json()).toEqual({ chats: knownChats });
+  });
+
+  test("can schedule recent-chat warmup from the branches endpoint without changing payload shape", async () => {
+    const { facade, knownChats, scheduledWarmups } = createFacade(() => createIdentitySnapshot());
+
+    const branchesResponse = facade.handleAgentBranches(
+      new Request("https://example.com/agent/branches?include_archived=1&prewarm_recent=1&prewarm_limit=4&exclude_chat_jid=web%3Adefault")
+    );
+    expect(branchesResponse.status).toBe(200);
+    expect(await branchesResponse.json()).toEqual({ chats: knownChats });
+    expect(scheduledWarmups).toEqual([{ limit: 4, excludeChatJids: ["web:default"] }]);
+  });
+
+  test("can schedule a validated priority warmup for the currently opened chat", async () => {
+    const { facade, scheduledPriorityWarmups } = createFacade(() => createIdentitySnapshot());
+
+    const response = facade.handleAgentBranches(
+      new Request("https://example.com/agent/branches?prewarm_chat_jid=web%3Abranch")
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ chats: [{ chat_jid: "web:branch", agent_name: "Branch" }] });
+    expect(scheduledPriorityWarmups).toEqual(["web:branch"]);
   });
 });


### PR DESCRIPTION
Refresh of #54 with reviewer feedback addressed:

- **Reserve `prewarm_chat_jid` priority slot before enqueueing recent batch.** The facade now calls `scheduleChatWarmup(..., { priority: true })` before `scheduleRecentChatWarmup(...)` and excludes the priority chat from the recent-batch candidates. Previously a recent enqueue could win the queue first and the later priority call would be rejected as already-queued.
- **Only count chats that actually entered the prewarm queue.** `scheduleRecentChatWarmup` now checks `sessionManager.prewarm()`'s return value before setting the cooldown / counting the slot. Previously a rejected candidate still consumed a slot and suppressed backfill.

Full agent-pool test suite passes.