### PR TITLE
[codex] fix(agent-pool): harden runtime-facade queue and refresh flows

### DIFF
--- a/runtime/src/agent-control/agent-control-types.ts
+++ b/runtime/src/agent-control/agent-control-types.ts
@@ -251,6 +251,7 @@ export interface AgentControlResult {
   status: "success" | "error";
   message: string;
   messages?: Array<{ role: string; text: string; customType?: string }>;
+  refresh_runtime?: boolean;
   queued_followup?: boolean;
   queued_steer?: boolean;
   model_label?: string | null;

--- a/runtime/src/agent-control/handlers/control.ts
+++ b/runtime/src/agent-control/handlers/control.ts
@@ -111,6 +111,7 @@ export async function handleRestart(session: AgentSession, _command: RestartComm
   return {
     status: "success",
     message: `Agent restarted. Killed ${killedLabel}.`,
+    refresh_runtime: true,
   };
 }
 

--- a/runtime/src/agent-pool/runtime-facade.ts
+++ b/runtime/src/agent-pool/runtime-facade.ts
@@ -396,7 +396,7 @@ export class AgentRuntimeFacade {
     const channel = detectChannel(chatJid);
     const apply = this.options.applyControlCommandFn ?? applyControlCommand;
     const result = await withChatContext(chatJid, channel, () => apply(runtime, this.options.modelRegistry, command));
-    if (runtime.session !== session) {
+    if (result.refresh_runtime || runtime.session !== session) {
       await this.options.refreshRuntime(chatJid, runtime);
     }
     return result;
@@ -623,7 +623,7 @@ export class AgentRuntimeFacade {
     const channel = detectChannel(chatJid);
     const exec = this.options.executeSlashCommandFn ?? executeSlashCommand;
     const result = await withChatContext(chatJid, channel, () => exec(session, chatJid, rawText));
-    if (runtime.session !== session) {
+    if (result.refresh_runtime || runtime.session !== session) {
       await this.options.refreshRuntime(chatJid, runtime);
     }
     this.options.clearAttachments(chatJid);

--- a/runtime/src/agent-pool/runtime-facade.ts
+++ b/runtime/src/agent-pool/runtime-facade.ts
@@ -574,11 +574,21 @@ export class AgentRuntimeFacade {
         const cleared = session.clearQueue();
         const nextFollowups = cleared.followUp.filter((_, idx) => idx !== removeIndex);
 
-        for (const steer of cleared.steering) {
-          await session.prompt(steer, { streamingBehavior: "steer" });
-        }
-        for (const followup of nextFollowups) {
-          await session.prompt(followup, { streamingBehavior: "followUp" });
+        try {
+          await this.restoreQueuedMessages(session, cleared.steering, nextFollowups);
+        } catch (err) {
+          try {
+            session.clearQueue();
+            await this.restoreQueuedMessages(session, cleared.steering, cleared.followUp);
+          } catch (restoreErr) {
+            this.options.onWarn?.("Failed to restore queued follow-up after removal error", {
+              operation: "remove_queued_follow_up.restore",
+              chatJid,
+              err: restoreErr,
+              originalError: err,
+            });
+          }
+          throw err;
         }
 
         return true;
@@ -590,6 +600,19 @@ export class AgentRuntimeFacade {
         err,
       });
       return false;
+    }
+  }
+
+  private async restoreQueuedMessages(
+    session: { prompt: (text: string, options?: { streamingBehavior?: "steer" | "followUp" }) => Promise<unknown> },
+    steering: readonly string[],
+    followUp: readonly string[],
+  ): Promise<void> {
+    for (const steer of steering) {
+      await session.prompt(steer, { streamingBehavior: "steer" });
+    }
+    for (const queued of followUp) {
+      await session.prompt(queued, { streamingBehavior: "followUp" });
     }
   }
 

--- a/runtime/src/agent-pool/slash-command.ts
+++ b/runtime/src/agent-pool/slash-command.ts
@@ -257,7 +257,12 @@ export async function executeSlashCommand(
       durationMs: Date.now() - startTime,
       outputChars: message.length,
     });
-    return { status: "success", message, messages: capturedMessages };
+    return {
+      status: "success",
+      message,
+      messages: capturedMessages,
+      ...(kind.kind === "extension" ? { refresh_runtime: true } : {}),
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.error("Slash command failed", {

--- a/runtime/test/agent-pool/agent-pool-slash-command.test.ts
+++ b/runtime/test/agent-pool/agent-pool-slash-command.test.ts
@@ -75,6 +75,7 @@ test("executeSlashCommand runs known extension command outside prompt turn handl
   const result = await executeSlashCommand(session as any, "web:default", "/ext hello");
   expect(result.status).toBe("success");
   expect(result.message).toContain("Ext hello");
+  expect(result.refresh_runtime).toBe(true);
   expect(session.promptCalls).toHaveLength(0);
   expect(session.commandCalls).toEqual([{ name: "ext", args: "hello" }]);
 });

--- a/runtime/test/agent-pool/runtime-facade.test.ts
+++ b/runtime/test/agent-pool/runtime-facade.test.ts
@@ -349,16 +349,46 @@ test("AgentRuntimeFacade leaves legacy XML session-tree entries unnormalized", (
 
 test("AgentRuntimeFacade clears attachments around slash commands", async () => {
   const session = { marker: true };
+  let refreshCalls = 0;
   const fixture = createFacade({
+    refreshRuntime: async () => {
+      refreshCalls += 1;
+    },
     executeSlashCommandFn: async (incomingSession, chatJid, rawText) => ({
       ok: incomingSession === session,
       chatJid,
       rawText,
+      refresh_runtime: true,
     } as any),
   });
   fixture.pool.set("web:default", { runtime: createRuntime(session), lastUsed: Date.now() });
 
   const result = await fixture.facade.applySlashCommand("web:default", "/tasks");
-  expect(result).toEqual({ ok: true, chatJid: "web:default", rawText: "/tasks" });
+  expect(result).toEqual({ ok: true, chatJid: "web:default", rawText: "/tasks", refresh_runtime: true });
   expect(fixture.cleared).toEqual(["web:default", "web:default"]);
+  expect(refreshCalls).toBe(1);
+});
+
+test("AgentRuntimeFacade refreshes runtime when a control command requests it without swapping sessions", async () => {
+  const session = { marker: true };
+  let refreshCalls = 0;
+  const fixture = createFacade({
+    refreshRuntime: async () => {
+      refreshCalls += 1;
+    },
+    applyControlCommandFn: async () => ({
+      status: "success",
+      message: "Agent restarted.",
+      refresh_runtime: true,
+    }),
+  });
+  fixture.pool.set("web:default", { runtime: createRuntime(session), lastUsed: Date.now() });
+
+  const result = await fixture.facade.applyControlCommand("web:default", { type: "restart", raw: "/restart" } as any);
+  expect(result).toEqual({
+    status: "success",
+    message: "Agent restarted.",
+    refresh_runtime: true,
+  });
+  expect(refreshCalls).toBe(1);
 });

--- a/runtime/test/agent-pool/runtime-facade.test.ts
+++ b/runtime/test/agent-pool/runtime-facade.test.ts
@@ -222,6 +222,49 @@ test("AgentRuntimeFacade removes one queued follow-up and replays the remaining 
   ]);
 });
 
+test("AgentRuntimeFacade restores the original queue when queued follow-up removal replay fails", async () => {
+  const prompts: Array<{ text: string; behavior: string }> = [];
+  let thirdFollowupAttempts = 0;
+  let queue = {
+    steering: ["keep steer"],
+    followUp: ["first", "second", "third"],
+  };
+
+  const session = {
+    isStreaming: true,
+    getFollowUpMessages: () => [...queue.followUp],
+    clearQueue: () => {
+      const cleared = {
+        steering: [...queue.steering],
+        followUp: [...queue.followUp],
+      };
+      queue = { steering: [], followUp: [] };
+      return cleared;
+    },
+    prompt: async (text: string, options?: { streamingBehavior?: string }) => {
+      prompts.push({ text, behavior: options?.streamingBehavior ?? "" });
+      if (text === "third" && options?.streamingBehavior === "followUp" && thirdFollowupAttempts++ === 0) {
+        throw new Error("requeue failed");
+      }
+      if (options?.streamingBehavior === "steer") {
+        queue.steering.push(text);
+      } else if (options?.streamingBehavior === "followUp") {
+        queue.followUp.push(text);
+      }
+    },
+  };
+
+  const fixture = createFacade();
+  fixture.pool.set("web:default", { runtime: createRuntime(session), lastUsed: Date.now() });
+
+  await expect(fixture.facade.removeQueuedFollowupMessage("web:default", "second")).resolves.toBe(false);
+  expect(queue).toEqual({
+    steering: ["keep steer"],
+    followUp: ["first", "second", "third"],
+  });
+  expect(fixture.warnings).toContain("Failed to remove queued follow-up");
+});
+
 test("AgentRuntimeFacade normalizes session-tree user prompts for display while keeping raw detail", () => {
   const session = {
     sessionManager: {


### PR DESCRIPTION
## Summary
- make queued follow-up removal rollback-safe by restoring the original queue if replaying the kept messages fails
- refresh the runtime facade when `/restart` or extension slash commands request an in-place session refresh without swapping the session object
- add regressions covering queued follow-up rollback, slash-command refresh signaling, and control-command refresh signaling

## Root Cause
`AgentRuntimeFacade` had two separate correctness gaps. Queued follow-up removal cleared and replayed the queue without a guaranteed rollback path, and runtime refresh only happened when `runtime.session` changed by identity, so in-place reloads could skip binder and branch refresh work.

## Validation
- `bun test runtime/test/agent-pool/runtime-facade.test.ts runtime/test/agent-pool/agent-pool-slash-command.test.ts`
- `bun run typecheck`
