### PR TITLE
[codex] fix(agent-pool): ignore late timeout aborts

### DIFF
--- a/runtime/src/agent-pool/run-agent-orchestrator.ts
+++ b/runtime/src/agent-pool/run-agent-orchestrator.ts
@@ -230,11 +230,18 @@ export async function runAgentPrompt(
     const unsub = options.turnCoordinator.subscribe(session, chatJid, tracker, runOptions.onEvent);
     const timeoutMs = typeof runOptions.timeoutMs === "number" ? runOptions.timeoutMs : getAgentRuntimeConfig().timeoutMs;
     const { timeoutId, timedOutRef, completedRef } = options.turnCoordinator.startPromptTimeout(session, chatJid, timeoutMs);
+    const finishPromptTimeout = () => {
+      if (!completedRef.value) {
+        completedRef.value = true;
+      }
+      if (timeoutId) clearTimeout(timeoutId);
+    };
 
     const channel = detectChannel(chatJid);
     return await withChatContext(chatJid, channel, async () => {
       try {
         await session.prompt(prompt);
+        finishPromptTimeout();
         options.onInfo?.("session.prompt() resolved", {
           operation: "run_agent.prompt_resolved",
           chatJid,
@@ -251,8 +258,7 @@ export async function runAgentPrompt(
           });
         });
       } finally {
-        completedRef.value = true;
-        if (timeoutId) clearTimeout(timeoutId);
+        finishPromptTimeout();
         unsub();
       }
 

--- a/runtime/src/agent-pool/turn-coordinator.ts
+++ b/runtime/src/agent-pool/turn-coordinator.ts
@@ -295,15 +295,25 @@ export class AgentTurnCoordinator {
       return { timeoutId: null, timedOutRef, completedRef };
     }
 
-    const timeoutId = setTimeout(async () => {
-      if (completedRef.value) return;
-      timedOutRef.value = true;
-      this.options.onError?.("Prompt timed out; aborting session", {
-        operation: "start_prompt_timeout",
-        chatJid,
-        timeoutMs,
+    const timeoutId = setTimeout(() => {
+      void (async () => {
+        if (completedRef.value) return;
+        timedOutRef.value = true;
+        this.options.onError?.("Prompt timed out; aborting session", {
+          operation: "start_prompt_timeout",
+          chatJid,
+          timeoutMs,
+        });
+        await session.abort();
+      })().catch((err) => {
+        if (completedRef.value) return;
+        this.options.onWarn?.("Failed to abort timed-out prompt", {
+          operation: "start_prompt_timeout.abort",
+          chatJid,
+          timeoutMs,
+          err,
+        });
       });
-      await session.abort();
     }, timeoutMs);
 
     return { timeoutId, timedOutRef, completedRef };

--- a/runtime/test/agent-pool/run-agent-orchestrator.test.ts
+++ b/runtime/test/agent-pool/run-agent-orchestrator.test.ts
@@ -398,6 +398,74 @@ test("runAgentPrompt ignores commentary-only aborted output", async () => {
   expect(result.attachments).toBeUndefined();
 });
 
+test("runAgentPrompt disarms the prompt timeout as soon as prompt() resolves", async () => {
+  let abortCalls = 0;
+
+  class StubSession {
+    private listeners: Array<(event: any) => void> = [];
+    sessionManager = { getLeafId: () => "leaf-1" };
+    isStreaming = true;
+    isCompacting = false;
+    isRetrying = false;
+    subscribe(listener: (event: any) => void) {
+      this.listeners.push(listener);
+      return () => {
+        this.listeners = this.listeners.filter((entry) => entry !== listener);
+      };
+    }
+    async prompt() {
+      for (const listener of this.listeners) {
+        listener({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "done" } });
+      }
+      setTimeout(() => {
+        this.isStreaming = false;
+      }, 5);
+    }
+    async abort() {
+      abortCalls += 1;
+    }
+  }
+
+  const session = new StubSession();
+  const turnCoordinator = new AgentTurnCoordinator({
+    takeAttachments: () => [],
+    touchSession: () => {},
+    recordMessageUsage: () => {},
+  });
+
+  let timeoutState: ReturnType<typeof turnCoordinator.startPromptTimeout> | null = null;
+  const originalStartPromptTimeout = turnCoordinator.startPromptTimeout.bind(turnCoordinator);
+  turnCoordinator.startPromptTimeout = ((...args: any[]) => {
+    timeoutState = originalStartPromptTimeout(...args);
+    return timeoutState!;
+  }) as any;
+
+  const result = await runAgentPrompt("test", "web:default", { timeoutMs: 50 }, {
+    getOrCreateRuntime: async () => createRuntime(session) as any,
+    turnCoordinator,
+    clearAttachments: () => {},
+    takeAttachments: () => [],
+    logsDir: createTestLogsDir(),
+    setActiveForkBaseLeaf: () => {},
+    clearActiveForkBaseLeaf: () => {},
+    onInfo: (message) => {
+      if (message !== "session.prompt() resolved" || !timeoutState) return;
+      queueMicrotask(async () => {
+        if (timeoutState?.completedRef.value) return;
+        timeoutState.timedOutRef.value = true;
+        await session.abort();
+      });
+    },
+  });
+
+  await Bun.sleep(20);
+
+  expect(result.status).toBe("success");
+  expect(result.result).toBe("done");
+  expect(timeoutState?.completedRef.value).toBe(true);
+  expect(abortCalls).toBe(0);
+});
+
 test("runAgentPrompt ignores a queued late-timeout callback after prompt completion", async () => {
   let abortCalls = 0;
 

--- a/runtime/test/agent-pool/turn-coordinator.test.ts
+++ b/runtime/test/agent-pool/turn-coordinator.test.ts
@@ -359,3 +359,25 @@ test("AgentTurnCoordinator ignores late timeout callbacks after completion", asy
   expect(abortCalls).toBe(0);
   expect(errors).toEqual([]);
 });
+
+test("AgentTurnCoordinator reports timed-out abort failures without leaking rejections", async () => {
+  const warns: string[] = [];
+  const session = {
+    abort: async () => {
+      throw new Error("abort failed");
+    },
+  };
+
+  const coordinator = new AgentTurnCoordinator({
+    takeAttachments: () => [],
+    touchSession: () => {},
+    recordMessageUsage: () => {},
+    onWarn: (message) => warns.push(message),
+  });
+
+  const { timedOutRef } = coordinator.startPromptTimeout(session as any, "web:default", 5);
+  await Bun.sleep(20);
+
+  expect(timedOutRef.value).toBe(true);
+  expect(warns).toContain("Failed to abort timed-out prompt");
+});


### PR DESCRIPTION
## Summary
- disarm the prompt timeout immediately after `session.prompt()` resolves instead of waiting for the later idle-settle cleanup
- keep timed-out prompt abort failures contained with an explicit warning path instead of leaking unhandled rejections
- add regressions for the post-prompt timeout race and abort rejection handling

## Root cause
The prompt timeout stayed armed until the orchestration `finally` block after `waitForSessionIdle()`. That left a window where a queued timeout callback could still abort a session that had already finished its prompt, contaminating the next prompt on the same session.

## Validation
- `bun test runtime/test/agent-pool/turn-coordinator.test.ts runtime/test/agent-pool/run-agent-orchestrator.test.ts`
- `bun run typecheck`
