### PR TITLE
[codex] fix(scheduler): harden run bookkeeping and shell truncation

### DIFF
--- a/runtime/src/task-scheduler.ts
+++ b/runtime/src/task-scheduler.ts
@@ -208,27 +208,36 @@ async function runShellTask(task: ScheduledTask): Promise<{ result: string | nul
 
   const exec = createTrackedBashOperations();
   let output = "";
-  let outputBytes = 0;
+  let outputChars = 0;
+  let previewChars = 0;
   let truncated = false;
+  const decoder = new TextDecoder();
+
+  const appendDecodedText = (text: string) => {
+    for (const char of text) {
+      outputChars += 1;
+      if (previewChars < MAX_SHELL_OUTPUT_CHARS) {
+        output += char;
+        previewChars += 1;
+      } else {
+        truncated = true;
+      }
+    }
+  };
 
   try {
     const res = await exec.exec(validated.command!, cwdResult.cwd || WORKSPACE_DIR, {
       onData: (chunk: Buffer) => {
-        outputBytes += chunk.length;
-        if (output.length < MAX_SHELL_OUTPUT_CHARS) {
-          const text = chunk.toString("utf8");
-          output += text.slice(0, MAX_SHELL_OUTPUT_CHARS - output.length);
-        } else {
-          truncated = true;
-        }
+        appendDecodedText(decoder.decode(chunk, { stream: true }));
       },
       timeout: task.timeout_sec ?? undefined,
       env: undefined,
     });
+    appendDecodedText(decoder.decode());
 
     const trimmed = output.trim();
     const summary = trimmed ? trimmed : "(no output)";
-    const suffix = truncated ? `\n…(truncated; ${outputBytes} bytes total)` : "";
+    const suffix = truncated ? `\n…(truncated; ${outputChars} characters total)` : "";
     const formatted = `\`\`\`\n${summary}${suffix}\n\`\`\``;
 
     if (res.exitCode && res.exitCode !== 0) {

--- a/runtime/src/task-scheduler.ts
+++ b/runtime/src/task-scheduler.ts
@@ -254,67 +254,39 @@ export async function runScheduledTask(task: ScheduledTask, deps: SchedulerDeps)
   schedulerMetrics.taskRunsStarted += 1;
   let result: string | null = null;
   let error: string | null = null;
+  try {
+    const kind = task.task_kind === "internal"
+      ? "internal"
+      : task.task_kind === "shell" || task.command
+        ? "shell"
+        : "agent";
 
-  const kind = task.task_kind === "internal"
-    ? "internal"
-    : task.task_kind === "shell" || task.command
-      ? "shell"
-      : "agent";
-
-  if (kind === "internal") {
-    // Switch model if the internal task specifies one (e.g. Dream).
-    const savedModel = task.model ? await deps.agentPool.getCurrentModelLabel(task.chat_jid) : null;
-    if (task.model && (!savedModel || savedModel !== task.model)) {
-      const switchErr = await switchTaskModel(task, deps);
-      if (switchErr) { error = switchErr; }
-    }
-    if (!error) {
-      const out = await runInternalTask(task, deps);
+    if (kind === "internal") {
+      // Switch model if the internal task specifies one (e.g. Dream).
+      const savedModel = task.model ? await deps.agentPool.getCurrentModelLabel(task.chat_jid) : null;
+      if (task.model && (!savedModel || savedModel !== task.model)) {
+        const switchErr = await switchTaskModel(task, deps);
+        if (switchErr) { error = switchErr; }
+      }
+      if (!error) {
+        const out = await runInternalTask(task, deps);
+        if (out.error) {
+          error = out.error;
+        } else {
+          result = out.result;
+        }
+      }
+      // Restore original model after internal task completes.
+      if (task.model) {
+        await restoreOriginalModel(task, deps, savedModel);
+      }
+    } else if (kind === "shell") {
+      const out = await runShellTask(task);
       if (out.error) {
         error = out.error;
-      } else {
+      } else if (out.result) {
         result = out.result;
-      }
-    }
-    // Restore original model after internal task completes.
-    if (task.model) {
-      await restoreOriginalModel(task, deps, savedModel);
-    }
-  } else if (kind === "shell") {
-    const out = await runShellTask(task);
-    if (out.error) {
-      error = out.error;
-    } else if (out.result) {
-      result = out.result;
-      if (out.notify) {
-        const t = formatOutbound(result, detectChannel(task.chat_jid));
-        if (t) {
-          await deps.sendMessage(task.chat_jid, t, { forceRoot: true, source: "scheduled" });
-          await deps.sendNudge?.(t);
-        }
-      }
-    }
-  } else {
-    // Save session position so we can restore after the task.
-    // This isolates the task's prompt/response in a side branch of the session
-    // tree, preventing context pollution of the user's conversation.
-    const savedLeafId = await deps.agentPool.saveSessionPosition(task.chat_jid);
-    const savedModel = await deps.agentPool.getCurrentModelLabel(task.chat_jid);
-
-    try {
-      // Switch model if task specifies one.
-      if (task.model) {
-        if (!savedModel || savedModel !== task.model) {
-          error = await switchTaskModel(task, deps);
-        }
-      }
-
-      if (!error) {
-        const out = await deps.agentPool.runAgent(task.prompt, task.chat_jid);
-        if (out.status === "error") {
-          error = out.error || "Unknown";
-        } else if (out.result) {
-          result = out.result;
+        if (out.notify) {
           const t = formatOutbound(result, detectChannel(task.chat_jid));
           if (t) {
             await deps.sendMessage(task.chat_jid, t, { forceRoot: true, source: "scheduled" });
@@ -322,16 +294,45 @@ export async function runScheduledTask(task: ScheduledTask, deps: SchedulerDeps)
           }
         }
       }
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      // Navigate back to the saved position — the task's prompt and response
-      // stay in a side branch and won't pollute the user's conversation context.
-      await deps.agentPool.restoreSessionPosition(task.chat_jid, savedLeafId);
+    } else {
+      // Save session position so we can restore after the task.
+      // This isolates the task's prompt/response in a side branch of the session
+      // tree, preventing context pollution of the user's conversation.
+      const savedLeafId = await deps.agentPool.saveSessionPosition(task.chat_jid);
+      const savedModel = await deps.agentPool.getCurrentModelLabel(task.chat_jid);
 
-      // Restore the original model if it was changed.
-      await restoreOriginalModel(task, deps, savedModel);
+      try {
+        // Switch model if task specifies one.
+        if (task.model) {
+          if (!savedModel || savedModel !== task.model) {
+            error = await switchTaskModel(task, deps);
+          }
+        }
+
+        if (!error) {
+          const out = await deps.agentPool.runAgent(task.prompt, task.chat_jid);
+          if (out.status === "error") {
+            error = out.error || "Unknown";
+          } else if (out.result) {
+            result = out.result;
+            const t = formatOutbound(result, detectChannel(task.chat_jid));
+            if (t) {
+              await deps.sendMessage(task.chat_jid, t, { forceRoot: true, source: "scheduled" });
+              await deps.sendNudge?.(t);
+            }
+          }
+        }
+      } finally {
+        // Navigate back to the saved position — the task's prompt and response
+        // stay in a side branch and won't pollute the user's conversation context.
+        await deps.agentPool.restoreSessionPosition(task.chat_jid, savedLeafId);
+
+        // Restore the original model if it was changed.
+        await restoreOriginalModel(task, deps, savedModel);
+      }
     }
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
   }
 
   if (error) schedulerMetrics.taskRunsFailed += 1;

--- a/runtime/test/runtime/scheduler.test.ts
+++ b/runtime/test/runtime/scheduler.test.ts
@@ -108,6 +108,61 @@ test("runScheduledTask logs run and updates task", async () => {
   expect(metrics.taskRunsFailed).toBe(0);
 });
 
+test("runScheduledTask still logs and advances the task after an early execution throw", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  const db = await import("../../src/db.js");
+  db.initDatabase();
+
+  const scheduler = await import("../../src/task-scheduler.js");
+  scheduler.resetSchedulerMetricsForTests();
+
+  const taskId = `task-early-error-${Date.now()}`;
+  db.createTask({
+    id: taskId,
+    chat_jid: "web:default",
+    prompt: "say hi",
+    schedule_type: "interval",
+    schedule_value: "60000",
+    next_run: new Date(Date.now() - 1000).toISOString(),
+    status: "active",
+    created_at: new Date().toISOString(),
+  });
+
+  const deps = {
+    queue: { enqueueTask: (_id: string, fn: () => Promise<void>) => fn() } as any,
+    agentPool: {
+      runAgent: async () => ({ status: "success", result: "Hello" }),
+      saveSessionPosition: async () => {
+        throw new Error("save failed");
+      },
+      restoreSessionPosition: async () => {},
+      getCurrentModelLabel: async () => null,
+      applyControlCommand: async () => ({ status: "success", message: "" }),
+    } as any,
+    sendMessage: async () => {},
+  };
+
+  const task = db.getTaskById(taskId)!;
+  await scheduler.runScheduledTask(task, deps as any);
+
+  const updated = db.getTaskById(taskId)!;
+  expect(updated.last_run).not.toBeNull();
+  expect(updated.last_result).toContain("save failed");
+  expect(updated.next_run).not.toBe(task.next_run);
+
+  const logs = db.getTaskRunLogs(taskId);
+  expect(logs.length).toBe(1);
+  expect(logs[0].status).toBe("error");
+  expect(logs[0].error).toContain("save failed");
+
+  const metrics = scheduler.getSchedulerMetrics();
+  expect(metrics.taskRunsStarted).toBe(1);
+  expect(metrics.taskRunsSucceeded).toBe(0);
+  expect(metrics.taskRunsFailed).toBe(1);
+});
+
 test("runScheduledTask switches and restores models", async () => {
   const ws = getTestWorkspace();
   restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });

--- a/runtime/test/task-scheduler-shell.test.ts
+++ b/runtime/test/task-scheduler-shell.test.ts
@@ -92,3 +92,35 @@ test("runScheduledTask keeps empty shell output silent", async () => {
   expect(sentMessages.length).toBe(0);
   expect(db!.getTaskById(taskId)?.last_result).toBe("```\n(no output)\n```");
 });
+
+test("runScheduledTask truncates shell output on code-point boundaries", async () => {
+  const taskId = `task-shell-unicode-${Date.now()}`;
+  db!.createTask({
+    id: taskId,
+    chat_jid: "web:default",
+    prompt: "unicode",
+    model: null,
+    task_kind: "shell",
+    command: "bun -e 'process.stdout.write(\"🙂\".repeat(9000))'",
+    cwd: ".",
+    timeout_sec: 10,
+    schedule_type: "once",
+    schedule_value: new Date().toISOString(),
+    next_run: new Date().toISOString(),
+    status: "active",
+    created_at: new Date().toISOString(),
+  });
+
+  const task = db!.getTaskById(taskId);
+  expect(task?.task_kind).toBe("shell");
+
+  await scheduler!.runScheduledTask(task!, {
+    queue: {} as any,
+    agentPool: {} as any,
+    sendMessage: async (jid, text) => { sentMessages.push({ jid, text }); },
+  });
+
+  expect(sentMessages.length).toBe(1);
+  expect(sentMessages[0].text).toContain("…(truncated; 9000 characters total)");
+  expect(sentMessages[0].text).not.toContain("\uFFFD");
+});


### PR DESCRIPTION
## Summary
- keep scheduled-task bookkeeping running even when an early await fails before the normal tail of `runScheduledTask()`
- truncate scheduled shell output on Unicode code-point boundaries and report the total using the same character unit
- add regressions covering early scheduler failures and Unicode shell-output truncation

## Root Cause
The scheduler had two separate correctness issues. Early exceptions could bypass `logTaskRun()` and `updateTaskAfterRun()`, leaving tasks due forever, and shell-output truncation mixed UTF-16 slicing with a byte-count label, which could split multibyte characters and misreport the total.

## Validation
- `bun test runtime/test/task-scheduler-shell.test.ts runtime/test/runtime/scheduler.test.ts`
- `bun run typecheck`
