### PR TITLE
[codex] fix(db): keep media indexing and orphan cleanup in sync

### DIFF
--- a/runtime/src/db/connection.ts
+++ b/runtime/src/db/connection.ts
@@ -108,6 +108,7 @@ function createSchema(database: Database): void {
       sender TEXT,
       sender_name TEXT,
       content TEXT,
+      fts_content TEXT,
       content_blocks TEXT,
       link_previews TEXT,
       thread_id INTEGER,
@@ -134,29 +135,25 @@ function createSchema(database: Database): void {
       sender UNINDEXED,
       sender_name UNINDEXED,
       timestamp UNINDEXED,
-      is_bot_message UNINDEXED,
-      content='messages',
-      content_rowid='rowid'
+      is_bot_message UNINDEXED
     );
 
     -- Trigger: populate FTS on message insert.
     CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
       INSERT INTO messages_fts(rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message)
-      VALUES (new.rowid, new.content, new.chat_jid, new.sender, new.sender_name, new.timestamp, new.is_bot_message);
+      VALUES (new.rowid, COALESCE(new.fts_content, new.content), new.chat_jid, new.sender, new.sender_name, new.timestamp, new.is_bot_message);
     END;
 
     -- Trigger: remove FTS entry on message delete.
     CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message)
-      VALUES ('delete', old.rowid, old.content, old.chat_jid, old.sender, old.sender_name, old.timestamp, old.is_bot_message);
+      DELETE FROM messages_fts WHERE rowid = old.rowid;
     END;
 
     -- Trigger: update FTS entry on message update (delete old + insert new).
     CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message)
-      VALUES ('delete', old.rowid, old.content, old.chat_jid, old.sender, old.sender_name, old.timestamp, old.is_bot_message);
+      DELETE FROM messages_fts WHERE rowid = old.rowid;
       INSERT INTO messages_fts(rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message)
-      VALUES (new.rowid, new.content, new.chat_jid, new.sender, new.sender_name, new.timestamp, new.is_bot_message);
+      VALUES (new.rowid, COALESCE(new.fts_content, new.content), new.chat_jid, new.sender, new.sender_name, new.timestamp, new.is_bot_message);
     END;
 
     CREATE TABLE IF NOT EXISTS media (
@@ -469,10 +466,8 @@ function createSchema(database: Database): void {
 }
 
 /**
- * Add columns that were introduced after the initial schema.
+ * Add message columns that were introduced after the initial schema.
  * Safe to call repeatedly – skips columns that already exist.
- * Handles the `content_blocks`, `link_previews`, and `thread_id` columns
- * added for the web channel's rich-message support.
  */
 function ensureMessageColumns(database: Database): void {
   const columns = database.prepare("PRAGMA table_info(messages)").all() as Array<{ name: string }>;
@@ -489,23 +484,66 @@ function ensureMessageColumns(database: Database): void {
       });
     }
   };
+  ensureColumn("fts_content");
   ensureColumn("content_blocks");
   ensureColumn("link_previews");
   ensureColumn("thread_id", "INTEGER");
   ensureColumn("is_terminal_agent_reply", "INTEGER DEFAULT 0");
   ensureColumn("is_steering_message", "INTEGER DEFAULT 0");
