### PR TITLE
[codex] fix(web): harden HTML attachment preview sandboxing

### DIFF
--- a/runtime/test/web/attachment-preview.test.ts
+++ b/runtime/test/web/attachment-preview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { HTML_ATTACHMENT_PREVIEW_SANDBOX } from "../../web/src/components/attachment-preview-modal.ts";
 import { getAttachmentPreviewKind, getAttachmentPreviewLabel } from "../../web/src/ui/attachment-preview.js";
 
 describe("attachment preview kind", () => {
@@ -11,5 +12,10 @@ describe("attachment preview kind", () => {
 
   test("returns the ZIP archive preview label", () => {
     expect(getAttachmentPreviewLabel("archive")).toBe("ZIP archive preview");
+  });
+
+  test("HTML attachment previews do not run with same-origin iframe privileges", () => {
+    expect(HTML_ATTACHMENT_PREVIEW_SANDBOX).toBe("allow-scripts");
+    expect(HTML_ATTACHMENT_PREVIEW_SANDBOX.includes("allow-same-origin")).toBe(false);
   });
 });

--- a/runtime/web/src/components/attachment-preview-modal.ts
+++ b/runtime/web/src/components/attachment-preview-modal.ts
@@ -8,6 +8,8 @@ import { highlightCodeToHtml, normalizeCodeLanguageLabel } from '../utils/code-h
 import { getAttachmentPreviewKind, getAttachmentPreviewLabel, isMarkdownAttachmentPreview } from '../ui/attachment-preview.js';
 import { formatCompressionRatio, getCompressionMethodLabel, parseZipPreview } from '../ui/zip-preview.js';
 
+export const HTML_ATTACHMENT_PREVIEW_SANDBOX = 'allow-scripts';
+
 function buildMetadata(info, languageLabel = null, archivePreview = null) {
     const size = info?.metadata?.size;
     const contentType = info?.content_type || 'application/octet-stream';
@@ -248,7 +250,7 @@ export function AttachmentPreviewModal({ mediaId, info, onClose }) {
                             <video class="attachment-preview-video" src=${getMediaUrl(mediaId)} controls autoplay style="max-width:100%;max-height:100%;" />
                         `}
                         ${!loading && !error && previewKind === 'html' && html`
-                            <iframe class="attachment-preview-frame" srcdoc=${textContent || ''} sandbox="allow-scripts allow-same-origin" title=${filename}></iframe>
+                            <iframe class="attachment-preview-frame" srcdoc=${textContent || ''} sandbox=${HTML_ATTACHMENT_PREVIEW_SANDBOX} title=${filename}></iframe>
                         `}
                         ${!loading && !error && (previewKind === 'pdf' || previewKind === 'office' || previewKind === 'drawio') && frameUrl && html`
                             <iframe class="attachment-preview-frame" src=${frameUrl} title=${filename}></iframe>


### PR DESCRIPTION
## Summary
- remove `allow-same-origin` from the HTML attachment preview iframe sandbox so preview scripts stay origin-isolated
- keep script execution limited to the sandboxed iframe only
- add a regression that locks the sandbox token set down

## Testing
- bun test runtime/test/web/attachment-preview.test.ts
- bun run typecheck