### PR TITLE
[codex] fix(whatsapp): harden reconnect error and queue settlement

### DIFF
--- a/runtime/src/channels/whatsapp.ts
+++ b/runtime/src/channels/whatsapp.ts
@@ -85,6 +85,8 @@ const BASE_RECONNECT_DELAY_MS = 2_000; // 2s, 4s, 8s, 16s, 32s
 export class WhatsAppChannel {
   private sock!: WASocket;
   private connected = false;
+  private connectReject: ((error: unknown) => void) | null = null;
+  private connectResolve: (() => void) | null = null;
   private outgoingQueue: Array<{ jid: string; text: string }> = [];
   private flushing = false;
   private opts: WhatsAppChannelOpts;
@@ -102,7 +104,19 @@ export class WhatsAppChannel {
 
   async connect(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      this.connectInternal(resolve).catch(reject);
+      this.connectResolve = () => {
+        this.connectResolve = null;
+        this.connectReject = null;
+        resolve();
+      };
+      this.connectReject = (error) => {
+        this.connectResolve = null;
+        this.connectReject = null;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      };
+      this.connectInternal(this.connectResolve).catch((error) => {
+        this.settlePendingConnectError(error);
+      });
     });
   }
 
@@ -171,6 +185,9 @@ export class WhatsAppChannel {
                 operation: "connection.update.reconnect",
                 err,
               });
+              if (pending) {
+                this.settlePendingConnectError(err);
+              }
             });
           }, delay);
         } else {
@@ -297,5 +314,12 @@ export class WhatsAppChannel {
       this.pairingRequested = false;
       throw err;
     }
+  }
+
+  private settlePendingConnectError(error: unknown): void {
+    const reject = this.connectReject;
+    this.connectResolve = null;
+    this.connectReject = null;
+    reject?.(error);
   }
 }

--- a/runtime/src/channels/whatsapp.ts
+++ b/runtime/src/channels/whatsapp.ts
@@ -290,6 +290,17 @@ export class WhatsAppChannel {
     await sendWhatsAppTypingUpdate(this.sock, jid, isTyping);
   }
 
+  private scheduleQueueFlush(operation: string): void {
+    queueMicrotask(() => {
+      void this.flushOutgoingQueue().catch((err) => {
+        log.error("Failed to flush queued outbound messages", {
+          operation,
+          err,
+        });
+      });
+    });
+  }
+
   private async flushOutgoingQueue(): Promise<void> {
     if (this.flushing || this.outgoingQueue.length === 0) return;
     this.flushing = true;
@@ -300,6 +311,9 @@ export class WhatsAppChannel {
       }
     } finally {
       this.flushing = false;
+      if (this.connected && this.outgoingQueue.length > 0) {
+        this.scheduleQueueFlush("flush_outgoing_queue.retry_after_race");
+      }
     }
   }
 

--- a/runtime/test/channels/whatsapp.test.ts
+++ b/runtime/test/channels/whatsapp.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+
+import { WhatsAppChannel } from "../../src/channels/whatsapp.js";
+
+test("WhatsAppChannel.connect rejects when the first scheduled reconnect attempt throws", async () => {
+  const channel = new WhatsAppChannel({
+    onMessage: () => {},
+    onChatMetadata: () => {},
+    chatJids: () => new Set(),
+  }) as any;
+
+  let connectCalls = 0;
+  channel.connectInternal = async (onFirstOpen?: () => void) => {
+    connectCalls += 1;
+    if (connectCalls === 1) {
+      queueMicrotask(() => {
+        void channel.connectInternal(onFirstOpen).catch((error: unknown) => {
+          channel.settlePendingConnectError(error);
+        });
+      });
+      return;
+    }
+    throw new Error("scheduled reconnect failed");
+  };
+
+  await expect(channel.connect()).rejects.toThrow("scheduled reconnect failed");
+  expect(connectCalls).toBe(2);
+});

--- a/runtime/test/channels/whatsapp.test.ts
+++ b/runtime/test/channels/whatsapp.test.ts
@@ -26,3 +26,46 @@ test("WhatsAppChannel.connect rejects when the first scheduled reconnect attempt
   await expect(channel.connect()).rejects.toThrow("scheduled reconnect failed");
   expect(connectCalls).toBe(2);
 });
+
+test("WhatsAppChannel re-kicks queue flushing after a reconnect races with a failing stale flush", async () => {
+  const channel = new WhatsAppChannel({
+    onMessage: () => {},
+    onChatMetadata: () => {},
+    chatJids: () => new Set(),
+  }) as any;
+
+  channel.connected = true;
+  channel.outgoingQueue.push(
+    { jid: "chat-1", text: "first" },
+    { jid: "chat-1", text: "second" },
+  );
+
+  let rejectFirstSend!: (error: Error) => void;
+  const firstSend = new Promise<never>((_, reject) => {
+    rejectFirstSend = reject;
+  });
+  const delivered: string[] = [];
+
+  channel.sock = {
+    sendMessage: (jid: string, payload: { text: string }) => {
+      if (payload.text === "first") {
+        return firstSend;
+      }
+      delivered.push(`${jid}:${payload.text}`);
+      return Promise.resolve();
+    },
+  };
+
+  const staleFlush = channel.flushOutgoingQueue();
+  expect(channel.flushing).toBe(true);
+  expect(channel.outgoingQueue.map((item: { text: string }) => item.text)).toEqual(["second"]);
+
+  channel.flushOutgoingQueue();
+
+  rejectFirstSend(new Error("socket closed"));
+  await expect(staleFlush).rejects.toThrow("socket closed");
+  await Bun.sleep(0);
+
+  expect(delivered).toEqual(["chat-1:second"]);
+  expect(channel.outgoingQueue).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary
- keep the first `connect()` promise wired to shared resolve/reject handlers across delayed reconnect attempts
- reject the pending startup connect when a scheduled reconnect attempt throws before the first successful open
- re-kick outbound queue flushing when a reconnect-open races with a failing stale flush so queued messages do not strand until a later event
- add regressions for both the reconnect-failure settlement path and the queued-message drain race

## Root Cause
The WhatsApp channel had two reconnect races. A delayed reconnect could throw without settling the original startup `connect()` promise, and an `open` event that arrived while an older queue flush was still unwinding would skip the new flush attempt, leaving queued outbound messages stuck until something else triggered another drain.

## Validation
- `bun test runtime/test/channels/whatsapp.test.ts`
- `bun run typecheck`
