### PR TITLE
[codex] fix(web): render provisional popout labels as text

### DIFF
--- a/runtime/test/web/chat-window.test.ts
+++ b/runtime/test/web/chat-window.test.ts
@@ -17,6 +17,26 @@ import {
   primeProvisionalChatWindow,
 } from "../../web/src/ui/chat-window.js";
 
+function createFakeElement(tagName = "div") {
+  return {
+    tagName,
+    textContent: "",
+    attributes: {} as Record<string, string>,
+    children: [] as any[],
+    innerHTML: "",
+    setAttribute(name: string, value: string) {
+      this.attributes[name] = value;
+    },
+    appendChild(child: any) {
+      this.children.push(child);
+      return child;
+    },
+    replaceChildren(...children: any[]) {
+      this.children = [...children];
+    },
+  };
+}
+
 test("isStandaloneWebAppMode detects iOS standalone mode", () => {
   expect(isStandaloneWebAppMode({ navigator: { standalone: true } })).toBe(true);
 });
@@ -114,19 +134,39 @@ test("openProvisionalChatWindow opens about:blank in a new tab on mobile", () =>
 
 test("prime/navigate/close provisional chat window are safe helper operations", () => {
   const calls: string[] = [];
+  const body = createFakeElement("body");
   const handle: any = {
     location: { replace: (url: string) => calls.push(`replace:${url}`) },
-    document: { title: "", body: { innerHTML: "" } },
+    document: { title: "", body, createElement: (tag: string) => createFakeElement(tag) },
     close: () => calls.push("close"),
   };
 
   primeProvisionalChatWindow(handle, { title: "Opening branch…", message: "Preparing…" });
   expect(handle.document.title).toBe("Opening branch…");
-  expect(handle.document.body.innerHTML).toContain("Preparing…");
+  expect(body.children).toHaveLength(1);
+  expect(body.children[0].children[0].textContent).toBe("Opening branch…");
+  expect(body.children[0].children[1].textContent).toBe("Preparing…");
 
   navigateProvisionalChatWindow(handle, "https://example.com/chat");
   closeProvisionalChatWindow(handle);
   expect(calls).toEqual(["replace:https://example.com/chat", "close"]);
+});
+
+test("primeProvisionalChatWindow renders labels as text instead of parsing HTML", () => {
+  const body = createFakeElement("body");
+  const handle: any = {
+    document: { title: "", body, createElement: (tag: string) => createFakeElement(tag) },
+  };
+
+  primeProvisionalChatWindow(handle, {
+    title: 'Opening <img src=x onerror=alert(1)>…',
+    message: 'Preparing <script>alert(1)</script>',
+  });
+
+  expect(body.children).toHaveLength(1);
+  expect(body.children[0].children[0].textContent).toBe('Opening <img src=x onerror=alert(1)>…');
+  expect(body.children[0].children[1].textContent).toBe('Preparing <script>alert(1)</script>');
+  expect(body.innerHTML).toBe("");
 });
 
 test("prime/navigate/close provisional chat window tolerate disappearing popup handles", () => {

--- a/runtime/web/src/ui/chat-window.ts
+++ b/runtime/web/src/ui/chat-window.ts
@@ -84,12 +84,33 @@ export function primeProvisionalChatWindow(handle, options = {}) {
         const title = String(options.title || 'Opening branch…');
         const message = String(options.message || 'Preparing a new branch window…');
         handle.document.title = title;
-        handle.document.body.innerHTML = `
-            <div style="font-family: system-ui, sans-serif; padding: 24px; color: #222;">
-                <h1 style="font-size: 18px; margin: 0 0 12px;">${title}</h1>
-                <p style="margin: 0; line-height: 1.5;">${message}</p>
-            </div>
-        `;
+        const body = handle.document.body;
+        if (!body) return;
+
+        if (typeof handle.document.createElement !== 'function') {
+            body.textContent = `${title}\n${message}`;
+            return;
+        }
+
+        const wrapper = handle.document.createElement('div');
+        wrapper.setAttribute('style', 'font-family: system-ui, sans-serif; padding: 24px; color: #222;');
+
+        const heading = handle.document.createElement('h1');
+        heading.setAttribute('style', 'font-size: 18px; margin: 0 0 12px;');
+        heading.textContent = title;
+
+        const paragraph = handle.document.createElement('p');
+        paragraph.setAttribute('style', 'margin: 0; line-height: 1.5;');
+        paragraph.textContent = message;
+
+        wrapper.appendChild(heading);
+        wrapper.appendChild(paragraph);
+        if (typeof body.replaceChildren === 'function') {
+            body.replaceChildren(wrapper);
+        } else {
+            body.innerHTML = '';
+            body.appendChild(wrapper);
+        }
     } catch {
         return;
     }


### PR DESCRIPTION
## Summary
- stop writing provisional popout titles and messages through `innerHTML`
- build the popup placeholder DOM with explicit elements and `textContent` instead
- add a regression that proves attacker-controlled labels remain text instead of parsed markup

## Testing
- bun test runtime/test/web/chat-window.test.ts runtime/test/web/app-window-actions.test.ts
- bun run typecheck