### PR TITLE
[codex] fix(web): serve SVG media as attachments

### DIFF
--- a/runtime/src/channels/web/handlers/media.ts
+++ b/runtime/src/channels/web/handlers/media.ts
@@ -50,7 +50,6 @@ const INLINE_SAFE_TYPES = new Set([
   "image/jpeg",
   "image/gif",
   "image/webp",
-  "image/svg+xml",
   "image/bmp",
   "image/x-icon",
 ]);

--- a/runtime/test/channels/web/media-handler.test.ts
+++ b/runtime/test/channels/web/media-handler.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+
+import { initDatabase, createMedia } from "../../../src/db.js";
+import { handleMedia } from "../../../src/channels/web/handlers/media.js";
+import { getTestWorkspace, setEnv } from "../../helpers.js";
+
+class StubChannel {
+  json(data: unknown, status = 200) {
+    return new Response(JSON.stringify(data), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
+test("handleMedia forces SVG downloads to attachment disposition", () => {
+  const ws = getTestWorkspace();
+  const restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
+
+  try {
+    initDatabase();
+    const mediaId = createMedia(
+      "vector.svg",
+      "image/svg+xml",
+      new TextEncoder().encode("<svg></svg>"),
+      null,
+      { size: 11 },
+    );
+
+    const res = handleMedia(new StubChannel() as any, mediaId, false);
+    expect(res.headers.get("Content-Disposition")).toBe("attachment");
+  } finally {
+    restoreEnv();
+  }
+});

--- a/runtime/test/channels/web/security-hardening.test.ts
+++ b/runtime/test/channels/web/security-hardening.test.ts
@@ -824,7 +824,7 @@ describe("media download headers", () => {
     restoreEnv();
   });
 
-  test("inline-safe images omit Content-Disposition", async () => {
+  test("SVG downloads use attachment disposition", async () => {
     const ws = getTestWorkspace();
     const restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
 
@@ -848,7 +848,7 @@ describe("media download headers", () => {
     }
 
     const res = handleMedia(new StubChannel() as any, mediaId, false);
-    expect(res.headers.get("Content-Disposition")).toBeNull();
+    expect(res.headers.get("Content-Disposition")).toBe("attachment");
 
     restoreEnv();
   });


### PR DESCRIPTION
## Summary
- remove `image/svg+xml` from the inline media allowlist so uploaded SVGs are downloaded instead of rendered in-origin
- update the existing hardening expectation for SVG media headers
- add a focused media-handler regression that verifies SVG responses now carry `Content-Disposition: attachment`

## Root cause
The media endpoint treated SVG as an inline-safe image type. In the web channel’s current CSP, that lets uploaded SVG content execute in the application origin instead of being forced through a download boundary.

## Validation
- `bun test runtime/test/channels/web/media-handler.test.ts`
- `bun run typecheck`