+  database.exec("UPDATE messages SET fts_content = content WHERE fts_content IS NULL");
 }
 
 /**
- * One-time FTS rebuild for databases created before the FTS triggers existed.
+ * Recreate the message FTS table and triggers with the current schema.
+ */
+function recreateMessageFts(database: Database): void {
+  database.exec(`
+    DROP TRIGGER IF EXISTS messages_ai;
+    DROP TRIGGER IF EXISTS messages_ad;
+    DROP TRIGGER IF EXISTS messages_au;
+    DROP TABLE IF EXISTS messages_fts;
+
+    CREATE VIRTUAL TABLE messages_fts USING fts5(
+      content,
+      chat_jid UNINDEXED,
+      sender UNINDEXED,
+      sender_name UNINDEXED,
+      timestamp UNINDEXED,
+      is_bot_message UNINDEXED
+    );
+
+    CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+      INSERT INTO messages_fts(rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message)
+      VALUES (new.rowid, COALESCE(new.fts_content, new.content), new.chat_jid, new.sender, new.sender_name, new.timestamp, new.is_bot_message);
+    END;
+
+    CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+      DELETE FROM messages_fts WHERE rowid = old.rowid;
+    END;
+
+    CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+      DELETE FROM messages_fts WHERE rowid = old.rowid;
+      INSERT INTO messages_fts(rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message)
+      VALUES (new.rowid, COALESCE(new.fts_content, new.content), new.chat_jid, new.sender, new.sender_name, new.timestamp, new.is_bot_message);
+    END;
+  `);
+}
+
+/**
+ * Rebuild the message FTS table when the search schema changes.
  * Uses PRAGMA user_version as a migration marker so it only runs once.
  */
 function ensureFts(database: Database): void {
   const row = database.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined;
   const version = typeof row?.user_version === "number" ? row.user_version : 0;
-  if (version >= 1) return;
-  database.exec("INSERT INTO messages_fts(messages_fts) VALUES('rebuild');");
-  database.exec("PRAGMA user_version = 1;");
+  if (version >= 2) return;
+  recreateMessageFts(database);
+  database.exec(`
+    INSERT INTO messages_fts(rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message)
+    SELECT rowid, COALESCE(fts_content, content), chat_jid, sender, sender_name, timestamp, is_bot_message
+    FROM messages;
+  `);
+  database.exec("PRAGMA user_version = 2;");
 }
 
 /**

--- a/runtime/src/db/media.ts
+++ b/runtime/src/db/media.ts
@@ -31,7 +31,7 @@ export function attachMediaToMessage(messageRowId: number, mediaIds: number[]): 
 
   // Extract searchable text from text-based media (SVG, markdown, plain text)
   // and append it to the FTS index so media content is full-text searchable.
-  appendMediaTextToFts(db, messageRowId, mediaIds);
+  appendMediaTextToFts(db, messageRowId);
 }
 
 /**
@@ -185,12 +185,15 @@ function stripTags(text: string): string {
 function appendMediaTextToFts(
   db: ReturnType<typeof getDb>,
   messageRowId: number,
-  mediaIds: number[],
 ): void {
-  const placeholders = mediaIds.map(() => "?").join(",");
   const rows = db
-    .prepare(`SELECT content_type, data FROM media WHERE id IN (${placeholders})`)
-    .all(...mediaIds) as Array<{ content_type: string; data: Uint8Array }>;
+    .prepare(
+      `SELECT media.content_type, media.data
+         FROM media
+         JOIN message_media ON message_media.media_id = media.id
+        WHERE message_media.message_rowid = ?`
+    )
+    .all(messageRowId) as Array<{ content_type: string; data: Uint8Array }>;
 
   const textParts: string[] = [];
   for (const row of rows) {
@@ -206,8 +209,6 @@ function appendMediaTextToFts(
       textParts.push(text);
     }
   }
-
-  if (textParts.length === 0) return;
 
   const msg = db
     .prepare(
@@ -225,14 +226,9 @@ function appendMediaTextToFts(
     | undefined;
   if (!msg) return;
 
-  const combined = msg.content + "\n\n" + textParts.join("\n");
+  const combined = textParts.length > 0
+    ? msg.content + "\n\n" + textParts.join("\n")
+    : msg.content;
 
-  // FTS5 content-sync: delete old entry, insert updated one
-  db.prepare(
-    "INSERT INTO messages_fts(messages_fts, rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message) VALUES ('delete', ?, ?, ?, ?, ?, ?, ?)",
-  ).run(messageRowId, msg.content, msg.chat_jid, msg.sender, msg.sender_name, msg.timestamp, msg.is_bot_message);
-
-  db.prepare(
-    "INSERT INTO messages_fts(rowid, content, chat_jid, sender, sender_name, timestamp, is_bot_message) VALUES (?, ?, ?, ?, ?, ?, ?)",
-  ).run(messageRowId, combined, msg.chat_jid, msg.sender, msg.sender_name, msg.timestamp, msg.is_bot_message);
+  db.prepare("UPDATE messages SET fts_content = ? WHERE rowid = ?").run(combined, messageRowId);
 }

--- a/runtime/src/db/media.ts
+++ b/runtime/src/db/media.ts
@@ -69,8 +69,27 @@ export function deleteUnreferencedMedia(mediaIds: number[]): number {
   if (mediaIds.length === 0) return 0;
   const db = getDb();
   const placeholders = mediaIds.map(() => "?").join(",");
+  db
+    .prepare(
+      `DELETE FROM message_media
+        WHERE media_id IN (${placeholders})
+          AND NOT EXISTS (
+            SELECT 1
+              FROM messages
+             WHERE messages.rowid = message_media.message_rowid
+          )`
+    )
+    .run(...mediaIds);
   const res = db
-    .prepare(`DELETE FROM media WHERE id IN (${placeholders}) AND id NOT IN (SELECT media_id FROM message_media)`)
+    .prepare(
+      `DELETE FROM media
+        WHERE id IN (${placeholders})
+          AND NOT EXISTS (
+            SELECT 1
+              FROM message_media
+             WHERE message_media.media_id = media.id
+          )`
+    )
     .run(...mediaIds);
   return Number(res.changes || 0);
 }

--- a/runtime/src/db/messages.ts
+++ b/runtime/src/db/messages.ts
@@ -39,6 +39,7 @@ interface StoredMessageRow {
   sender: string;
   sender_name: string;
   content: string;
+  fts_content: string | null;
   content_blocks: string | null;
   link_previews: string | null;
   thread_id: number | null;
@@ -47,7 +48,7 @@ interface StoredMessageRow {
 }
 
 /** Column list used in SELECT queries to ensure a consistent shape. */
