### PR TITLE
[codex] fix(runtime): commit agent watermark only after turn success

### DIFF
--- a/runtime/src/runtime/message-loop.ts
+++ b/runtime/src/runtime/message-loop.ts
@@ -72,8 +72,11 @@ export async function processMessages(chatJid: string, deps: MessageProcessingDe
   if (!hasTrigger) return true;
 
   const channel = detectChannel(chatJid);
-  deps.state.lastAgentTimestamp[chatJid] = messages[messages.length - 1].timestamp;
-  deps.state.saveTimestamps();
+  const nextTimestamp = messages[messages.length - 1].timestamp;
+  const commitLastAgentTimestamp = () => {
+    deps.state.lastAgentTimestamp[chatJid] = nextTimestamp;
+    deps.state.saveTimestamps();
+  };
 
   const stripTrigger = (text: string): string => {
     if (!text) return "";
@@ -106,8 +109,10 @@ export async function processMessages(chatJid: string, deps: MessageProcessingDe
         chatJid,
         errorMessage: result.message,
       });
+      return true;
     }
 
+    commitLastAgentTimestamp();
     return true;
   }
 
@@ -146,6 +151,7 @@ export async function processMessages(chatJid: string, deps: MessageProcessingDe
     if (text) await deps.whatsapp.sendMessage(chatJid, text);
   }
 
+  commitLastAgentTimestamp();
   return true;
 }
 

--- a/runtime/test/runtime/message-loop.test.ts
+++ b/runtime/test/runtime/message-loop.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+
+import { importFresh, withTempWorkspaceEnv } from "../helpers.js";
+
+function makeMessage(chatJid: string, content: string, timestamp: string) {
+  return {
+    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    chat_jid: chatJid,
+    sender: "user",
+    sender_name: "User",
+    content,
+    timestamp,
+    is_from_me: false,
+    is_bot_message: false,
+  };
+}
+
+test("processMessages leaves lastAgentTimestamp unchanged when runAgent throws", async () => {
+  await withTempWorkspaceEnv("piclaw-message-loop-", { PICLAW_KEYCHAIN_KEY: "test-key" }, async () => {
+    const db = await importFresh<typeof import("../../src/db.js")>("../src/db.js");
+    const loop = await importFresh<typeof import("../../src/runtime/message-loop.js")>("../src/runtime/message-loop.js");
+    db.initDatabase();
+
+    const chatJid = `wa:${Date.now()}`;
+    const timestamp = "2026-04-17T01:00:00.000Z";
+    db.storeMessage(makeMessage(chatJid, "@Pi hello", timestamp));
+
+    let saveCalls = 0;
+    const state = {
+      lastAgentTimestamp: {} as Record<string, string>,
+      wasCommandProcessed: () => false,
+      markCommandProcessed: () => {},
+      saveTimestamps: () => {
+        saveCalls += 1;
+      },
+    };
+
+    await expect(loop.processMessages(chatJid, {
+      state: state as any,
+      assistantName: "Pi",
+      triggerPattern: /@Pi/i,
+      whatsapp: {
+        sendMessage: async () => {},
+        setTyping: async () => {},
+      } as any,
+      agentPool: {
+        runAgent: async () => {
+          throw new Error("agent crashed");
+        },
+      } as any,
+    })).rejects.toThrow("agent crashed");
+
+    expect(state.lastAgentTimestamp[chatJid]).toBeUndefined();
+    expect(saveCalls).toBe(0);
+  });
+});
+
+test("processMessages persists lastAgentTimestamp after a successful agent run", async () => {
+  await withTempWorkspaceEnv("piclaw-message-loop-", { PICLAW_KEYCHAIN_KEY: "test-key" }, async () => {
+    const db = await importFresh<typeof import("../../src/db.js")>("../src/db.js");
+    const loop = await importFresh<typeof import("../../src/runtime/message-loop.js")>("../src/runtime/message-loop.js");
+    db.initDatabase();
+
+    const chatJid = `wa:${Date.now()}`;
+    const timestamp = "2026-04-17T01:05:00.000Z";
+    db.storeMessage(makeMessage(chatJid, "@Pi hello", timestamp));
+
+    let saveCalls = 0;
+    const outbound: string[] = [];
+    const state = {
+      lastAgentTimestamp: {} as Record<string, string>,
+      wasCommandProcessed: () => false,
+      markCommandProcessed: () => {},
+      saveTimestamps: () => {
+        saveCalls += 1;
+      },
+    };
+
+    const ok = await loop.processMessages(chatJid, {
+      state: state as any,
+      assistantName: "Pi",
+      triggerPattern: /@Pi/i,
+      whatsapp: {
+        sendMessage: async (_jid: string, text: string) => {
+          outbound.push(text);
+        },
+        setTyping: async () => {},
+      } as any,
+      agentPool: {
+        runAgent: async () => ({
+          status: "success",
+          result: "done",
+        }),
+      } as any,
+    });
+
+    expect(ok).toBe(true);
+    expect(state.lastAgentTimestamp[chatJid]).toBe(timestamp);
+    expect(saveCalls).toBe(1);
+    expect(outbound).toEqual(["done"]);
+  });
+});


### PR DESCRIPTION
## Summary
`processMessages()` persisted `lastAgentTimestamp` before slash commands or agent runs completed, so a failed turn could permanently hide inbound messages from later polls.

This patch:
- defers `lastAgentTimestamp` persistence until a slash command or agent turn completes successfully
- keeps failed turns retriable by leaving the prior watermark in place
- adds regression tests covering both the failing and successful agent-run paths

## Validation
- `bun test runtime/test/runtime/message-loop.test.ts runtime/test/runtime/coordinator.test.ts`
- `bun run typecheck`