### PR TITLE
[codex] fix(agent-pool): harden session-manager lifecycle races

### DIFF
--- a/runtime/src/agent-pool/session-manager.ts
+++ b/runtime/src/agent-pool/session-manager.ts
@@ -51,6 +51,8 @@ export interface AgentSessionManagerOptions {
 export class AgentSessionManager {
   private readonly branchSeedRealizationInFlight = new Map<string, Promise<boolean>>();
   private readonly createInFlight = new Map<string, Promise<AgentSessionRuntime>>();
+  private readonly idleMainDisposalsInFlight = new Map<string, Promise<void>>();
+  private readonly idleSideDisposalsInFlight = new Map<string, Promise<void>>();
   private readonly invalidDeferredBranchSeedErrors = new Map<string, { error: Error; fingerprint: string | null }>();
   private readonly runtimeDisposeInFlight = new WeakMap<AgentSessionRuntime, Promise<void>>();
   private readonly prewarmInFlight = new Set<string>();
@@ -89,6 +91,11 @@ export class AgentSessionManager {
   }
 
   async getOrCreate(chatJid: string): Promise<AgentSessionRuntime> {
+    const pendingIdleDispose = this.idleMainDisposalsInFlight.get(chatJid);
+    if (pendingIdleDispose) {
+      await pendingIdleDispose;
+    }
+
     const knownInvalidSeedError = this.getBlockingInvalidSeedError(chatJid);
     if (knownInvalidSeedError) {
       throw knownInvalidSeedError;
@@ -157,6 +164,11 @@ export class AgentSessionManager {
   }
 
   async getOrCreateSide(chatJid: string): Promise<AgentSessionRuntime> {
+    const pendingIdleDispose = this.idleSideDisposalsInFlight.get(chatJid);
+    if (pendingIdleDispose) {
+      await pendingIdleDispose;
+    }
+
     const existing = this.options.sidePool.get(chatJid);
     if (existing) {
       existing.lastUsed = Date.now();
@@ -326,14 +338,7 @@ export class AgentSessionManager {
           operation: "evict_idle.main_session",
           chatJid: jid,
         });
-        Promise.resolve(entry.runtime.dispose()).catch((err) => {
-          this.options.onWarn?.("Failed to dispose evicted session", {
-            operation: "evict_idle.main_session",
-            chatJid: jid,
-            err,
-          });
-        });
-        this.options.pool.delete(jid);
+        this.startIdleDispose(this.options.pool, this.idleMainDisposalsInFlight, jid, entry, "evict_idle.main_session", false);
       }
     }
     for (const [jid, entry] of this.options.sidePool) {
@@ -347,14 +352,7 @@ export class AgentSessionManager {
           operation: "evict_idle.side_session",
           chatJid: jid,
         });
-        Promise.resolve(entry.runtime.dispose()).catch((err) => {
-          this.options.onWarn?.("Failed to dispose evicted side session", {
-            operation: "evict_idle.side_session",
-            chatJid: jid,
-            err,
-          });
-        });
-        this.options.sidePool.delete(jid);
+        this.startIdleDispose(this.options.sidePool, this.idleSideDisposalsInFlight, jid, entry, "evict_idle.side_session", true);
       }
     }
   }
@@ -511,28 +509,68 @@ export class AgentSessionManager {
     })();
   }
 
