### PR TITLE
[codex] fix(workspace-search): preserve partial refreshes and index .env

### DIFF
--- a/runtime/src/workspace-search.ts
+++ b/runtime/src/workspace-search.ts
@@ -172,23 +172,45 @@ const isTextFile = (filePath: string): boolean => {
   return getIndexedExtensions().has(ext);
 };
 
-async function walkFiles(root: string): Promise<string[]> {
+type WalkFilesResult = {
+  files: string[];
+  hadError: boolean;
+};
+
+async function walkFiles(root: string): Promise<WalkFilesResult> {
   const files: string[] = [];
+  let hadError = false;
+  let entries;
   try {
-    const entries = await fs.readdir(root, { withFileTypes: true });
-    for (const entry of entries) {
-      const full = path.join(root, entry.name);
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (err) {
+    debugSuppressedError(log, "Workspace walk skipped an unreadable directory.", err, {
+      operation: "workspace_search.walk.readdir",
+      path: toRelative(root),
+    });
+    return { files, hadError: true };
+  }
+
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    try {
       if (entry.isDirectory()) {
         if (entry.name === "node_modules" || entry.name === ".git" || entry.name === ".cache" || entry.name === "generated") continue;
-        files.push(...(await walkFiles(full)));
+        const nested = await walkFiles(full);
+        files.push(...nested.files);
+        hadError = hadError || nested.hadError;
       } else if (entry.isFile()) {
         files.push(full);
       }
+    } catch (err) {
+      hadError = true;
+      debugSuppressedError(log, "Workspace walk skipped an unreadable entry.", err, {
+        operation: "workspace_search.walk.entry",
+        path: toRelative(full),
+      });
     }
-  } catch {
-    return files;
   }
-  return files;
+  return { files, hadError };
 }
 
 function normalizeRoots(scope: string | undefined): string[] {
@@ -298,11 +320,13 @@ async function indexWorkspace(roots: string[], maxBytes: number): Promise<void> 
   const seen = new Set<string>();
   const now = new Date().toISOString();
   const rootPrefixes = rootsToPrefixes(roots);
+  let hadScanError = false;
 
   for (const root of roots) {
     const absRoot = path.resolve(root);
-    const files = await walkFiles(absRoot);
-    for (const file of files) {
+    const walk = await walkFiles(absRoot);
+    hadScanError = hadScanError || walk.hadError;
+    for (const file of walk.files) {
       if (!isTextFile(file)) continue;
       const rel = toRelative(file);
       try {
@@ -328,12 +352,17 @@ async function indexWorkspace(roots: string[], maxBytes: number): Promise<void> 
           "INSERT INTO workspace_files (path, mtime_ms, size_bytes, indexed_at) VALUES (?, ?, ?, ?) ON CONFLICT(path) DO UPDATE SET mtime_ms = excluded.mtime_ms, size_bytes = excluded.size_bytes, indexed_at = excluded.indexed_at",
         ).run(rel, mtimeMs, stat.size, now);
       } catch (err) {
+        hadScanError = true;
         debugSuppressedError(log, "Workspace index skipped an unreadable file.", err, {
           operation: "workspace_search.refresh.read_file",
           path: rel,
         });
       }
     }
+  }
+
+  if (hadScanError) {
+    return;
   }
 
   // aggressive cleanup: remove deleted files only within scanned roots

--- a/runtime/src/workspace-search.ts
+++ b/runtime/src/workspace-search.ts
@@ -169,7 +169,10 @@ function getIndexedExtensions(): Set<string> {
 
 const isTextFile = (filePath: string): boolean => {
   const ext = path.extname(filePath).toLowerCase();
-  return getIndexedExtensions().has(ext);
+  if (ext) {
+    return getIndexedExtensions().has(ext);
+  }
+  return getIndexedExtensions().has(path.basename(filePath).toLowerCase());
 };
 
 type WalkFilesResult = {

--- a/runtime/test/workspace-search.test.ts
+++ b/runtime/test/workspace-search.test.ts
@@ -87,3 +87,27 @@ test("workspace refresh does not prune previously indexed files when a subtree b
   const betaResults = await workspaceSearch.searchWorkspace({ scope: "notes", query: "hedgehogs", refresh: false });
   expect(betaResults.rows.map((row) => row.path)).toEqual(["notes/nested/beta.md"]);
 });
+
+test("workspace search indexes bare .env files by basename when extname is empty", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({
+    PICLAW_WORKSPACE: ws.workspace,
+    PICLAW_STORE: ws.store,
+    PICLAW_DATA: ws.data,
+  });
+
+  await fs.rm(path.join(ws.workspace, "notes"), { recursive: true, force: true });
+  await fs.rm(path.join(ws.data, "workspace-search"), { recursive: true, force: true });
+  await fs.mkdir(path.join(ws.workspace, "notes"), { recursive: true });
+  await fs.writeFile(path.join(ws.workspace, "notes", ".env"), "ENV_SECRET=alpha-needle");
+
+  const db = await importFresh<typeof import("../src/db.js")>("../src/db.js");
+  db.initDatabase();
+  const workspaceSearch = await importFresh<typeof import("../src/workspace-search.js")>("../src/workspace-search.js");
+
+  const refreshed = await workspaceSearch.refreshWorkspaceIndex({ scope: "notes" });
+  expect(refreshed.indexed_file_count).toBe(1);
+
+  const results = await workspaceSearch.searchWorkspace({ scope: "notes", query: "ENV_SECRET", refresh: false });
+  expect(results.rows.map((row) => row.path)).toEqual(["notes/.env"]);
+});

--- a/runtime/test/workspace-search.test.ts
+++ b/runtime/test/workspace-search.test.ts
@@ -45,3 +45,45 @@ test("workspace search status tracks never-indexed, ready, and stale lifecycle",
   expect(stale.state).toBe("stale");
   expect(stale.last_indexed_at).toBe(ready.last_indexed_at);
 });
+
+test("workspace refresh does not prune previously indexed files when a subtree becomes unreadable", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({
+    PICLAW_WORKSPACE: ws.workspace,
+    PICLAW_STORE: ws.store,
+    PICLAW_DATA: ws.data,
+  });
+
+  await fs.rm(path.join(ws.workspace, "notes"), { recursive: true, force: true });
+  await fs.rm(path.join(ws.data, "workspace-search"), { recursive: true, force: true });
+  await fs.mkdir(path.join(ws.workspace, "notes", "nested"), { recursive: true });
+  await fs.writeFile(path.join(ws.workspace, "notes", "alpha.md"), "alpha kittens");
+  await fs.writeFile(path.join(ws.workspace, "notes", "nested", "beta.md"), "beta hedgehogs");
+
+  const db = await importFresh<typeof import("../src/db.js")>("../src/db.js");
+  db.initDatabase();
+  const workspaceSearch = await importFresh<typeof import("../src/workspace-search.js")>("../src/workspace-search.js");
+
+  const initial = await workspaceSearch.refreshWorkspaceIndex({ scope: "notes" });
+  expect(initial.indexed_file_count).toBe(2);
+
+  const originalReaddir = fs.readdir.bind(fs);
+  (fs.readdir as typeof fs.readdir) = (async (target: fs.PathLike, options?: fs.ObjectEncodingOptions & { withFileTypes?: false } | BufferEncoding | null) => {
+    if (String(target).endsWith(path.join("notes", "nested"))) {
+      const error = new Error("permission denied");
+      (error as NodeJS.ErrnoException).code = "EACCES";
+      throw error;
+    }
+    return originalReaddir(target as Parameters<typeof fs.readdir>[0], options as Parameters<typeof fs.readdir>[1]);
+  }) as typeof fs.readdir;
+
+  try {
+    const refreshed = await workspaceSearch.refreshWorkspaceIndex({ scope: "notes" });
+    expect(refreshed.indexed_file_count).toBe(2);
+  } finally {
+    (fs.readdir as typeof fs.readdir) = originalReaddir;
+  }
+
+  const betaResults = await workspaceSearch.searchWorkspace({ scope: "notes", query: "hedgehogs", refresh: false });
+  expect(betaResults.rows.map((row) => row.path)).toEqual(["notes/nested/beta.md"]);
+});


### PR DESCRIPTION
## Summary
- make workspace directory walking report partial scan errors instead of silently collapsing them into a partial file list
- skip destructive stale-row pruning whenever a refresh encountered unreadable directories or files
- index bare `.env` files by basename when `path.extname()` returns an empty string for dotfiles
- add regressions covering both unreadable-subtree preservation and bare `.env` indexing

## Root cause
Workspace refresh previously treated walk errors as partial success and still pruned rows for files it could no longer see, which could erase valid index state after transient I/O failures. Separately, file-type detection only looked at `path.extname()`, so bare dotfiles like `.env` produced an empty extension and never matched the default indexed-extension set.

## Impact
Workspace refresh is now resilient to transient walk failures, and common config dotfiles such as `.env` are indexed by default instead of being skipped silently.

## Testing
- `bun test runtime/test/workspace-search.test.ts`
- `bun run typecheck`
