### PR TITLE
[codex] fix(skills): restore Proxmox lifecycle wrappers (SKL-01)

### DIFF
--- a/runtime/skills/operator/proxmox-management/proxmox-resume-vm.ts
+++ b/runtime/skills/operator/proxmox-management/proxmox-resume-vm.ts
@@ -37,28 +37,8 @@
  *   "role": "entrypoint"
  * }
  */
-/** Resume a Proxmox QEMU VM via the packaged helper. */
+/** Resume a Proxmox QEMU VM through the shared workflow layer. */
 
-import { resolve } from "path";
+import { runVmLifecycleScript } from "./proxmox-vm-lifecycle-lib.js";
 
-const vmid = process.env.PVE_VMID?.trim();
-if (!vmid) {
-  console.error("Missing required env var: PVE_VMID");
-  process.exit(2);
-}
-
-const args = [resolve(import.meta.dir, "../../scripts/proxmox.ts"), "vm", "resume", "--vmid", vmid, "--json"];
-if (process.env.PVE_BASE?.trim()) args.push("--base", process.env.PVE_BASE.trim());
-if (process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN?.trim()) args.push("--keychain", process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN.trim());
-if (process.env.PVE_TIMEOUT_SEC?.trim()) {
-  const secs = Number(process.env.PVE_TIMEOUT_SEC.trim());
-  if (Number.isFinite(secs) && secs > 0) args.push("--timeout-ms", String(Math.round(secs * 1000)));
-}
-
-const proc = Bun.spawnSync(["bun", ...args], {
-  cwd: process.cwd(),
-  stdout: "inherit",
-  stderr: "inherit",
-  env: process.env,
-});
-process.exit(proc.exitCode ?? 1);
+process.exit(await runVmLifecycleScript("vm.resume"));

--- a/runtime/skills/operator/proxmox-management/proxmox-start-vm.ts
+++ b/runtime/skills/operator/proxmox-management/proxmox-start-vm.ts
@@ -37,28 +37,8 @@
  *   "role": "entrypoint"
  * }
  */
-/** Start a Proxmox QEMU VM via the packaged helper. */
+/** Start a Proxmox QEMU VM through the shared workflow layer. */
 
-import { resolve } from "path";
+import { runVmLifecycleScript } from "./proxmox-vm-lifecycle-lib.js";
 
-const vmid = process.env.PVE_VMID?.trim();
-if (!vmid) {
-  console.error("Missing required env var: PVE_VMID");
-  process.exit(2);
-}
-
-const args = [resolve(import.meta.dir, "../../scripts/proxmox.ts"), "vm", "start", "--vmid", vmid, "--json"];
-if (process.env.PVE_BASE?.trim()) args.push("--base", process.env.PVE_BASE.trim());
-if (process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN?.trim()) args.push("--keychain", process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN.trim());
-if (process.env.PVE_TIMEOUT_SEC?.trim()) {
-  const secs = Number(process.env.PVE_TIMEOUT_SEC.trim());
-  if (Number.isFinite(secs) && secs > 0) args.push("--timeout-ms", String(Math.round(secs * 1000)));
-}
-
-const proc = Bun.spawnSync(["bun", ...args], {
-  cwd: process.cwd(),
-  stdout: "inherit",
-  stderr: "inherit",
-  env: process.env,
-});
-process.exit(proc.exitCode ?? 1);
+process.exit(await runVmLifecycleScript("vm.start"));

--- a/runtime/skills/operator/proxmox-management/proxmox-stop-vm.ts
+++ b/runtime/skills/operator/proxmox-management/proxmox-stop-vm.ts
@@ -37,29 +37,8 @@
  *   "role": "entrypoint"
  * }
  */
-/** Stop a Proxmox QEMU VM via the packaged helper. */
+/** Stop a Proxmox QEMU VM through the shared workflow layer. */
 
-import { resolve } from "path";
+import { runVmLifecycleScript } from "./proxmox-vm-lifecycle-lib.js";
 
