### PR TITLE
[codex] fix(db): preserve message row identity on upsert

### DIFF
--- a/runtime/src/db/messages.ts
+++ b/runtime/src/db/messages.ts
@@ -154,7 +154,7 @@ export function listRecentChatJids(limit = 10, options?: { excludeChatJids?: str
 }
 
 /**
- * Persist a message into the `messages` table (INSERT OR REPLACE).
+ * Persist a message into the `messages` table.
  * Returns the SQLite rowid of the inserted row (used as the interaction id
  * in the web timeline and for media attachment linking).
  */
@@ -165,11 +165,23 @@ export function storeMessage(msg: NewMessage): number {
   const linkPreviews = msg.link_previews ? JSON.stringify(msg.link_previews) : null;
 
   db.prepare(
-    `INSERT OR REPLACE INTO messages (
+    `INSERT INTO messages (
       id, chat_jid, sender, sender_name, content, content_blocks, link_previews,
       thread_id, timestamp, is_from_me, is_bot_message, is_terminal_agent_reply, is_steering_message
     )
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id, chat_jid) DO UPDATE SET
+       sender = excluded.sender,
+       sender_name = excluded.sender_name,
+       content = excluded.content,
+       content_blocks = excluded.content_blocks,
+       link_previews = excluded.link_previews,
+       thread_id = excluded.thread_id,
+       timestamp = excluded.timestamp,
+       is_from_me = excluded.is_from_me,
+       is_bot_message = excluded.is_bot_message,
+       is_terminal_agent_reply = excluded.is_terminal_agent_reply,
+       is_steering_message = excluded.is_steering_message`
   ).run(
     msg.id,
     msg.chat_jid,

--- a/runtime/test/db/db.test.ts
+++ b/runtime/test/db/db.test.ts
@@ -389,6 +389,35 @@ test("media attachments are stored and returned", () => {
   expect(interaction?.data.media_ids).toEqual([mediaId]);
 });
 
+test("storeMessage updates existing rows without orphaning media attachments", () => {
+  const chatJid = `test:${Date.now()}-media-upsert`;
+  db.storeChatMetadata(chatJid, new Date().toISOString(), "Test");
+
+  const mediaId = db.createMedia(
+    "note.txt",
+    "text/plain",
+    new TextEncoder().encode("hello"),
+    null,
+    { size: 5 }
+  );
+
+  const message = makeMessage(chatJid, "original", "2024-03-01T00:00:00.000Z");
+  const firstRowId = db.storeMessage(message);
+  db.attachMediaToMessage(firstRowId, [mediaId]);
+
+  const secondRowId = db.storeMessage({
+    ...message,
+    content: "edited",
+    timestamp: "2024-03-01T00:01:00.000Z",
+  });
+
+  expect(secondRowId).toBe(firstRowId);
+
+  const interaction = db.getMessageByRowId(chatJid, secondRowId);
+  expect(interaction?.data.content).toBe("edited");
+  expect(interaction?.data.media_ids).toEqual([mediaId]);
+});
+
 test("text media attachments are added to message search indexing", () => {
   const chatJid = `test:${Date.now()}-media-fts`;
   db.storeChatMetadata(chatJid, new Date().toISOString(), "Test");


### PR DESCRIPTION
## Summary
- replace `INSERT OR REPLACE` in `storeMessage()` with an `ON CONFLICT ... DO UPDATE` upsert
- preserve the original `messages.rowid` so existing `message_media` links stay attached
- add a regression test that updates an existing message and verifies its media attachment survives

## Testing
- bun test runtime/test/db/db.test.ts
- bun run typecheck