### PR TITLE
[codex] fix(cli): stop global flags from consuming subcommands

### DIFF
--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -61,6 +61,12 @@ function getFlagValue(args: string[], flag: string): string | undefined {
   return value;
 }
 
+const CLI_SUBCOMMANDS = new Set(["keychain"]);
+
+function isCliSubcommand(value: string | undefined): boolean {
+  return typeof value === "string" && CLI_SUBCOMMANDS.has(value);
+}
+
 function consumeLeadingGlobalOptions(args: string[]): string[] {
   const remaining = [...args];
   while (remaining.length > 0) {
@@ -72,7 +78,7 @@ function consumeLeadingGlobalOptions(args: string[]): string[] {
     }
     if (current === "-w" || current === "--workspace" || current === "-p" || current === "--port" || current === "--host" || current === "--idle-timeout" || current === "--tls-cert" || current === "--tls-key") {
       remaining.shift();
-      if (remaining.length > 0 && !remaining[0]?.startsWith("-")) {
+      if (remaining.length > 0 && !remaining[0]?.startsWith("-") && !isCliSubcommand(remaining[0])) {
         remaining.shift();
       }
       continue;

--- a/runtime/test/cli-keychain.test.ts
+++ b/runtime/test/cli-keychain.test.ts
@@ -109,6 +109,28 @@ test("cli keychain command accepts leading global runtime flags", async () => {
   expect(() => JSON.parse(logs[logs.length - 1] || "[]")).not.toThrow();
 });
 
+test("cli keychain list survives value-taking flags without swallowing the subcommand", async () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: any[]) => {
+    logs.push(args.map(String).join(" "));
+  };
+
+  try {
+    const handledPort = await handleCliOptions(["-p", "keychain", "list"]);
+    const handledWorkspace = await handleCliOptions(["-w", "keychain", "list"]);
+    expect(handledPort).toBe(true);
+    expect(handledWorkspace).toBe(true);
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(logs.length).toBeGreaterThanOrEqual(2);
+  for (const output of logs.slice(-2)) {
+    expect(() => JSON.parse(output || "[]")).not.toThrow();
+  }
+});
+
 test("cli keychain errors when disabled", async () => {
   const restoreDisabled = setEnv({ PICLAW_KEYCHAIN_KEY: undefined, PICLAW_KEYCHAIN_KEY_FILE: undefined });
 


### PR DESCRIPTION
## Summary
Value-taking global flags such as `-p` and `-w` could consume `keychain` as a flag value, so commands like `piclaw -p keychain list` failed to route into the CLI subcommand handler.

This patch:
- teaches the leading global option parser to stop consuming values when the next token is a known CLI subcommand
- preserves existing support for leading runtime flags before `keychain`
- adds regression coverage for the exact `-p keychain list` and `-w keychain list` cases

## Validation
- `bun test runtime/test/cli-keychain.test.ts`
- `bun run typecheck`