### PR TITLE
fix(web): force SSE reconnect after iOS resume

### DIFF
--- a/runtime/test/web/use-sse-connection.test.ts
+++ b/runtime/test/web/use-sse-connection.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from 'bun:test';
+
+import { bindSseWakeLifecycle } from '../../web/src/ui/use-sse-connection.js';
+
+function createEventTarget() {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+  return {
+    addEventListener(type: string, listener: (...args: any[]) => void) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(listener);
+    },
+    removeEventListener(type: string, listener: (...args: any[]) => void) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) || []) {
+        listener({ type });
+      }
+    },
+    count(type: string) {
+      return listeners.get(type)?.size || 0;
+    },
+  };
+}
+
+test('bindSseWakeLifecycle reconnects on focus but does not wake on visible-only churn when focus reconnect is enabled', () => {
+  const win = createEventTarget() as any;
+  const doc = createEventTarget() as any;
+  doc.visibilityState = 'visible';
+
+  let reconnects = 0;
+  let wakes = 0;
+  const dispose = bindSseWakeLifecycle({
+    sse: {
+      reconnectIfNeeded() {
+        reconnects += 1;
+      },
+    },
+    onWake() {
+      wakes += 1;
+    },
+  }, {
+    window: win,
+    document: doc,
+    useFocusReconnect: true,
+  });
+
+  win.dispatch('focus');
+  win.dispatch('pageshow');
+  doc.dispatch('visibilitychange');
+
+  expect(reconnects).toBe(1);
+  expect(wakes).toBe(0);
+
+  dispose();
+  expect(win.count('focus')).toBe(0);
+  expect(win.count('pageshow')).toBe(0);
+  expect(doc.count('visibilitychange')).toBe(0);
+});
+
+test('bindSseWakeLifecycle reconnects and wakes once after a real return without raw focus reconnect on iOS-style paths', () => {
+  const win = createEventTarget() as any;
+  const doc = createEventTarget() as any;
+  doc.visibilityState = 'visible';
+
+  let now = 1000;
+  let reconnects = 0;
+  let forcedReconnects = 0;
+  let wakes = 0;
+  const dispose = bindSseWakeLifecycle({
+    sse: {
+      reconnectIfNeeded() {
+        reconnects += 1;
+      },
+      forceReconnect() {
+        forcedReconnects += 1;
+      },
+    },
+    onWake() {
+      wakes += 1;
+    },
+  }, {
+    window: win,
+    document: doc,
+    now: () => now,
+    minHiddenMs: 150,
+    dedupeMs: 1000,
+    useFocusReconnect: false,
+  });
+
+  doc.visibilityState = 'hidden';
+  doc.dispatch('visibilitychange');
+  now += 175;
+  doc.visibilityState = 'visible';
+  win.dispatch('pageshow');
+  doc.dispatch('visibilitychange');
+
+  expect(reconnects).toBe(0);
+  expect(forcedReconnects).toBe(1);
+  expect(wakes).toBe(1);
+
+  dispose();
+});

--- a/runtime/web/src/ui/use-sse-connection.ts
+++ b/runtime/web/src/ui/use-sse-connection.ts
@@ -1,6 +1,74 @@
 // @ts-nocheck
 import { useEffect, useRef } from '../vendor/preact-htm.js';
 import { SSEClient } from '../api.js';
+import { isIOSDevice } from './app-helpers.js';
+
+export function bindSseWakeLifecycle({ sse, onWake }, runtime = {}) {
+  const win = runtime.window ?? (typeof window !== 'undefined' ? window : null);
+  const doc = runtime.document ?? (typeof document !== 'undefined' ? document : null);
+  if (!win || !doc || !sse) {
+    return () => {};
+  }
+
+  const reconnectAfterReturn = () => {
+    if (typeof sse.forceReconnect === 'function') {
+      sse.forceReconnect();
+      return;
+    }
+    sse.reconnectIfNeeded();
+  };
+
+  const shouldUseFocusReconnect = typeof runtime.useFocusReconnect === 'boolean'
+    ? runtime.useFocusReconnect
+    : !isIOSDevice();
+  let pendingWake = doc.visibilityState && doc.visibilityState !== 'visible';
+
+  const handleHiddenState = () => {
+    if (doc.visibilityState && doc.visibilityState !== 'visible') {
+      pendingWake = true;
+      return true;
+    }
+    return false;
+  };
+
+  const handleVisibleReturn = () => {
+    if (handleHiddenState()) return;
+    if (pendingWake) {
+      pendingWake = false;
+      reconnectAfterReturn();
+      onWake?.();
+    }
+  };
+
+  const handleWindowFocus = () => {
+    if (handleHiddenState()) return;
+    if (pendingWake) {
+      handleVisibleReturn();
+      return;
+    }
+    if (shouldUseFocusReconnect) {
+      sse.reconnectIfNeeded();
+    }
+  };
+
+  const handlePageShow = () => {
+    handleVisibleReturn();
+  };
+
+  const handleVisibilityChange = () => {
+    handleVisibleReturn();
+  };
+
+  win.addEventListener('focus', handleWindowFocus);
+  win.addEventListener('pageshow', handlePageShow);
+  doc.addEventListener('visibilitychange', handleVisibilityChange);
+
+  return () => {
+    win.removeEventListener('focus', handleWindowFocus);
+    win.removeEventListener('pageshow', handlePageShow);
+    doc.removeEventListener('visibilitychange', handleVisibilityChange);
+  };
+}
 
 /**
  * Manages the SSE connection lifecycle.
@@ -31,19 +99,13 @@ export function useSseConnection({ handleSseEvent, handleConnectionStatusChange,
     );
     sse.connect();
 
-    const handleWindowFocus = () => {
-      sse.reconnectIfNeeded();
-      const doc = typeof document !== 'undefined' ? document : null;
-      if (!doc || doc.visibilityState === 'visible') {
-        onWakeRef.current?.();
-      }
-    };
-    window.addEventListener('focus', handleWindowFocus);
-    document.addEventListener('visibilitychange', handleWindowFocus);
+    const disposeWakeLifecycle = bindSseWakeLifecycle({
+      sse,
+      onWake: () => onWakeRef.current?.(),
+    });
 
     return () => {
-      window.removeEventListener('focus', handleWindowFocus);
-      document.removeEventListener('visibilitychange', handleWindowFocus);
+      disposeWakeLifecycle();
       sse.disconnect();
     };
   }, [chatJid]);


### PR DESCRIPTION
Fixes an iOS PWA resume regression where the web UI could return from background with a dead SSE stream and never reopen it.

## Problem

On iPhone/iPad Safari PWA paths, the browser can resume with an `EventSource` that is effectively dead while the frontend still believes it is connected. In that state, `reconnectIfNeeded()` is a no-op and the chat never starts receiving realtime events again until a manual refresh.

## Fix

- add a small `bindSseWakeLifecycle()` helper in `runtime/web/src/ui/use-sse-connection.ts`
- keep desktop-style focus reconnects for normal visible churn
- on a real hidden → visible return, force a fresh SSE reconnect instead of relying on `reconnectIfNeeded()`
- add `pageshow` handling so Safari/PWA resume paths are covered
- add a regression test for the return-from-hidden path

## Tests

```bash
bun test test/web/use-sse-connection.test.ts test/web/app-resume.test.ts test/channels/web/web-sse-client.test.ts
```