-  private async disposeMainRuntimeAfterError(chatJid: string, runtime: AgentSessionRuntime, operation: string): Promise<void> {
-    if (this.options.pool.get(chatJid)?.runtime === runtime) {
-      this.options.pool.delete(chatJid);
-    }
+  private startIdleDispose(
+    map: Map<string, PoolEntry>,
+    pendingDisposals: Map<string, Promise<void>>,
+    chatJid: string,
+    entry: PoolEntry,
+    operation: string,
+    side: boolean,
+  ): void {
+    if (pendingDisposals.has(chatJid)) return;
+
+    let task!: Promise<void>;
+    task = (async () => {
+      try {
+        await this.disposeRuntimeOnce(entry.runtime);
+      } catch (err) {
+        this.options.onWarn?.(side ? "Failed to dispose evicted side session" : "Failed to dispose evicted session", {
+          operation,
+          chatJid,
+          err,
+        });
+      } finally {
+        if (map.get(chatJid)?.runtime === entry.runtime) {
+          map.delete(chatJid);
+        }
+        if (pendingDisposals.get(chatJid) === task) {
+          pendingDisposals.delete(chatJid);
+        }
+      }
+    })();
+
+    pendingDisposals.set(chatJid, task);
+  }
+
+  private async disposeRuntimeOnce(runtime: AgentSessionRuntime): Promise<void> {
     const pendingDispose = this.runtimeDisposeInFlight.get(runtime);
     if (pendingDispose) {
       await pendingDispose;
       return;
     }
 
-    const task = (async () => {
-      try {
-        await runtime.dispose();
-      } catch (disposeErr) {
-        this.options.onWarn?.("Failed to dispose session after initialization error", {
-          operation,
-          chatJid,
-          err: disposeErr,
-        });
+    let task!: Promise<void>;
+    task = Promise.resolve(runtime.dispose()).finally(() => {
+      if (this.runtimeDisposeInFlight.get(runtime) === task) {
+        this.runtimeDisposeInFlight.delete(runtime);
       }
-    })();
+    });
     this.runtimeDisposeInFlight.set(runtime, task);
     await task;
+  }
+
+  private async disposeMainRuntimeAfterError(chatJid: string, runtime: AgentSessionRuntime, operation: string): Promise<void> {
+    if (this.options.pool.get(chatJid)?.runtime === runtime) {
+      this.options.pool.delete(chatJid);
+    }
+    try {
+      await this.disposeRuntimeOnce(runtime);
+    } catch (disposeErr) {
+      this.options.onWarn?.("Failed to dispose session after initialization error", {
+        operation,
+        chatJid,
+        err: disposeErr,
+      });
+    }
   }
 }

--- a/runtime/src/agent-pool/session-manager.ts
+++ b/runtime/src/agent-pool/session-manager.ts
@@ -53,6 +53,7 @@ export class AgentSessionManager {
   private readonly createInFlight = new Map<string, Promise<AgentSessionRuntime>>();
   private readonly idleMainDisposalsInFlight = new Map<string, Promise<void>>();
   private readonly idleSideDisposalsInFlight = new Map<string, Promise<void>>();
+  private readonly createSideInFlight = new Map<string, Promise<AgentSessionRuntime>>();
   private readonly invalidDeferredBranchSeedErrors = new Map<string, { error: Error; fingerprint: string | null }>();
   private readonly runtimeDisposeInFlight = new WeakMap<AgentSessionRuntime, Promise<void>>();
   private readonly prewarmInFlight = new Set<string>();
@@ -169,38 +170,50 @@ export class AgentSessionManager {
       await pendingIdleDispose;
     }
 
+    const pendingCreate = this.createSideInFlight.get(chatJid);
+    if (pendingCreate) {
+      return await pendingCreate;
+    }
+
     const existing = this.options.sidePool.get(chatJid);
     if (existing) {
       existing.lastUsed = Date.now();
       return existing.runtime;
     }
 
-    this.options.onInfo?.("Creating new side session", {
-      operation: "get_or_create_side.create_session",
-      chatJid,
+    const task = (async () => {
+      this.options.onInfo?.("Creating new side session", {
+        operation: "get_or_create_side.create_session",
+        chatJid,
+      });
+      const sideSessionDir = ensureNamedSessionDir(chatJid, "btw-side");
+
+      const extensionFactories = await this.options.getSessionExtensionFactories?.(chatJid) ?? [];
+      const runtime = this.options.createSideSession
+        ? await this.options.createSideSession(chatJid, sideSessionDir)
+        : await createSessionInDir(sideSessionDir, {
+            authStorage: this.options.authStorage,
+            modelRegistry: this.options.modelRegistry,
+            settingsManager: this.options.settingsManager,
+            tools: this.options.createDefaultTools(),
+            customTools: this.options.createCustomToolOverrides?.() ?? [],
+            extensionFactories,
+          });
+
+      this.options.sidePool.set(chatJid, { runtime, lastUsed: Date.now() });
+      return runtime;
+    })().finally(() => {
+      this.createSideInFlight.delete(chatJid);
     });
-    const sideSessionDir = ensureNamedSessionDir(chatJid, "btw-side");
 
-    const extensionFactories = await this.options.getSessionExtensionFactories?.(chatJid) ?? [];
-    const runtime = this.options.createSideSession
-      ? await this.options.createSideSession(chatJid, sideSessionDir)
-      : await createSessionInDir(sideSessionDir, {
-          authStorage: this.options.authStorage,
-          modelRegistry: this.options.modelRegistry,
-          settingsManager: this.options.settingsManager,
-          tools: this.options.createDefaultTools(),
-          customTools: this.options.createCustomToolOverrides?.() ?? [],
-          extensionFactories,
-        });
-
-    this.options.sidePool.set(chatJid, { runtime, lastUsed: Date.now() });
-    return runtime;
+    this.createSideInFlight.set(chatJid, task);
+    return await task;
   }
 
   async syncSideSessionFromMain(mainSession: AgentSession, sideRuntime: AgentSessionRuntime): Promise<void> {
     try {
       const mainContext = mainSession.sessionManager.buildSessionContext();
-      await sideRuntime.newSession({
+      const result = await sideRuntime.newSession({
         setup: async (sessionManager) => {
           seedRotatedSession(sessionManager, mainContext, {
             sessionName: "BTW",
@@ -208,11 +221,16 @@ export class AgentSessionManager {
           });
         },
       });
+      if (result.cancelled) {
+        throw new Error("Side-session reseed was cancelled.");
+      }
     } catch (err) {
       this.options.onWarn?.("Failed to reseed side session from main context", {
         operation: "sync_side_session_from_main.reseed",
         err,
       });
+      await this.disposeSideRuntimeAfterError(sideRuntime, "sync_side_session_from_main.dispose_after_reseed_failure");
+      throw err;
     }
 
     const sideSession = sideRuntime.session;
@@ -557,6 +575,29 @@ export class AgentSessionManager {
     });
     this.runtimeDisposeInFlight.set(runtime, task);
     await task;
+  }
+
+  private findChatJidByRuntime(map: Map<string, PoolEntry>, runtime: AgentSessionRuntime): string | null {
+    for (const [chatJid, entry] of map) {
+      if (entry.runtime === runtime) return chatJid;
+    }
+    return null;
+  }
+
+  private async disposeSideRuntimeAfterError(runtime: AgentSessionRuntime, operation: string): Promise<void> {
+    const chatJid = this.findChatJidByRuntime(this.options.sidePool, runtime);
+    if (chatJid && this.options.sidePool.get(chatJid)?.runtime === runtime) {
+      this.options.sidePool.delete(chatJid);
+    }
+    try {
+      await this.disposeRuntimeOnce(runtime);
+    } catch (disposeErr) {
+      this.options.onWarn?.("Failed to dispose side session after initialization error", {
+        operation,
+        ...(chatJid ? { chatJid } : {}),
+        err: disposeErr,
+      });
+    }
   }
 
   private async disposeMainRuntimeAfterError(chatJid: string, runtime: AgentSessionRuntime, operation: string): Promise<void> {

--- a/runtime/test/agent-pool/session-manager.test.ts
+++ b/runtime/test/agent-pool/session-manager.test.ts
@@ -174,6 +174,7 @@ test("AgentSessionManager evicts idle sessions and shuts down remaining sessions
   fixture.pool.set("web:active", { runtime: createRuntime(activeSession), lastUsed: Date.now() - 10_000 });
 
   fixture.manager.evictIdle(1_000);
+  await Bun.sleep(0);
 
   expect(fixture.pool.has("web:old")).toBe(false);
   expect(fixture.pool.has("web:active")).toBe(true);
@@ -183,6 +184,48 @@ test("AgentSessionManager evicts idle sessions and shuts down remaining sessions
   expect(fixture.pool.size).toBe(0);
   expect(fixture.sidePool.size).toBe(0);
   expect(disposed).toBe(2);
+});
+
+test("AgentSessionManager waits for idle eviction disposal before recreating a main session", async () => {
+  let createCalls = 0;
+  let disposeStarted = false;
+  let releaseDispose!: () => void;
+  const disposeGate = new Promise<void>((resolve) => {
+    releaseDispose = resolve;
+  });
+  const originalRuntime = createRuntime({
+    isStreaming: false,
+    isBashRunning: false,
+    isCompacting: false,
+    dispose() {
+      disposeStarted = true;
+      return disposeGate;
+    },
+  });
+  const replacementSession = { dispose() {} };
+  const fixture = createManager({
+    createSession: async () => {
+      createCalls += 1;
+      return createRuntime(replacementSession) as any;
+    },
+  });
+
+  fixture.pool.set("web:default", { runtime: originalRuntime, lastUsed: Date.now() - 10_000 });
+
+  fixture.manager.evictIdle(1_000);
+  const recreated = fixture.manager.getOrCreate("web:default");
+  await Promise.resolve();
+
+  expect(disposeStarted).toBe(true);
+  expect(createCalls).toBe(0);
+
+  releaseDispose();
+
+  expect((await recreated).session).toBe(replacementSession);
+  expect(createCalls).toBe(1);
+  expect(fixture.pool.get("web:default")?.runtime.session).toBe(replacementSession);
+
+  await fixture.manager.shutdown();
 });
 
 test("AgentSessionManager serializes queued prewarms and honors priority ordering", async () => {

--- a/runtime/test/agent-pool/session-manager.test.ts
+++ b/runtime/test/agent-pool/session-manager.test.ts
@@ -120,6 +120,32 @@ test("AgentSessionManager singleflights concurrent main-session creation for the
   expect(fixture.state.bound).toEqual(["web:default"]);
 });
 
+test("AgentSessionManager singleflights concurrent side-session creation for the same chat", async () => {
+  let createCalls = 0;
+  let releaseCreate!: () => void;
+  const waitForCreate = new Promise<void>((resolve) => {
+    releaseCreate = resolve;
+  });
+  const session = {
+    dispose() {},
+  };
+  const fixture = createManager({
+    createSideSession: async () => {
+      createCalls += 1;
+      await waitForCreate;
+      return createRuntime(session) as any;
+    },
+  });
+
+  const first = fixture.manager.getOrCreateSide("web:default");
+  const second = fixture.manager.getOrCreateSide("web:default");
+  releaseCreate();
+
+  expect(await first).toBe(await second);
+  expect(createCalls).toBe(1);
+  expect(fixture.sidePool.get("web:default")?.runtime.session).toBe(session);
+});
+
 test("AgentSessionManager recreates cached main and side sessions", async () => {
   let disposed = 0;
   const mainSession = {
@@ -148,6 +174,52 @@ test("AgentSessionManager recreates cached main and side sessions", async () => 
   expect(fixture.pool.has("web:default")).toBe(false);
   expect(fixture.sidePool.has("web:default")).toBe(false);
   expect(disposed).toBe(2);
+});
+
+test("AgentSessionManager disposes a cached side runtime when reseeding it is cancelled", async () => {
+  let disposed = 0;
+  let setModelCalls = 0;
+  let setThinkingCalls = 0;
+  let setToolsCalls = 0;
+
+  const sideSession = {
+    model: null,
+    setModel: async () => {
+      setModelCalls += 1;
+    },
+    setThinkingLevel: () => {
+      setThinkingCalls += 1;
+    },
+    setActiveToolsByName: () => {
+      setToolsCalls += 1;
+    },
+    dispose() {
+      disposed += 1;
+    },
+  };
+  const sideRuntime = createRuntime(sideSession);
+  sideRuntime.newSession = async () => ({ cancelled: true });
+
+  const fixture = createManager();
+  fixture.sidePool.set("web:default", { runtime: sideRuntime, lastUsed: Date.now() });
+
+  await expect(fixture.manager.syncSideSessionFromMain({
+    sessionManager: {
+      buildSessionContext: () => ({
+        model: { provider: "test", id: "main-model" },
+      }),
+    },
+    model: { provider: "test", id: "main-model" },
+    thinkingLevel: "high",
+    getActiveToolNames: () => ["web_search"],
+  } as any, sideRuntime)).rejects.toThrow("Side-session reseed was cancelled.");
+
+  expect(fixture.sidePool.has("web:default")).toBe(false);
+  expect(disposed).toBe(1);
+  expect(setModelCalls).toBe(0);
+  expect(setThinkingCalls).toBe(0);
+  expect(setToolsCalls).toBe(0);
+  expect(fixture.state.warns).toContain("Failed to reseed side session from main context");
 });
 
 test("AgentSessionManager evicts idle sessions and shuts down remaining sessions", async () => {


### PR DESCRIPTION
## Summary
- wait for evicted session runtimes to finish disposing before recreating the same chat session
- singleflight concurrent side-session creation so duplicate BTW-side runtimes cannot race
- fail fast and dispose the cached side runtime when side-session reseeding is cancelled instead of mutating a half-reset session
- add focused regressions for idle-eviction recreation, side-session singleflighting, and cancelled side-session reseeds

## Root Cause
`AgentSessionManager` had multiple independent lifecycle races. Idle eviction deleted cached entries before disposal finished, concurrent side-session callers could create duplicate side runtimes, and a cancelled side-session reseed left a partially reset side runtime cached and still eligible for later sync mutations.

## Validation
- `bun test runtime/test/agent-pool/session-manager.test.ts`
- `bun run typecheck`