-const vmid = process.env.PVE_VMID?.trim();
-if (!vmid) {
-  console.error("Missing required env var: PVE_VMID");
-  process.exit(2);
-}
-
-const args = [resolve(import.meta.dir, "../../scripts/proxmox.ts"), "vm", "stop", "--vmid", vmid, "--json"];
-if (process.env.PVE_BASE?.trim()) args.push("--base", process.env.PVE_BASE.trim());
-if (process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN?.trim()) args.push("--keychain", process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN.trim());
-if (process.env.PVE_FORCE?.trim() === "1") args.push("--force");
-if (process.env.PVE_TIMEOUT_SEC?.trim()) {
-  const secs = Number(process.env.PVE_TIMEOUT_SEC.trim());
-  if (Number.isFinite(secs) && secs > 0) args.push("--timeout-ms", String(Math.round(secs * 1000)));
-}
-
-const proc = Bun.spawnSync(["bun", ...args], {
-  cwd: process.cwd(),
-  stdout: "inherit",
-  stderr: "inherit",
-  env: process.env,
-});
-process.exit(proc.exitCode ?? 1);
+process.exit(await runVmLifecycleScript("vm.stop"));

--- a/runtime/skills/operator/proxmox-management/proxmox-vm-lifecycle-lib.ts
+++ b/runtime/skills/operator/proxmox-management/proxmox-vm-lifecycle-lib.ts
@@ -1,0 +1,70 @@
+import { runProxmoxWorkflow, type ProxmoxApiConfig, type ProxmoxWorkflowName } from "../../../src/proxmox/client.js";
+
+const DEFAULT_BASE_URL = "https://proxmox.example.com:8006/api2/json";
+const DEFAULT_TOKEN_KEYCHAIN = "proxmox/piclaw-management-token";
+
+type VmLifecycleWorkflow = Extract<ProxmoxWorkflowName, "vm.inspect" | "vm.start" | "vm.stop" | "vm.resume">;
+
+export interface VmLifecycleDeps {
+  runWorkflow?: typeof runProxmoxWorkflow;
+  writeStdout?: (text: string) => void;
+  writeStderr?: (text: string) => void;
+}
+
+function parsePositiveInteger(value: string | undefined): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (!/^[0-9]+$/.test(trimmed)) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function readTimeoutMs(env: NodeJS.ProcessEnv): number | undefined {
+  const timeoutSec = parsePositiveInteger(env.PVE_TIMEOUT_SEC);
+  return timeoutSec ? timeoutSec * 1000 : undefined;
+}
+
+function readAllowInsecureTls(env: NodeJS.ProcessEnv): boolean {
+  const raw = env.PVE_ALLOW_INSECURE_TLS ?? env.PICLAW_PROXMOX_ALLOW_INSECURE_TLS;
+  if (!raw?.trim()) return true;
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
+
+export function buildVmLifecycleConfig(env: NodeJS.ProcessEnv): ProxmoxApiConfig {
+  return {
+    base_url: env.PVE_BASE?.trim() || DEFAULT_BASE_URL,
+    api_token_keychain: env.PICLAW_PROXMOX_TOKEN_KEYCHAIN?.trim() || DEFAULT_TOKEN_KEYCHAIN,
+    allow_insecure_tls: readAllowInsecureTls(env),
+  };
+}
+
+export async function runVmLifecycleScript(
+  workflow: VmLifecycleWorkflow,
+  env: NodeJS.ProcessEnv = process.env,
+  deps: VmLifecycleDeps = {},
+): Promise<number> {
+  const writeStdout = deps.writeStdout ?? ((text: string) => process.stdout.write(text));
+  const writeStderr = deps.writeStderr ?? ((text: string) => process.stderr.write(text));
+  const runWorkflow = deps.runWorkflow ?? runProxmoxWorkflow;
+
+  const vmid = parsePositiveInteger(env.PVE_VMID);
+  if (!vmid) {
+    writeStderr("Missing required env var: PVE_VMID\n");
+    return 2;
+  }
+
+  try {
+    const timeoutMs = readTimeoutMs(env);
+    const result = await runWorkflow(buildVmLifecycleConfig(env), {
+      workflow,
+      vmid,
+      ...(timeoutMs ? { timeout_ms: timeoutMs } : {}),
+      ...(workflow === "vm.stop" && env.PVE_FORCE?.trim() === "1" ? { force: true } : {}),
+    });
+    writeStdout(`${JSON.stringify(result.result, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    writeStderr(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}

--- a/runtime/skills/operator/proxmox-management/proxmox-vm-status.ts
+++ b/runtime/skills/operator/proxmox-management/proxmox-vm-status.ts
@@ -37,38 +37,8 @@
  *   "role": "entrypoint"
  * }
  */
-/**
- * Wrapper around the packaged Proxmox helper for VM inspect/status output.
- *
- * Required env:
- * - PVE_VMID
- *
- * Optional env:
- * - PVE_BASE
- * - PVE_TIMEOUT_SEC
- * - PICLAW_PROXMOX_TOKEN_KEYCHAIN
- */
+/** Inspect a Proxmox QEMU VM through the shared workflow layer. */
 
-import { resolve } from "path";
+import { runVmLifecycleScript } from "./proxmox-vm-lifecycle-lib.js";
 
-const vmid = process.env.PVE_VMID?.trim();
-if (!vmid) {
-  console.error("Missing required env var: PVE_VMID");
-  process.exit(2);
-}
-
-const args = [resolve(import.meta.dir, "../../scripts/proxmox.ts"), "vm", "inspect", "--vmid", vmid, "--json"];
-if (process.env.PVE_BASE?.trim()) args.push("--base", process.env.PVE_BASE.trim());
-if (process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN?.trim()) args.push("--keychain", process.env.PICLAW_PROXMOX_TOKEN_KEYCHAIN.trim());
-if (process.env.PVE_TIMEOUT_SEC?.trim()) {
-  const secs = Number(process.env.PVE_TIMEOUT_SEC.trim());
-  if (Number.isFinite(secs) && secs > 0) args.push("--timeout-ms", String(Math.round(secs * 1000)));
-}
-
-const proc = Bun.spawnSync(["bun", ...args], {
-  cwd: process.cwd(),
-  stdout: "inherit",
-  stderr: "inherit",
-  env: process.env,
-});
-process.exit(proc.exitCode ?? 1);
+process.exit(await runVmLifecycleScript("vm.inspect"));

--- a/runtime/test/scripts/proxmox-vm-lifecycle.test.ts
+++ b/runtime/test/scripts/proxmox-vm-lifecycle.test.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runVmLifecycleScript } from "../../skills/operator/proxmox-management/proxmox-vm-lifecycle-lib.ts";
+
+test("runVmLifecycleScript delegates vm.inspect through the shared workflow client", async () => {
+  let seenConfig: Record<string, unknown> | null = null;
+  let seenInput: Record<string, unknown> | null = null;
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  const exitCode = await runVmLifecycleScript("vm.inspect", {
+    PVE_VMID: "117",
+    PVE_BASE: "https://pve.example.com:8006/api2/json",
+    PICLAW_PROXMOX_TOKEN_KEYCHAIN: "proxmox/custom",
+    PVE_TIMEOUT_SEC: "7",
+  } as NodeJS.ProcessEnv, {
+    runWorkflow: async (config, input) => {
+      seenConfig = config as Record<string, unknown>;
+      seenInput = input as Record<string, unknown>;
+      return {
+        workflow: "vm.inspect",
+        vmid: 117,
+        node: "pve",
+        result: {
+          status: { status: "running" },
+          config: { name: "vm117" },
+        },
+      } as any;
+    },
+    writeStdout: (text) => stdout.push(text),
+    writeStderr: (text) => stderr.push(text),
+  });
+
+  expect(exitCode).toBe(0);
+  expect(seenConfig).toEqual({
+    base_url: "https://pve.example.com:8006/api2/json",
+    api_token_keychain: "proxmox/custom",
+    allow_insecure_tls: true,
+  });
+  expect(seenInput).toEqual({
+    workflow: "vm.inspect",
+    vmid: 117,
+    timeout_ms: 7000,
+  });
+  expect(stdout.join("")).toContain('"name": "vm117"');
+  expect(stderr).toHaveLength(0);
+});
+
+test("runVmLifecycleScript forwards stop force and explicit TLS preference", async () => {
+  let seenConfig: Record<string, unknown> | null = null;
+  let seenInput: Record<string, unknown> | null = null;
+
+  const exitCode = await runVmLifecycleScript("vm.stop", {
+    PVE_VMID: "204",
+    PVE_FORCE: "1",
+    PVE_ALLOW_INSECURE_TLS: "0",
+  } as NodeJS.ProcessEnv, {
+    runWorkflow: async (config, input) => {
+      seenConfig = config as Record<string, unknown>;
+      seenInput = input as Record<string, unknown>;
+      return {
+        workflow: "vm.stop",
+        vmid: 204,
+        node: "pve",
+        result: { status: "stopped" },
+      } as any;
+    },
+    writeStdout: () => {},
+  });
+
+  expect(exitCode).toBe(0);
+  expect(seenConfig).toEqual({
+    base_url: "https://proxmox.example.com:8006/api2/json",
+    api_token_keychain: "proxmox/piclaw-management-token",
+    allow_insecure_tls: false,
+  });
+  expect(seenInput).toEqual({
+    workflow: "vm.stop",
+    vmid: 204,
+    force: true,
+  });
+});
+
+test("runVmLifecycleScript rejects missing vmid before invoking the workflow client", async () => {
+  let called = false;
+  const stderr: string[] = [];
+
+  const exitCode = await runVmLifecycleScript("vm.start", {} as NodeJS.ProcessEnv, {
+    runWorkflow: async () => {
+      called = true;
+      throw new Error("should not be reached");
+    },
+    writeStderr: (text) => stderr.push(text),
+  });
+
+  expect(exitCode).toBe(2);
+  expect(called).toBe(false);
+  expect(stderr.join("")).toContain("Missing required env var: PVE_VMID");
+});
+
+test("vm lifecycle wrappers load and fail through the shared workflow path instead of a missing helper", () => {
+  const base = mkdtempSync(join(tmpdir(), "piclaw-proxmox-wrapper-"));
+  const store = join(base, "store");
+  const data = join(base, "data");
+  mkdirSync(store, { recursive: true });
+  mkdirSync(data, { recursive: true });
+
+  try {
+    for (const script of [
+      "proxmox-vm-status.ts",
+      "proxmox-start-vm.ts",
+      "proxmox-stop-vm.ts",
+      "proxmox-resume-vm.ts",
+    ]) {
+      const proc = Bun.spawnSync(
+        ["bun", `runtime/skills/operator/proxmox-management/${script}`],
+        {
+          cwd: "/workspace/.tmp/piclaw-skl-01",
+          env: {
+            ...process.env,
+            PICLAW_WORKSPACE: base,
+            PICLAW_STORE: store,
+            PICLAW_DATA: data,
+            PICLAW_DB_IN_MEMORY: "1",
+            PICLAW_KEYCHAIN_KEY: "test-key",
+            PVE_VMID: "117",
+            PICLAW_PROXMOX_TOKEN_KEYCHAIN: "proxmox/missing",
+          },
+        },
+      );
+
+      const stderr = proc.stderr.toString();
+      expect(proc.exitCode).toBe(1);
+      expect(stderr).not.toContain("scripts/proxmox.ts");
+      expect(stderr).not.toContain("Cannot find module");
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
The Proxmox lifecycle wrappers in `runtime/skills/operator/proxmox-management/` still shelled out to a removed helper, so every invocation failed before reaching the shared runtime client.

This patch:
- adds a shared lifecycle helper in the skill directory that calls `runProxmoxWorkflow()` directly
- rewires `proxmox-vm-status.ts`, `proxmox-start-vm.ts`, `proxmox-stop-vm.ts`, and `proxmox-resume-vm.ts` to use that helper
- adds regression tests for request shaping plus subprocess smoke coverage for all four wrappers

## Validation
- `bun test runtime/test/scripts/proxmox-vm-lifecycle.test.ts runtime/test/proxmox/client.test.ts`
- `bun run typecheck`