### PR TITLE
[codex] fix(web-terminal): isolate anonymous owners and live clients

### DIFF
--- a/runtime/src/channels/web/terminal/terminal-session-service.ts
+++ b/runtime/src/channels/web/terminal/terminal-session-service.ts
@@ -66,10 +66,7 @@ interface TerminalSessionRecord {
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 30;
 const TERMINAL_FONT_FAMILY = "FiraCode Nerd Font Mono";
-const FALLBACK_TERMINAL_OWNER: TerminalSessionOwner = {
-  token: "web-terminal-local-default",
-  userId: DEFAULT_WEB_USER_ID,
-};
+const TERMINAL_ANON_CLIENT_HEADER = "x-piclaw-terminal-client";
 
 const IS_LINUX = process.platform === "linux";
 const DEFAULT_TERMINAL_HANDOFF_TTL_MS = 5 * 60 * 1000;
@@ -97,6 +94,17 @@ function createTerminalSessionId(): string {
   } catch (error) {
     debugSuppressedError(log, "crypto.randomUUID unavailable for terminal session id", error);
     return `terminal-session-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+}
+
+function readAnonymousTerminalClientToken(req: Request): string | null {
+  try {
+    const urlToken = new URL(req.url).searchParams.get("client")?.trim() || "";
+    const headerToken = req.headers.get(TERMINAL_ANON_CLIENT_HEADER)?.trim() || "";
+    const token = urlToken || headerToken;
+    return /^[a-zA-Z0-9._:-]{8,128}$/.test(token) ? token : null;
+  } catch {
+    return null;
   }
 }
 
@@ -270,7 +278,15 @@ export class TerminalSessionService {
         return { kind: "terminal", token, userId: session.user_id, handoffToken: null };
       }
     }
-    return allowUnauthenticated ? { kind: "terminal", ...FALLBACK_TERMINAL_OWNER, handoffToken: null } : null;
+    if (!allowUnauthenticated) return null;
+    const anonymousClientToken = readAnonymousTerminalClientToken(req);
+    if (!anonymousClientToken) return null;
+    return {
+      kind: "terminal",
+      token: `web-terminal-anon:${anonymousClientToken}`,
+      userId: DEFAULT_WEB_USER_ID,
+      handoffToken: null,
+    };
   }
 
   getSessionInfo(owner: TerminalSessionOwner) {

--- a/runtime/src/channels/web/terminal/terminal-session-service.ts
+++ b/runtime/src/channels/web/terminal/terminal-session-service.ts
@@ -350,6 +350,7 @@ export class TerminalSessionService {
   handleMessage(ws: ServerWebSocket<TerminalSocketData>, rawMessage: string | Buffer | Uint8Array): void {
     const session = this.sessions.get(ws.data.token);
     if (!session) return;
+    if (!session.clients.has(ws)) return;
 
     const messageText = typeof rawMessage === "string" ? rawMessage : Buffer.from(rawMessage).toString("utf8");
     const payload = this.parseClientMessage(messageText);

--- a/runtime/test/channels/web/terminal-session-service.test.ts
+++ b/runtime/test/channels/web/terminal-session-service.test.ts
@@ -186,6 +186,28 @@ test("terminal session handoff tokens are issued for live sessions and close pri
   expect(service.getSessionInfo({ token: "terminal-handoff", userId: "user-handoff" }).connected_clients).toBe(1);
 });
 
+test("terminal session service ignores input from detached clients during reconnect grace", () => {
+  createWebSession("terminal-detached", "user-detached", 3600, "totp");
+  const proc = new FakeProcess();
+  const service = new TerminalSessionService({
+    spawnProcess: () => proc as any,
+    reconnectGraceMs: 1_000,
+  });
+  const ws = {
+    data: { kind: "terminal", token: "terminal-detached", userId: "user-detached", handoffToken: null },
+    send: () => {},
+  } as any;
+
+  service.attachClient(ws);
+  service.detachClient(ws);
+
+  expect(service.getSessionInfo({ token: "terminal-detached", userId: "user-detached" }).active).toBe(true);
+  expect(service.getSessionInfo({ token: "terminal-detached", userId: "user-detached" }).connected_clients).toBe(0);
+
+  service.handleMessage(ws, JSON.stringify({ type: "input", data: "whoami\n" }));
+  expect(proc.stdinWrites).toEqual([]);
+});
+
 test("terminal session shutdown kills live shells", () => {
   const proc = new FakeProcess();
   const service = new TerminalSessionService({

--- a/runtime/test/channels/web/terminal-session-service.test.ts
+++ b/runtime/test/channels/web/terminal-session-service.test.ts
@@ -62,18 +62,29 @@ test("terminal session service resolves owner from web session cookie", () => {
   expect(service.resolveOwnerFromRequest(req)).toEqual({ kind: "terminal", token: "terminal-token", userId: "user-1", handoffToken: null });
 });
 
-test("terminal session service falls back to the local default owner when allowed", () => {
+test("terminal session service derives an anonymous owner from the per-client token when allowed", () => {
+  const service = new TerminalSessionService({
+    spawnProcess: () => new FakeProcess() as any,
+  });
+
+  const req = new Request("https://example.com/terminal/session", {
+    headers: { "x-piclaw-terminal-client": "anon-client-1" },
+  });
+  expect(service.resolveOwnerFromRequest(req, true)).toEqual({
+    kind: "terminal",
+    token: "web-terminal-anon:anon-client-1",
+    userId: "default",
+    handoffToken: null,
+  });
+});
+
+test("terminal session service refuses unauthenticated fallback when no per-client token is supplied", () => {
   const service = new TerminalSessionService({
     spawnProcess: () => new FakeProcess() as any,
   });
 
   const req = new Request("https://example.com/terminal/session");
-  expect(service.resolveOwnerFromRequest(req, true)).toEqual({
-    kind: "terminal",
-    token: "web-terminal-local-default",
-    userId: "default",
-    handoffToken: null,
-  });
+  expect(service.resolveOwnerFromRequest(req, true)).toBeNull();
 });
 
 test("terminal session service spawns one shell per web session and relays IO", () => {

--- a/runtime/test/web/terminal-pane.test.ts
+++ b/runtime/test/web/terminal-pane.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { tryRun } from "../helpers.js";
 
-import { buildTerminalTheme, relocateTerminalPaneRoot } from '../../web/src/panes/terminal-pane.js';
+import { buildTerminalTheme, getOrCreateAnonymousTerminalClientToken, relocateTerminalPaneRoot } from '../../web/src/panes/terminal-pane.js';
 
 // --- Inline types (same as pane-types.ts, for Bun test runner) ---
 
@@ -209,6 +209,29 @@ test('relocateTerminalPaneRoot moves the existing terminal shell into a new host
     expect(host.innerHTML).toBe('');
     expect(children).toEqual([root]);
     expect(relocateTerminalPaneRoot(root, null as any)).toBe(false);
+});
+
+test('getOrCreateAnonymousTerminalClientToken persists a stable client token', () => {
+    const storage = new Map<string, string>();
+    const runtimeWindow = {
+        localStorage: {
+            getItem(key: string) {
+                return storage.has(key) ? storage.get(key)! : null;
+            },
+            setItem(key: string, value: string) {
+                storage.set(key, value);
+            },
+        },
+        crypto: {
+            randomUUID: () => 'terminal-client-fixed',
+        },
+    } as any;
+
+    const first = getOrCreateAnonymousTerminalClientToken(runtimeWindow);
+    const second = getOrCreateAnonymousTerminalClientToken(runtimeWindow);
+
+    expect(first).toBe('terminal-client-fixed');
+    expect(second).toBe('terminal-client-fixed');
 });
 
 describe('Terminal pane extension', () => {

--- a/runtime/web/src/panes/terminal-pane.ts
+++ b/runtime/web/src/panes/terminal-pane.ts
@@ -22,6 +22,8 @@ export const TERMINAL_TAB_PATH = 'piclaw://terminal';
 const TERMINAL_FONT_FAMILY = 'FiraCode Nerd Font Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace';
 const TERMINAL_FONT_LOAD_SPEC = '400 13px "FiraCode Nerd Font Mono"';
 const TERMINAL_FONT_LOAD_SPEC_BOLD = '700 13px "FiraCode Nerd Font Mono"';
+const TERMINAL_ANON_CLIENT_HEADER = 'x-piclaw-terminal-client';
+const TERMINAL_ANON_CLIENT_STORAGE_KEY = 'piclaw_terminal_client';
 const LIGHT_TERMINAL_PALETTE = {
     yellow: '#9a6700',
     magenta: '#8250df',
@@ -110,10 +112,38 @@ async function ensureTerminalFontsReady() {
     await terminalFontsReadyPromise;
 }
 
-async function fetchTerminalSession() {
+function createTerminalClientToken(runtimeWindow = typeof window !== 'undefined' ? window : null) {
+    try {
+        if (typeof runtimeWindow?.crypto?.randomUUID === 'function') {
+            return runtimeWindow.crypto.randomUUID();
+        }
+    } catch (_error) {
+        // Fall back to a timestamp/random token below.
+    }
+    return `terminal-client-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function getOrCreateAnonymousTerminalClientToken(runtimeWindow = typeof window !== 'undefined' ? window : null) {
+    if (!runtimeWindow) return null;
+    try {
+        const storage = runtimeWindow.localStorage;
+        const existing = typeof storage?.getItem === 'function'
+            ? String(storage.getItem(TERMINAL_ANON_CLIENT_STORAGE_KEY) || '').trim()
+            : '';
+        if (existing) return existing;
+        const created = createTerminalClientToken(runtimeWindow);
+        storage?.setItem?.(TERMINAL_ANON_CLIENT_STORAGE_KEY, created);
+        return created;
+    } catch (_error) {
+        return createTerminalClientToken(runtimeWindow);
+    }
+}
+
+async function fetchTerminalSession(clientToken = getOrCreateAnonymousTerminalClientToken()) {
     const response = await fetch('/terminal/session', {
         method: 'GET',
         credentials: 'same-origin',
+        headers: clientToken ? { [TERMINAL_ANON_CLIENT_HEADER]: clientToken } : undefined,
     });
     const body = await response.json().catch(() => ({}));
     if (!response.ok) {
@@ -122,10 +152,11 @@ async function fetchTerminalSession() {
     return body;
 }
 
-async function requestTerminalHandoff() {
+async function requestTerminalHandoff(clientToken = getOrCreateAnonymousTerminalClientToken()) {
     const response = await fetch('/terminal/handoff', {
         method: 'POST',
         credentials: 'same-origin',
+        headers: clientToken ? { [TERMINAL_ANON_CLIENT_HEADER]: clientToken } : undefined,
     });
     const body = await response.json().catch(() => ({}));
     if (!response.ok) {
@@ -136,11 +167,14 @@ async function requestTerminalHandoff() {
         : null;
 }
 
-function buildTerminalWebSocketUrl(path, handoffToken = null) {
+function buildTerminalWebSocketUrl(path, handoffToken = null, clientToken = getOrCreateAnonymousTerminalClientToken()) {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const url = new URL(`${protocol}//${window.location.host}${path}`);
     if (handoffToken) {
         url.searchParams.set('handoff', String(handoffToken));
+    }
+    if (clientToken) {
+        url.searchParams.set('client', String(clientToken));
     }
     return url.toString();
 }


### PR DESCRIPTION
## Summary
- stop unauthenticated terminal users from sharing one fixed owner token by binding anonymous terminal access to a per-client token
- have the terminal pane persist and send that client token on session fetch, handoff, and websocket connect
- ignore websocket writes from detached clients so reconnect-grace stragglers cannot still write into a live terminal session
- add regressions for server-side anonymous-owner resolution, client-side token persistence, and detached-client write rejection

## Root Cause
The terminal service used one shared anonymous owner token when auth was disabled, and its websocket write path trusted `ws.data.token` alone. That meant separate anonymous browsers could converge on the same shell, and a detached websocket that still carried the right token could keep writing during reconnect grace.

## Validation
- `bun test runtime/test/channels/web/terminal-session-service.test.ts runtime/test/web/terminal-pane.test.ts`
- `bun run typecheck`
