### PR TITLE
[codex] fix(session-rotation): restore cancelled sessions

### DIFF
--- a/runtime/src/session-rotation.ts
+++ b/runtime/src/session-rotation.ts
@@ -145,6 +145,28 @@ export function seedRotatedSession(
   }
 }
 
+async function restoreCancelledRotationSession(
+  runtime: AgentSessionRuntime,
+  previousSessionFile: string,
+): Promise<string | null> {
+  const activeSessionFile = runtime.session.sessionFile?.trim();
+  if (!activeSessionFile || activeSessionFile === previousSessionFile) {
+    return null;
+  }
+
+  const result = await runtime.switchSession(previousSessionFile);
+  if (result.cancelled) {
+    return `Failed to restore previous session after cancellation: ${previousSessionFile}`;
+  }
+
+  const restoredSessionFile = runtime.session.sessionFile?.trim();
+  if (restoredSessionFile !== previousSessionFile) {
+    return `Failed to restore previous session after cancellation: expected ${previousSessionFile} but active session is ${restoredSessionFile || "(none)"}`;
+  }
+
+  return null;
+}
+
 /** Rotate a persisted session into a newly-seeded successor session file. */
 export async function rotateSession(
   session: AgentSession,
@@ -227,7 +249,13 @@ export async function rotateSession(
 
     if (result.cancelled) {
       if (archived) rmSync(archivePath, { force: true });
-      return { status: "error", reason, compacted, message: "Session rotation cancelled." };
+      const restoreError = await restoreCancelledRotationSession(runtime, previousSessionFile);
+      return {
+        status: "error",
+        reason,
+        compacted,
+        message: restoreError ? `Session rotation cancelled. ${restoreError}` : "Session rotation cancelled.",
+      };
     }
 
     const activeSession = runtime.session;

--- a/runtime/test/session-rotation.test.ts
+++ b/runtime/test/session-rotation.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, writeFileSync } from "fs";
+import { join } from "path";
+
+import type { AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+
+import { createTempWorkspace, importFresh, setEnv } from "./helpers.js";
+
+let restoreEnv: (() => void) | null = null;
+let cleanupWorkspace: (() => void) | null = null;
+
+afterEach(() => {
+  restoreEnv?.();
+  cleanupWorkspace?.();
+  restoreEnv = null;
+  cleanupWorkspace = null;
+});
+
+function createPersistedSession(workspace: string, sessionDir: string, sessionName: string) {
+  const sessionManager = SessionManager.create(workspace, sessionDir);
+  sessionManager.appendSessionInfo(sessionName);
+  sessionManager.appendMessage({
+    role: "user",
+    content: "Preserve this context",
+    timestamp: Date.now(),
+  } as const);
+  const sessionFile = sessionManager.getSessionFile();
+  const header = sessionManager.getHeader();
+  if (sessionFile && header) {
+    const entries = sessionManager.getEntries();
+    const content = [header, ...entries].map((entry) => JSON.stringify(entry)).join("\n");
+    writeFileSync(sessionFile, `${content}\n`);
+  }
+
+  return {
+    sessionManager,
+    sessionFile,
+    sessionName,
+    model: null,
+    isStreaming: false,
+    isCompacting: false,
+    isRetrying: false,
+    pendingMessageCount: 0,
+    async compact() {
+      sessionManager.appendCompaction("Rotation summary", "root", 128);
+    },
+  };
+}
+
+test("rotateSession restores the previous session when a cancelled newSession already replaced runtime.session", async () => {
+  const workspace = createTempWorkspace("piclaw-rotate-session-cancelled-");
+  cleanupWorkspace = workspace.cleanup;
+  restoreEnv = setEnv({
+    PICLAW_WORKSPACE: workspace.workspace,
+    PICLAW_STORE: workspace.store,
+    PICLAW_DATA: workspace.data,
+  });
+
+  const { rotateSession, getArchivePath } = await importFresh<typeof import("../src/session-rotation.js")>("../src/session-rotation.js");
+  const sessionDir = join(workspace.workspace, "session-rotation");
+  const originalSession = createPersistedSession(workspace.workspace, sessionDir, "Original session");
+  const previousSessionFile = originalSession.sessionFile;
+  expect(previousSessionFile).toBeTruthy();
+
+  const archivePath = getArchivePath(previousSessionFile!);
+  let switchCalls = 0;
+
+  const runtime = {
+    session: originalSession,
+    cwd: workspace.workspace,
+    diagnostics: [],
+    services: {} as any,
+    modelFallbackMessage: undefined,
+    newSession: async (options?: { parentSession?: string; setup?: (sessionManager: SessionManager) => Promise<void> | void }) => {
+      const replacementManager = SessionManager.create(workspace.workspace, sessionDir);
+      replacementManager.newSession({ parentSession: options?.parentSession });
+      await options?.setup?.(replacementManager);
+      runtime.session = {
+        ...createPersistedSession(workspace.workspace, sessionDir, "Cancelled replacement"),
+        sessionManager: replacementManager,
+        sessionFile: replacementManager.getSessionFile(),
+      } as any;
+      return { cancelled: true };
+    },
+    switchSession: async (sessionPath: string) => {
+      switchCalls += 1;
+      expect(sessionPath).toBe(previousSessionFile);
+      runtime.session = originalSession as any;
+      return { cancelled: false };
+    },
+    fork: async () => ({ cancelled: false }),
+    importFromJsonl: async () => ({ cancelled: false }),
+    dispose: async () => {},
+  } as AgentSessionRuntime;
+
+  const result = await rotateSession(originalSession as any, runtime, { reason: "manual" });
+
+  expect(result.status).toBe("error");
+  expect(result.message).toBe("Session rotation cancelled.");
+  expect(switchCalls).toBe(1);
+  expect(runtime.session.sessionFile).toBe(previousSessionFile);
+  expect(existsSync(previousSessionFile!)).toBe(true);
+  expect(existsSync(archivePath)).toBe(false);
+});


### PR DESCRIPTION
## Summary
- restore the previous persisted session if a cancelled `runtime.newSession()` leaves `runtime.session` pointing at a replacement session
- keep the archive cleanup on cancellation, but stop leaving the runtime pointed at the wrong session file afterward
- add a regression for cancelled rotations plus existing auto-rotation coverage

## Root cause
`rotateSession()` treated a `{ cancelled: true }` result from `runtime.newSession()` as if it guaranteed `runtime.session` was unchanged. That assumption is not enforced by the `AgentSessionRuntime` interface, so a cancelling runtime could leave the old session file on disk while the in-memory runtime kept the replacement session wired in.

## Validation
- `bun test runtime/test/session-rotation.test.ts runtime/test/agent-pool/session-auto-rotation.test.ts`
- `bun run typecheck`
