### PR TITLE
[codex] fix(skills): delete source VM only after restore succeeds

### DIFF
--- a/runtime/skills/operator/proxmox-management/proxmox-move-vm-via-backup-restore.ts
+++ b/runtime/skills/operator/proxmox-management/proxmox-move-vm-via-backup-restore.ts
@@ -117,106 +117,145 @@ async function waitTask(base: string, token: Token, node: string, upid: string, 
   }
 }
 
-const sourceNode = (process.env.PVE_SOURCE_NODE || "").trim();
-const vmid = Number(process.env.PVE_VMID || "0");
-const targetNode = (process.env.PVE_TARGET_NODE || "").trim();
-const targetStorage = (process.env.PVE_TARGET_STORAGE || "").trim();
+type WaitTaskResult = { status?: string; exitstatus?: string };
 
-if (!sourceNode || !vmid || !targetNode || !targetStorage) {
-  console.error("Missing required env vars: PVE_SOURCE_NODE, PVE_VMID, PVE_TARGET_NODE, PVE_TARGET_STORAGE");
-  process.exit(2);
+export interface ProxmoxMoveVmViaBackupRestoreDeps {
+  env?: Record<string, string | undefined>;
+  apiImpl?: typeof api;
+  waitTaskImpl?: typeof waitTask;
+  getTokenImpl?: typeof getToken;
 }
 
-const targetVmid = Number(process.env.PVE_TARGET_VMID || String(vmid));
-const backupStorage = (process.env.PVE_BACKUP_STORAGE || "backup").trim();
-const backupMode = (process.env.PVE_BACKUP_MODE || "stop").trim();
-const deleteSource = process.env.PVE_DELETE_SOURCE === "1";
+function readRequiredMoveEnv(env: Record<string, string | undefined>) {
+  const sourceNode = (env.PVE_SOURCE_NODE || "").trim();
+  const vmid = Number(env.PVE_VMID || "0");
+  const targetNode = (env.PVE_TARGET_NODE || "").trim();
+  const targetStorage = (env.PVE_TARGET_STORAGE || "").trim();
 
-const base = process.env.PVE_BASE || "https://proxmox.example.com:8006/api2/json";
-const token = getToken();
+  if (!sourceNode || !vmid || !targetNode || !targetStorage) {
+    throw new Error("Missing required env vars: PVE_SOURCE_NODE, PVE_VMID, PVE_TARGET_NODE, PVE_TARGET_STORAGE");
+  }
 
-const sourceConfig = await api(base, token, `/nodes/${encodeURIComponent(sourceNode)}/qemu/${vmid}/config`);
-const sourceName = String(sourceConfig.data?.name || `vm-${vmid}`);
-const targetName = (process.env.PVE_TARGET_NAME || sourceName).trim();
+  return {
+    sourceNode,
+    vmid,
+    targetNode,
+    targetStorage,
+    targetVmid: Number(env.PVE_TARGET_VMID || String(vmid)),
+    backupStorage: (env.PVE_BACKUP_STORAGE || "backup").trim(),
+    backupMode: (env.PVE_BACKUP_MODE || "stop").trim(),
+    deleteSource: env.PVE_DELETE_SOURCE === "1",
+    base: env.PVE_BASE || "https://proxmox.example.com:8006/api2/json",
+  };
+}
 
-const backupParams = new URLSearchParams({
-  vmid: String(vmid),
-  storage: backupStorage,
-  mode: backupMode,
-  compress: "zstd",
-  remove: "0",
-});
+export async function runProxmoxMoveVmViaBackupRestore({
+  env = process.env,
+  apiImpl = api,
+  waitTaskImpl = waitTask,
+  getTokenImpl = getToken,
+}: ProxmoxMoveVmViaBackupRestoreDeps = {}) {
+  const {
+    sourceNode,
+    vmid,
+    targetNode,
+    targetStorage,
+    targetVmid,
+    backupStorage,
+    backupMode,
+    deleteSource,
+    base,
+  } = readRequiredMoveEnv(env);
+  const token = getTokenImpl();
 
-const backupTask = await api(base, token, `/nodes/${encodeURIComponent(sourceNode)}/vzdump`, {
-  method: "POST",
-  headers: { "Content-Type": "application/x-www-form-urlencoded" },
-  body: backupParams,
-});
+  const sourceConfig = await apiImpl(base, token, `/nodes/${encodeURIComponent(sourceNode)}/qemu/${vmid}/config`);
+  const sourceName = String(sourceConfig.data?.name || `vm-${vmid}`);
+  const targetName = (env.PVE_TARGET_NAME || sourceName).trim();
 
-const backupUpid = String(backupTask.data || "");
-if (!backupUpid.startsWith("UPID:")) throw new Error(`unexpected backup task response: ${JSON.stringify(backupTask)}`);
+  const backupParams = new URLSearchParams({
+    vmid: String(vmid),
+    storage: backupStorage,
+    mode: backupMode,
+    compress: "zstd",
+    remove: "0",
+  });
 
-const backupResult = await waitTask(base, token, sourceNode, backupUpid, 7200);
-if (backupResult.exitstatus !== "OK") throw new Error(`backup failed: ${backupResult.exitstatus || "unknown"}`);
+  const backupTask = await apiImpl(base, token, `/nodes/${encodeURIComponent(sourceNode)}/vzdump`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: backupParams,
+  });
 
-const content = await api(
-  base,
-  token,
-  `/nodes/${encodeURIComponent(sourceNode)}/storage/${encodeURIComponent(backupStorage)}/content?content=backup`,
-);
+  const backupUpid = String(backupTask.data || "");
+  if (!backupUpid.startsWith("UPID:")) throw new Error(`unexpected backup task response: ${JSON.stringify(backupTask)}`);
 
-const backups = ((content.data || []) as any[])
-  .filter((x) => String(x.volid || "").includes(`vzdump-qemu-${vmid}-`))
-  .sort((a, b) => Number(b.ctime || 0) - Number(a.ctime || 0));
+  const backupResult = await waitTaskImpl(base, token, sourceNode, backupUpid, 7200);
+  if (backupResult.exitstatus !== "OK") throw new Error(`backup failed: ${backupResult.exitstatus || "unknown"}`);
 
-if (!backups.length) throw new Error(`no backup artifact found for qemu/${vmid} in storage '${backupStorage}'`);
-const archive = String(backups[0].volid);
-
-let deleteResult: { status?: string; exitstatus?: string } | null = null;
-if (deleteSource) {
-  const del = await api(
+  const content = await apiImpl(
     base,
     token,
-    `/nodes/${encodeURIComponent(sourceNode)}/qemu/${vmid}?purge=1&destroy-unreferenced-disks=1`,
-    { method: "DELETE" },
+    `/nodes/${encodeURIComponent(sourceNode)}/storage/${encodeURIComponent(backupStorage)}/content?content=backup`,
   );
-  const delUpid = String(del.data || "");
-  if (!delUpid.startsWith("UPID:")) throw new Error(`unexpected delete response: ${JSON.stringify(del)}`);
-  deleteResult = await waitTask(base, token, sourceNode, delUpid, 3600);
-  if (deleteResult.exitstatus !== "OK") throw new Error(`source delete failed: ${deleteResult.exitstatus || "unknown"}`);
+
+  const backups = ((content.data || []) as any[])
+    .filter((x) => String(x.volid || "").includes(`vzdump-qemu-${vmid}-`))
+    .sort((a, b) => Number(b.ctime || 0) - Number(a.ctime || 0));
+
+  if (!backups.length) throw new Error(`no backup artifact found for qemu/${vmid} in storage '${backupStorage}'`);
+  const archive = String(backups[0].volid);
+
+  const restoreParams = new URLSearchParams();
+  restoreParams.set("vmid", String(targetVmid));
+  restoreParams.set("archive", archive);
+  restoreParams.set("storage", targetStorage);
+  restoreParams.set("name", targetName);
+  restoreParams.set("unique", "1");
+
+  const restoreTask = await apiImpl(base, token, `/nodes/${encodeURIComponent(targetNode)}/qemu`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: restoreParams,
+  });
+
+  const restoreUpid = String(restoreTask.data || "");
+  if (!restoreUpid.startsWith("UPID:")) throw new Error(`unexpected restore response: ${JSON.stringify(restoreTask)}`);
+
+  const restoreResult = await waitTaskImpl(base, token, targetNode, restoreUpid, 7200);
+  if (restoreResult.exitstatus !== "OK") throw new Error(`restore failed: ${restoreResult.exitstatus || "unknown"}`);
+
+  let deleteResult: WaitTaskResult | null = null;
+  if (deleteSource) {
+    const del = await apiImpl(
+      base,
+      token,
+      `/nodes/${encodeURIComponent(sourceNode)}/qemu/${vmid}?purge=1&destroy-unreferenced-disks=1`,
+      { method: "DELETE" },
+    );
+    const delUpid = String(del.data || "");
+    if (!delUpid.startsWith("UPID:")) throw new Error(`unexpected delete response: ${JSON.stringify(del)}`);
+    deleteResult = await waitTaskImpl(base, token, sourceNode, delUpid, 3600);
+    if (deleteResult.exitstatus !== "OK") throw new Error(`source delete failed: ${deleteResult.exitstatus || "unknown"}`);
+  }
+
+  const targetConfig = await apiImpl(base, token, `/nodes/${encodeURIComponent(targetNode)}/qemu/${targetVmid}/config`);
+
+  return {
+    source: { node: sourceNode, vmid, name: sourceName },
+    backup: { storage: backupStorage, upid: backupUpid, archive },
+    deleted_source: deleteSource ? deleteResult : null,
+    restored: { node: targetNode, vmid: targetVmid, name: targetName, upid: restoreUpid },
+    target_config: targetConfig.data || {},
+  };
 }
 
-const restoreParams = new URLSearchParams();
-restoreParams.set("vmid", String(targetVmid));
-restoreParams.set("archive", archive);
-restoreParams.set("storage", targetStorage);
-restoreParams.set("name", targetName);
-restoreParams.set("unique", "1");
-
-const restoreTask = await api(base, token, `/nodes/${encodeURIComponent(targetNode)}/qemu`, {
-  method: "POST",
-  headers: { "Content-Type": "application/x-www-form-urlencoded" },
-  body: restoreParams,
-});
-
-const restoreUpid = String(restoreTask.data || "");
-if (!restoreUpid.startsWith("UPID:")) throw new Error(`unexpected restore response: ${JSON.stringify(restoreTask)}`);
-
-const restoreResult = await waitTask(base, token, targetNode, restoreUpid, 7200);
-if (restoreResult.exitstatus !== "OK") throw new Error(`restore failed: ${restoreResult.exitstatus || "unknown"}`);
-
-const targetConfig = await api(base, token, `/nodes/${encodeURIComponent(targetNode)}/qemu/${targetVmid}/config`);
-
-console.log(
-  JSON.stringify(
-    {
-      source: { node: sourceNode, vmid, name: sourceName },
-      backup: { storage: backupStorage, upid: backupUpid, archive },
-      deleted_source: deleteSource ? deleteResult : null,
-      restored: { node: targetNode, vmid: targetVmid, name: targetName, upid: restoreUpid },
-      target_config: targetConfig.data || {},
-    },
-    null,
-    2,
-  ),
-);
+if (import.meta.main) {
+  try {
+    const result = await runProxmoxMoveVmViaBackupRestore();
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(message.startsWith("Missing required env vars:") ? 2 : 1);
+  }
+}

--- a/runtime/test/extensions/proxmox-move-vm-via-backup-restore.test.ts
+++ b/runtime/test/extensions/proxmox-move-vm-via-backup-restore.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test";
+
+import { importFresh } from "../helpers.js";
+
+const SCRIPT_PATH = "../skills/operator/proxmox-management/proxmox-move-vm-via-backup-restore.ts";
+
+test("runProxmoxMoveVmViaBackupRestore deletes the source only after a successful restore", async () => {
+  const mod = await importFresh<typeof import("../../skills/operator/proxmox-management/proxmox-move-vm-via-backup-restore.ts")>(SCRIPT_PATH);
+  const apiCalls: string[] = [];
+  const taskWaits: string[] = [];
+
+  const result = await mod.runProxmoxMoveVmViaBackupRestore({
+    env: {
+      PVE_SOURCE_NODE: "pve-source",
+      PVE_VMID: "117",
+      PVE_TARGET_NODE: "pve-target",
+      PVE_TARGET_STORAGE: "fast-ssd",
+      PVE_DELETE_SOURCE: "1",
+    },
+    getTokenImpl: () => ({ username: "user@pam!token", secret: "secret" }),
+    apiImpl: async (_base, _token, path, init) => {
+      apiCalls.push(`${init?.method ?? "GET"} ${path}`);
+      switch (`${init?.method ?? "GET"} ${path}`) {
+        case "GET /nodes/pve-source/qemu/117/config":
+          return { data: { name: "source-vm" } };
+        case "POST /nodes/pve-source/vzdump":
+          return { data: "UPID:backup" };
+        case "GET /nodes/pve-source/storage/backup/content?content=backup":
+          return { data: [{ volid: "backup:backup/vzdump-qemu-117-2026_04_17-00_00_00.vma.zst", ctime: 123 }] };
+        case "POST /nodes/pve-target/qemu":
+          return { data: "UPID:restore" };
+        case "DELETE /nodes/pve-source/qemu/117?purge=1&destroy-unreferenced-disks=1":
+          return { data: "UPID:delete" };
+        case "GET /nodes/pve-target/qemu/117/config":
+          return { data: { name: "source-vm" } };
+        default:
+          throw new Error(`unexpected api call: ${init?.method ?? "GET"} ${path}`);
+      }
+    },
+    waitTaskImpl: async (_base, _token, node, upid) => {
+      taskWaits.push(`${node}:${upid}`);
+      return { status: "stopped", exitstatus: "OK" };
+    },
+  });
+
+  expect(apiCalls).toEqual([
+    "GET /nodes/pve-source/qemu/117/config",
+    "POST /nodes/pve-source/vzdump",
+    "GET /nodes/pve-source/storage/backup/content?content=backup",
+    "POST /nodes/pve-target/qemu",
+    "DELETE /nodes/pve-source/qemu/117?purge=1&destroy-unreferenced-disks=1",
+    "GET /nodes/pve-target/qemu/117/config",
+  ]);
+  expect(taskWaits).toEqual([
+    "pve-source:UPID:backup",
+    "pve-target:UPID:restore",
+    "pve-source:UPID:delete",
+  ]);
+  expect(result.deleted_source).toEqual({ status: "stopped", exitstatus: "OK" });
+});
+
+test("runProxmoxMoveVmViaBackupRestore keeps the source VM when restore fails", async () => {
+  const mod = await importFresh<typeof import("../../skills/operator/proxmox-management/proxmox-move-vm-via-backup-restore.ts")>(SCRIPT_PATH);
+  const apiCalls: string[] = [];
+
+  await expect(
+    mod.runProxmoxMoveVmViaBackupRestore({
+      env: {
+        PVE_SOURCE_NODE: "pve-source",
+        PVE_VMID: "117",
+        PVE_TARGET_NODE: "pve-target",
+        PVE_TARGET_STORAGE: "fast-ssd",
+        PVE_DELETE_SOURCE: "1",
+      },
+      getTokenImpl: () => ({ username: "user@pam!token", secret: "secret" }),
+      apiImpl: async (_base, _token, path, init) => {
+        apiCalls.push(`${init?.method ?? "GET"} ${path}`);
+        switch (`${init?.method ?? "GET"} ${path}`) {
+          case "GET /nodes/pve-source/qemu/117/config":
+            return { data: { name: "source-vm" } };
+          case "POST /nodes/pve-source/vzdump":
+            return { data: "UPID:backup" };
+          case "GET /nodes/pve-source/storage/backup/content?content=backup":
+            return { data: [{ volid: "backup:backup/vzdump-qemu-117-2026_04_17-00_00_00.vma.zst", ctime: 123 }] };
+          case "POST /nodes/pve-target/qemu":
+            return { data: "UPID:restore" };
+          default:
+            throw new Error(`unexpected api call: ${init?.method ?? "GET"} ${path}`);
+        }
+      },
+      waitTaskImpl: async (_base, _token, node, upid) => {
+        if (node === "pve-target" && upid === "UPID:restore") {
+          return { status: "stopped", exitstatus: "ERROR" };
+        }
+        return { status: "stopped", exitstatus: "OK" };
+      },
+    }),
+  ).rejects.toThrow("restore failed: ERROR");
+
+  expect(apiCalls).toEqual([
+    "GET /nodes/pve-source/qemu/117/config",
+    "POST /nodes/pve-source/vzdump",
+    "GET /nodes/pve-source/storage/backup/content?content=backup",
+    "POST /nodes/pve-target/qemu",
+  ]);
+  expect(apiCalls.some((call) => call.startsWith("DELETE "))).toBe(false);
+});


### PR DESCRIPTION
## Summary
- refactor the Proxmox move-via-backup script into a callable entrypoint so its ordering can be tested directly
- wait for the restore task to finish successfully before issuing the optional source delete
- add regression coverage proving restore happens before delete and that restore failures never reach the delete step

## Testing
- bun test runtime/test/extensions/proxmox-move-vm-via-backup-restore.test.ts
- bun run typecheck