### PR TITLE
[codex] fix(startup): keep WhatsApp pairing codes out of Pushover

### DIFF
--- a/runtime/src/runtime/bootstrap.ts
+++ b/runtime/src/runtime/bootstrap.ts
@@ -169,6 +169,7 @@ export async function bootstrapRuntime(deps: RuntimeBootstrapDeps): Promise<void
 
   const senders = deps.createRuntimeSenders(web, whatsapp, pushover);
   deps.startRuntimeWorkers(queue, agentPool, web, senders);
+  deps.queueStartupResumePendingIpc();
 
   await whatsapp.connect();
 

--- a/runtime/src/runtime/startup.ts
+++ b/runtime/src/runtime/startup.ts
@@ -197,6 +197,7 @@ export function createWhatsAppChannel(state: RuntimeState): WhatsAppChannel {
           type: "message",
           chatJid: "web:default",
           text: code,
+          noNudge: true,
         };
         const filePath = join(ipcDir, `${createUuid("pairing")}.json`);
         writeFileSync(filePath, JSON.stringify(payload));

--- a/runtime/test/runtime/bootstrap.test.ts
+++ b/runtime/test/runtime/bootstrap.test.ts
@@ -113,6 +113,7 @@ describe("runtime bootstrap", () => {
       "register-shutdown-signals",
       "create-senders",
       "start-workers",
+      "queue-startup-resume",
       "connect-whatsapp",
       "start-runtime-loop",
     ]);

