### PR TITLE
[codex] fix(drawio): validate postMessage source and origin before saves

### DIFF
--- a/runtime/extensions/viewers/drawio-editor/index.ts
+++ b/runtime/extensions/viewers/drawio-editor/index.ts
@@ -95,6 +95,17 @@ export function buildEmbeddedDrawioAppUrl(isDark: boolean, readOnly = false, rou
   return editorUrl;
 }
 
+// Keep this helper self-contained too: the wrapper page stringifies it so the
+// runtime check and the TypeScript regression tests share the same trust rule.
+export function isTrustedDrawioMessageEvent(
+  eventOrigin: string,
+  expectedOrigin: string,
+  eventSource: unknown,
+  frameWindow: unknown,
+): boolean {
+  return Boolean(frameWindow) && eventSource === frameWindow && eventOrigin === expectedOrigin;
+}
+
 export function isExplicitDrawioExportRequest(mimeType?: string, filename?: string): boolean {
   const explicitMime = mimeType && !/^(application|text)\/xml$/i.test(mimeType)
     ? EXPORT_EXTENSIONS[mimeType || ""]
@@ -245,6 +256,7 @@ document.title = fileName + ' · Draw.io';
 var frame = document.getElementById('editor-frame');
 var loading = document.getElementById('loading');
 var readonlyLock = document.getElementById('readonly-lock');
+var expectedFrameOrigin = window.location.origin;
 if (readOnly && readonlyLock) readonlyLock.classList.add('active');
 var DEFAULT_DRAWIO_XML = ${JSON.stringify(DEFAULT_DRAWIO_XML)};
 var xmlData = DEFAULT_DRAWIO_XML;
@@ -492,10 +504,7 @@ function startEditor() {
 window.addEventListener('message', function(e) {
   var msg;
   try { msg = JSON.parse(e.data); } catch(_) { return; }
-
-  // Most messages must come from our iframe. workspace-export is emitted
-  // by our wrapper-installed patch, which can surface with a wrapper source.
-  if (msg.event !== 'workspace-export' && e.source !== frame.contentWindow) return;
+  if (!(${isTrustedDrawioMessageEvent.toString()})(e.origin, expectedFrameOrigin, e.source, frame.contentWindow)) return;
 
   switch (msg.event) {
     case 'init':

--- a/runtime/test/extensions/drawio-editor-vendor-resolution.test.ts
+++ b/runtime/test/extensions/drawio-editor-vendor-resolution.test.ts
@@ -8,6 +8,7 @@ import {
   getDrawioVendorDirCandidates,
   isBinaryDrawioSaveTarget,
   isExplicitDrawioExportRequest,
+  isTrustedDrawioMessageEvent,
   MINIMAL_DRAWIO_EXPORT_ACTIONS,
   MINIMAL_DRAWIO_FILE_MENU_ACTIONS,
   resolveDrawioSavePath,
@@ -58,6 +59,24 @@ test('stringified buildEmbeddedDrawioAppUrl still works in the browser wrapper c
   const revived = new Function(`return (${buildEmbeddedDrawioAppUrl.toString()});`)() as typeof buildEmbeddedDrawioAppUrl;
   expect(revived(false)).toBe('/drawio/index.html?embed=1&proto=json&spin=1&modified=0&noSaveBtn=1&noExitBtn=1&saveAndExit=0&libraries=0&ui=dark&dark=0');
   expect(revived(true, true)).toContain('chrome=0');
+});
+
+test('drawio wrapper only trusts same-origin messages from the embedded iframe', () => {
+  const frameWindow = {};
+
+  expect(isTrustedDrawioMessageEvent('https://piclaw.test', 'https://piclaw.test', frameWindow, frameWindow)).toBe(true);
+  expect(isTrustedDrawioMessageEvent('https://attacker.test', 'https://piclaw.test', frameWindow, frameWindow)).toBe(false);
+  expect(isTrustedDrawioMessageEvent('https://piclaw.test', 'https://piclaw.test', {}, frameWindow)).toBe(false);
+  expect(isTrustedDrawioMessageEvent('https://piclaw.test', 'https://piclaw.test', frameWindow, null)).toBe(false);
+});
+
+test('stringified drawio trust helper keeps the same iframe and origin checks', () => {
+  const revived = new Function(`return (${isTrustedDrawioMessageEvent.toString()});`)() as typeof isTrustedDrawioMessageEvent;
+  const frameWindow = {};
+
+  expect(revived('https://piclaw.test', 'https://piclaw.test', frameWindow, frameWindow)).toBe(true);
+  expect(revived('https://attacker.test', 'https://piclaw.test', frameWindow, frameWindow)).toBe(false);
+  expect(revived('https://piclaw.test', 'https://piclaw.test', {}, frameWindow)).toBe(false);
 });
 
 test('minimal drawio menu constants keep Save plus reduced export formats', () => {


### PR DESCRIPTION
## Summary
- require draw.io wrapper messages to come from the embedded iframe and the same origin
- reuse the same trust predicate in the generated wrapper page and TypeScript tests so the browser copy stays aligned
- add regression coverage for cross-origin and wrong-source message attempts

## Testing
- bun test runtime/test/extensions/drawio-editor-vendor-resolution.test.ts
- bun test runtime/test/web/drawio-pane.test.ts
- bun run typecheck