-const MESSAGE_COLUMNS = "rowid, chat_jid, sender, sender_name, content, content_blocks, link_previews, thread_id, timestamp, is_bot_message";
+const MESSAGE_COLUMNS = "rowid, chat_jid, sender, sender_name, content, fts_content, content_blocks, link_previews, thread_id, timestamp, is_bot_message";
 
 function ensureMonotonicMessageTimestamp(chatJid: string, requestedTimestamp: string): string {
   const requestedMs = Date.parse(requestedTimestamp);
@@ -166,15 +167,16 @@ export function storeMessage(msg: NewMessage): number {
 
   db.prepare(
     `INSERT OR REPLACE INTO messages (
-      id, chat_jid, sender, sender_name, content, content_blocks, link_previews,
+      id, chat_jid, sender, sender_name, content, fts_content, content_blocks, link_previews,
       thread_id, timestamp, is_from_me, is_bot_message, is_terminal_agent_reply, is_steering_message
     )
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     msg.id,
     msg.chat_jid,
     msg.sender,
     msg.sender_name,
+    msg.content,
     msg.content,
     contentBlocks,
     linkPreviews,
@@ -283,9 +285,10 @@ export function replaceMessageContent(
   const linkPreviews = options.linkPreviews ? JSON.stringify(options.linkPreviews) : null;
   const res = db
     .prepare(
-      "UPDATE messages SET content = ?, content_blocks = ?, link_previews = ?, is_terminal_agent_reply = COALESCE(?, is_terminal_agent_reply) WHERE chat_jid = ? AND rowid = ?"
+      "UPDATE messages SET content = ?, fts_content = ?, content_blocks = ?, link_previews = ?, is_terminal_agent_reply = COALESCE(?, is_terminal_agent_reply) WHERE chat_jid = ? AND rowid = ?"
     )
     .run(
+      content,
       content,
       contentBlocks,
       linkPreviews,

--- a/runtime/test/db/db.test.ts
+++ b/runtime/test/db/db.test.ts
@@ -409,6 +409,31 @@ test("text media attachments are added to message search indexing", () => {
   expect(results.map((row) => row.data.content)).toContain("message body");
 });
 
+test("replacing message content refreshes media-backed FTS terms without leaving stale tokens", () => {
+  const chatJid = `test:${Date.now()}-media-fts-update`;
+  db.storeChatMetadata(chatJid, new Date().toISOString(), "Test");
+
+  const mediaId = db.createMedia(
+    "note.txt",
+    "text/plain",
+    new TextEncoder().encode("attached needle"),
+    null,
+    { size: 15 }
+  );
+
+  const rowId = db.storeMessage(makeMessage(chatJid, "original body", "2024-03-01T00:00:00.000Z"));
+  db.attachMediaToMessage(rowId, [mediaId]);
+
+  expect(db.searchMessages(chatJid, "needle", 10, 0).map((row) => row.id)).toEqual([rowId]);
+
+  const updated = db.replaceMessageContent(chatJid, rowId, "renamed body", { mediaIds: [mediaId] });
+  expect(updated?.data.content).toBe("renamed body");
+
+  expect(db.searchMessages(chatJid, "renamed", 10, 0).map((row) => row.id)).toEqual([rowId]);
+  expect(db.searchMessages(chatJid, "needle", 10, 0).map((row) => row.id)).toEqual([rowId]);
+  expect(db.searchMessages(chatJid, "original", 10, 0)).toEqual([]);
+});
+
 // --- New coverage: same-timestamp ordering & cursor filters ---
 
 test("same-timestamp ordering is stable for timeline and cursor queries", () => {

--- a/runtime/test/db/db.test.ts
+++ b/runtime/test/db/db.test.ts
@@ -531,6 +531,35 @@ test("deleteMessageByRowId cleans up media only when unreferenced", () => {
   expect(db.getMediaById(mediaId)).toBeUndefined();
 });
 
+test("deleteUnreferencedMedia removes media after sweeping dangling message_media rows", () => {
+  const mediaId = db.createMedia(
+    "orphan.txt",
+    "text/plain",
+    new TextEncoder().encode("orphaned"),
+    null,
+    { size: 8 }
+  );
+
+  db.getDb()
+    .prepare("INSERT INTO message_media (message_rowid, media_id) VALUES (?, ?)")
+    .run(999999, mediaId);
+
+  expect(db.getMediaById(mediaId)).toBeTruthy();
+  expect(
+    db.getDb()
+      .prepare("SELECT COUNT(*) AS count FROM message_media WHERE media_id = ?")
+      .get(mediaId),
+  ).toEqual({ count: 1 });
+
+  expect(db.deleteUnreferencedMedia([mediaId])).toBe(1);
+  expect(db.getMediaById(mediaId)).toBeUndefined();
+  expect(
+    db.getDb()
+      .prepare("SELECT COUNT(*) AS count FROM message_media WHERE media_id = ?")
+      .get(mediaId),
+  ).toEqual({ count: 0 });
+});
+
 test("deleteThreadByRowId removes thread replies and cleans up media", () => {
   const chatJid = `test:${Date.now()}-delete-thread`;
   db.storeChatMetadata(chatJid, new Date().toISOString(), "Test");


### PR DESCRIPTION
## Summary
- persist a dedicated `fts_content` source column for messages and rebuild the message FTS table from it
- update media attachment indexing to refresh `fts_content` instead of writing mismatched FTS rows directly
- sweep dangling `message_media` rows before orphan cleanup so stale join rows cannot keep media blobs alive forever
- add regressions covering both media-backed FTS refreshes and orphan-link cleanup

## Root cause
Media text indexing was mutating the FTS table directly while the message row remained unchanged, which let later message edits recreate stale search content. Separately, `deleteUnreferencedMedia()` trusted `message_media` blindly, so a dangling join row for a deleted message prevented the referenced media from ever being reclaimed.

## Impact
Search results stay aligned with the current message content plus any attached text media, and orphan media cleanup now recovers space even when older stale `message_media` rows exist.

## Testing
- `bun test runtime/test/db/db.test.ts runtime/test/extensions/messages-crud.test.ts`
- `bun run typecheck`