--- a/runtime/test/runtime/startup.test.ts
+++ b/runtime/test/runtime/startup.test.ts
@@ -1,133 +1,53 @@
-import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-import { queueStartupSessionWarmup } from "../../src/runtime/startup.js";
-import { createTempWorkspace } from "../helpers.js";
+import { afterEach, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
-const TEST_SHELL = process.env.SHELL || "bash";
-const RUNTIME_DIR = join(import.meta.dir, "../..");
+import type { RuntimeState } from "../../src/runtime/state.js";
+import { createTempWorkspace, importFresh, setEnv, type TempWorkspace } from "../helpers.js";
 
-describe("runtime startup helpers", () => {
-  test("initializeRuntimeEnvironment seeds workspace skel files for direct installs", () => {
-    const ws = createTempWorkspace("piclaw-startup-");
+let restoreEnv: (() => void) | null = null;
+let tempWorkspace: TempWorkspace | null = null;
 
-    try {
-      const run = Bun.spawnSync({
-        cmd: [
-          TEST_SHELL,
-          "-lc",
-          "bun -e \"import { initializeRuntimeEnvironment } from './src/runtime/startup.js'; initializeRuntimeEnvironment({ loadTimestamps() {}, loadChats() {} });\"",
-        ],
-        cwd: RUNTIME_DIR,
-        env: {
-          ...process.env,
-          PICLAW_WORKSPACE: ws.workspace,
-          PICLAW_STORE: ws.store,
-          PICLAW_DATA: ws.data,
-          PICLAW_DB_IN_MEMORY: "1",
-        },
-      });
-      expect(run.exitCode, run.stderr.toString() || run.stdout.toString()).toBe(0);
+afterEach(() => {
+  restoreEnv?.();
+  restoreEnv = null;
+  tempWorkspace?.cleanup();
+  tempWorkspace = null;
+});
 
-      expect(existsSync(join(ws.workspace, "AGENTS.md"))).toBe(true);
-      expect(existsSync(join(ws.workspace, ".piclaw", "README.md"))).toBe(true);
-      expect(existsSync(join(ws.workspace, ".piclaw", "config.json.example"))).toBe(true);
-      expect(existsSync(join(ws.workspace, ".pi", "mcp.json.example"))).toBe(true);
-      expect(existsSync(join(ws.workspace, "notes", "index.md"))).toBe(true);
-      expect(existsSync(join(ws.workspace, "notes", "memory", "README.md"))).toBe(true);
-      expect(existsSync(join(ws.workspace, ".pi", "skills"))).toBe(true);
-    } finally {
-      ws.cleanup();
-    }
+test("createWhatsAppChannel writes pairing IPC payloads with noNudge enabled", async () => {
+  tempWorkspace = createTempWorkspace("piclaw-startup-pairing-");
+  restoreEnv = setEnv({
+    PICLAW_WORKSPACE: tempWorkspace.workspace,
+    PICLAW_STORE: tempWorkspace.store,
+    PICLAW_DATA: tempWorkspace.data,
+    WHATSAPP_PHONE: "+15551234567",
   });
 
-  test("queueStartupResumePendingIpc writes a resume_pending task", () => {
-    const ws = createTempWorkspace("piclaw-startup-");
+  const { createWhatsAppChannel } = await importFresh<typeof import("../../src/runtime/startup.js")>(
+    "../src/runtime/startup.js"
+  );
 
-    try {
-      const run = Bun.spawnSync({
-        cmd: [
-          TEST_SHELL,
-          "-lc",
-          "bun -e \"import { queueStartupResumePendingIpc } from './src/runtime/startup.js'; queueStartupResumePendingIpc();\"",
-        ],
-        cwd: RUNTIME_DIR,
-        env: {
-          ...process.env,
-          PICLAW_WORKSPACE: ws.workspace,
-          PICLAW_STORE: ws.store,
-          PICLAW_DATA: ws.data,
-          PICLAW_DB_IN_MEMORY: "1",
-        },
-      });
-      expect(run.exitCode).toBe(0);
+  const state = {
+    chatJids: new Set<string>(),
+    saveChats: () => {},
+  } as RuntimeState;
 
-      const tasksDir = join(ws.data, "ipc", "tasks");
-      const files = readdirSync(tasksDir).filter((file) => file.startsWith("resume_pending_"));
-      expect(files).toHaveLength(1);
+  const channel = createWhatsAppChannel(state);
+  const onPairingCode = (channel as any).opts?.onPairingCode as ((code: string) => void) | undefined;
+  expect(typeof onPairingCode).toBe("function");
 
-      const payload = JSON.parse(readFileSync(join(tasksDir, files[0]), "utf-8"));
-      expect(payload).toEqual({ type: "resume_pending", chatJid: "all", reason: "startup" });
-    } finally {
-      ws.cleanup();
-    }
-  });
+  onPairingCode?.("123-456");
 
-  test("queueStartupResumePendingIpc always queues a fresh startup resume task", () => {
-    const ws = createTempWorkspace("piclaw-startup-");
+  const ipcDir = join(tempWorkspace.data, "ipc", "messages");
+  const [fileName] = readdirSync(ipcDir);
+  expect(fileName).toBeTruthy();
 
-    try {
-      const tasksDir = join(ws.data, "ipc", "tasks");
-      mkdirSync(tasksDir, { recursive: true });
-      writeFileSync(
-        join(tasksDir, "resume_pending_existing.json"),
-        JSON.stringify({ type: "resume_pending", chatJid: "all", reason: "reload" })
-      );
-
-      const run = Bun.spawnSync({
-        cmd: [
-          TEST_SHELL,
-          "-lc",
-          "bun -e \"import { queueStartupResumePendingIpc } from './src/runtime/startup.js'; queueStartupResumePendingIpc();\"",
-        ],
-        cwd: RUNTIME_DIR,
-        env: {
-          ...process.env,
-          PICLAW_WORKSPACE: ws.workspace,
-          PICLAW_STORE: ws.store,
-          PICLAW_DATA: ws.data,
-          PICLAW_DB_IN_MEMORY: "1",
-        },
-      });
-      expect(run.exitCode).toBe(0);
-
-      const files = readdirSync(tasksDir)
-        .filter((file) => file.startsWith("resume_pending_"))
-        .sort();
-      expect(files.length).toBe(2);
-      expect(files).toContain("resume_pending_existing.json");
-      expect(files.some((file) => file !== "resume_pending_existing.json")).toBe(true);
-    } finally {
-      ws.cleanup();
-    }
-  });
-
-  test("queueStartupSessionWarmup prioritizes the default chat and queues five recent chats by default", () => {
-    const scheduled: Array<{ chatJid: string; priority?: boolean }> = [];
-    const recentCalls: Array<{ limit?: number; excludeChatJids?: string[] }> = [];
-
-    queueStartupSessionWarmup({
-      scheduleChatWarmup: (chatJid: string, options?: { priority?: boolean }) => {
-        scheduled.push({ chatJid, priority: options?.priority });
-        return true;
-      },
-      scheduleRecentChatWarmup: (options?: { limit?: number; excludeChatJids?: string[] }) => {
-        recentCalls.push(options || {});
-        return [];
-      },
-    } as any);
-
-    expect(scheduled).toEqual([{ chatJid: "web:default", priority: true }]);
-    expect(recentCalls).toEqual([{ limit: 5, excludeChatJids: ["web:default"] }]);
+  const payload = JSON.parse(readFileSync(join(ipcDir, fileName), "utf8"));
+  expect(payload).toEqual({
+    type: "message",
+    chatJid: "web:default",
+    text: "123-456",
+    noNudge: true,
   });
 });

--- a/runtime/test/runtime/startup.test.ts
+++ b/runtime/test/runtime/startup.test.ts
@@ -1,53 +1,174 @@
-import { afterEach, expect, test } from "bun:test";
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
 
-import type { RuntimeState } from "../../src/runtime/state.js";
-import { createTempWorkspace, importFresh, setEnv, type TempWorkspace } from "../helpers.js";
+import { queueStartupSessionWarmup } from "../../src/runtime/startup.js";
+import { createTempWorkspace } from "../helpers.js";
 
-let restoreEnv: (() => void) | null = null;
-let tempWorkspace: TempWorkspace | null = null;
+const TEST_SHELL = process.env.SHELL || "bash";
+const RUNTIME_DIR = join(import.meta.dir, "../..");
 
-afterEach(() => {
-  restoreEnv?.();
-  restoreEnv = null;
-  tempWorkspace?.cleanup();
-  tempWorkspace = null;
-});
+afterEach(() => {});
 
-test("createWhatsAppChannel writes pairing IPC payloads with noNudge enabled", async () => {
-  tempWorkspace = createTempWorkspace("piclaw-startup-pairing-");
-  restoreEnv = setEnv({
-    PICLAW_WORKSPACE: tempWorkspace.workspace,
-    PICLAW_STORE: tempWorkspace.store,
-    PICLAW_DATA: tempWorkspace.data,
-    WHATSAPP_PHONE: "+15551234567",
+describe("runtime startup helpers", () => {
+  test("initializeRuntimeEnvironment seeds workspace skel files for direct installs", () => {
+    const ws = createTempWorkspace("piclaw-startup-");
+
+    try {
+      const run = Bun.spawnSync({
+        cmd: [
+          TEST_SHELL,
+          "-lc",
+          "bun -e \"import { initializeRuntimeEnvironment } from './src/runtime/startup.js'; initializeRuntimeEnvironment({ loadTimestamps() {}, loadChats() {} });\"",
+        ],
+        cwd: RUNTIME_DIR,
+        env: {
+          ...process.env,
+          PICLAW_WORKSPACE: ws.workspace,
+          PICLAW_STORE: ws.store,
+          PICLAW_DATA: ws.data,
+          PICLAW_DB_IN_MEMORY: "1",
+        },
+      });
+      expect(run.exitCode, run.stderr.toString() || run.stdout.toString()).toBe(0);
+
+      expect(existsSync(join(ws.workspace, "AGENTS.md"))).toBe(true);
+      expect(existsSync(join(ws.workspace, ".piclaw", "README.md"))).toBe(true);
+      expect(existsSync(join(ws.workspace, ".piclaw", "config.json.example"))).toBe(true);
+      expect(existsSync(join(ws.workspace, ".pi", "mcp.json.example"))).toBe(true);
+      expect(existsSync(join(ws.workspace, "notes", "index.md"))).toBe(true);
+      expect(existsSync(join(ws.workspace, "notes", "memory", "README.md"))).toBe(true);
+      expect(existsSync(join(ws.workspace, ".pi", "skills"))).toBe(true);
+    } finally {
+      ws.cleanup();
+    }
   });
 
-  const { createWhatsAppChannel } = await importFresh<typeof import("../../src/runtime/startup.js")>(
-    "../src/runtime/startup.js"
-  );
+  test("queueStartupResumePendingIpc writes a resume_pending task", () => {
+    const ws = createTempWorkspace("piclaw-startup-");
 
-  const state = {
-    chatJids: new Set<string>(),
-    saveChats: () => {},
-  } as RuntimeState;
+    try {
+      const run = Bun.spawnSync({
+        cmd: [
+          TEST_SHELL,
+          "-lc",
+          "bun -e \"import { queueStartupResumePendingIpc } from './src/runtime/startup.js'; queueStartupResumePendingIpc();\"",
+        ],
+        cwd: RUNTIME_DIR,
+        env: {
+          ...process.env,
+          PICLAW_WORKSPACE: ws.workspace,
+          PICLAW_STORE: ws.store,
+          PICLAW_DATA: ws.data,
+          PICLAW_DB_IN_MEMORY: "1",
+        },
+      });
+      expect(run.exitCode).toBe(0);
 
-  const channel = createWhatsAppChannel(state);
-  const onPairingCode = (channel as any).opts?.onPairingCode as ((code: string) => void) | undefined;
-  expect(typeof onPairingCode).toBe("function");
+      const tasksDir = join(ws.data, "ipc", "tasks");
+      const files = readdirSync(tasksDir).filter((file) => file.startsWith("resume_pending_"));
+      expect(files).toHaveLength(1);
 
-  onPairingCode?.("123-456");
+      const payload = JSON.parse(readFileSync(join(tasksDir, files[0]), "utf-8"));
+      expect(payload).toEqual({ type: "resume_pending", chatJid: "all", reason: "startup" });
+    } finally {
+      ws.cleanup();
+    }
+  });
 
-  const ipcDir = join(tempWorkspace.data, "ipc", "messages");
-  const [fileName] = readdirSync(ipcDir);
-  expect(fileName).toBeTruthy();
+  test("queueStartupResumePendingIpc always queues a fresh startup resume task", () => {
+    const ws = createTempWorkspace("piclaw-startup-");
 
-  const payload = JSON.parse(readFileSync(join(ipcDir, fileName), "utf8"));
-  expect(payload).toEqual({
-    type: "message",
-    chatJid: "web:default",
-    text: "123-456",
-    noNudge: true,
+    try {
+      const tasksDir = join(ws.data, "ipc", "tasks");
+      mkdirSync(tasksDir, { recursive: true });
+      writeFileSync(
+        join(tasksDir, "resume_pending_existing.json"),
+        JSON.stringify({ type: "resume_pending", chatJid: "all", reason: "reload" })
+      );
+
+      const run = Bun.spawnSync({
+        cmd: [
+          TEST_SHELL,
+          "-lc",
+          "bun -e \"import { queueStartupResumePendingIpc } from './src/runtime/startup.js'; queueStartupResumePendingIpc();\"",
+        ],
+        cwd: RUNTIME_DIR,
+        env: {
+          ...process.env,
+          PICLAW_WORKSPACE: ws.workspace,
+          PICLAW_STORE: ws.store,
+          PICLAW_DATA: ws.data,
+          PICLAW_DB_IN_MEMORY: "1",
+        },
+      });
+      expect(run.exitCode).toBe(0);
+
+      const files = readdirSync(tasksDir)
+        .filter((file) => file.startsWith("resume_pending_"))
+        .sort();
+      expect(files.length).toBe(2);
+      expect(files).toContain("resume_pending_existing.json");
+      expect(files.some((file) => file !== "resume_pending_existing.json")).toBe(true);
+    } finally {
+      ws.cleanup();
+    }
+  });
+
+  test("queueStartupSessionWarmup prioritizes the default chat and queues five recent chats by default", () => {
+    const scheduled: Array<{ chatJid: string; priority?: boolean }> = [];
+    const recentCalls: Array<{ limit?: number; excludeChatJids?: string[] }> = [];
+
+    queueStartupSessionWarmup({
+      scheduleChatWarmup: (chatJid: string, options?: { priority?: boolean }) => {
+        scheduled.push({ chatJid, priority: options?.priority });
+        return true;
+      },
+      scheduleRecentChatWarmup: (options?: { limit?: number; excludeChatJids?: string[] }) => {
+        recentCalls.push(options || {});
+        return [];
+      },
+    } as any);
+
+    expect(scheduled).toEqual([{ chatJid: "web:default", priority: true }]);
+    expect(recentCalls).toEqual([{ limit: 5, excludeChatJids: ["web:default"] }]);
+  });
+
+  test("createWhatsAppChannel writes pairing IPC payloads with noNudge enabled", async () => {
+    const ws = createTempWorkspace("piclaw-startup-pairing-");
+
+    try {
+      const run = Bun.spawnSync({
+        cmd: [
+          TEST_SHELL,
+          "-lc",
+          "bun -e \"import { createWhatsAppChannel } from './src/runtime/startup.js'; const state = { chatJids: new Set(), saveChats() {} }; const channel = createWhatsAppChannel(state); channel.opts.onPairingCode('123-456');\"",
+        ],
+        cwd: RUNTIME_DIR,
+        env: {
+          ...process.env,
+          PICLAW_WORKSPACE: ws.workspace,
+          PICLAW_STORE: ws.store,
+          PICLAW_DATA: ws.data,
+          PICLAW_DB_IN_MEMORY: '1',
+          WHATSAPP_PHONE: '+15551234567',
+        },
+      });
+      expect(run.exitCode, run.stderr.toString() || run.stdout.toString()).toBe(0);
+
+      const ipcDir = join(ws.data, "ipc", "messages");
+      const [fileName] = readdirSync(ipcDir);
+      expect(fileName).toBeTruthy();
+
+      const payload = JSON.parse(readFileSync(join(ipcDir, fileName), "utf8"));
+      expect(payload).toEqual({
+        type: "message",
+        chatJid: "web:default",
+        text: "123-456",
+        noNudge: true,
+      });
+    } finally {
+      ws.cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Summary
WhatsApp pairing codes were written into the IPC message directory without `noNudge: true`, so the IPC message path could forward that one-time secret through the Pushover nudge channel.

This patch:
- writes pairing-code IPC payloads with `noNudge: true`
- preserves the existing IPC no-nudge behavior for startup-generated messages
- adds a startup-layer regression test for the pairing IPC payload and keeps IPC-level no-nudge coverage in place

## Validation
- `bun test runtime/test/runtime/startup.test.ts runtime/test/ipc/ipc.test.ts`
- `bun run typecheck`