### PR TITLE
[codex] fix(reload): harden restarts and IPC file writes

### DIFF
--- a/runtime/skills/builtin/reload/restart-piclaw.sh
+++ b/runtime/skills/builtin/reload/restart-piclaw.sh
@@ -26,7 +26,7 @@
 set -euo pipefail
 
 export BUN_INSTALL="/usr/local/lib/bun"
-export PATH="$BUN_INSTALL/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH="$BUN_INSTALL/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"
 
 LOG_PATH="${PICLAW_RELOAD_LOG:-/tmp/restart-piclaw-force.log}"
 DETACH_DEFAULT="${PICLAW_RELOAD_ASYNC:-1}"
@@ -259,6 +259,23 @@ tidy_lock() {
     exec 9>&- || true
   fi
 }
+trap tidy_lock EXIT
+
+ipc_unique_suffix() {
+  printf '%s_%s_%s' "$(date +%s%N 2>/dev/null || date +%s)" "$$" "${RANDOM:-0}"
+}
+
+write_ipc_json_file() {
+  local dir="$1" prefix="$2" payload="$3"
+  local suffix final_path tmp_path
+  mkdir -p "$dir"
+  suffix=$(ipc_unique_suffix)
+  final_path="$dir/${prefix}_${suffix}.json"
+  tmp_path="$dir/.tmp.${prefix}_${suffix}.json"
+  printf '%s\n' "$payload" > "$tmp_path"
+  mv -f "$tmp_path" "$final_path"
+  printf '%s\n' "$final_path"
+}
 
 CHILD_PID=""
 handle_signal() {
@@ -267,7 +284,7 @@ handle_signal() {
     kill "$CHILD_PID" 2>/dev/null || true
     wait "$CHILD_PID" 2>/dev/null || true
   }
-  tidy_lock; exit 0
+  exit 0
 }
 trap handle_signal SIGTERM SIGINT
 
@@ -280,11 +297,13 @@ notify_ready() {
   fi
   for _ in $(seq 1 40); do
     if can_connect_local_port "$ready_port"; then
-      mkdir -p "$IPC_MESSAGES_DIR"
-      cat > "$IPC_MESSAGES_DIR/reload_$(date +%s%N).json" <<EOF
+      local payload
+      payload=$(cat <<EOF
 {"type":"message","chatJid":"web:default","text":"Piclaw reload complete."}
 EOF
-      echo "ready" > "$NOTIFY_SENT_FILE"
+)
+      write_ipc_json_file "$IPC_MESSAGES_DIR" "reload" "$payload" >/dev/null
+      printf 'ready\n' > "$NOTIFY_SENT_FILE"
       return 0
     fi
     sleep 0.5
@@ -299,9 +318,12 @@ queue_resume_pending() {
   ls "$IPC_TASKS_DIR"/resume_pending_*.json >/dev/null 2>&1 && {
     echo "[reload] Resume IPC already queued; skipping."; return 0
   }
-  cat > "$IPC_TASKS_DIR/resume_pending_$(date +%s%N).json" <<EOF
+  local payload
+  payload=$(cat <<EOF
 {"type":"resume_pending","chatJid":"all","reason":"reload"}
 EOF
+)
+  write_ipc_json_file "$IPC_TASKS_DIR" "resume_pending" "$payload" >/dev/null
   echo "[reload] Queued resume_pending IPC."
 }
 
@@ -357,7 +379,6 @@ restart_manual() {
     [ -n "$OLD_SUPERVISOR" ] && [ "$OLD_SUPERVISOR" != "$$" ] && kill_pid "$OLD_SUPERVISOR" "old supervisor"
   fi
   echo $$ > "$SUPERVISOR_PIDFILE"
-  tidy_lock
 
   echo "[reload] Starting: $* (supervisor PID $$)"
   local attempt=0
@@ -367,10 +388,14 @@ restart_manual() {
     CHILD_PID=$!
     echo "$CHILD_PID" > "$PIDFILE"
     [ ! -f "$NOTIFY_SENT_FILE" ] && notify_ready &
-    wait "$CHILD_PID"
-    local status=$?
+    local status=0
+    wait "$CHILD_PID" || status=$?
     CHILD_PID=""
     [ $status -eq 0 ] && { echo "[reload] piclaw exited cleanly"; exit 0; }
+    if [ $status -eq 130 ] || [ $status -eq 143 ]; then
+      echo "[reload] piclaw received SIGTERM/SIGINT; stopping supervisor cleanly"
+      exit 0
+    fi
     [ $attempt -ge 5 ] && { echo "[reload] piclaw exited with status $status; giving up"; exit $status; }
     echo "[reload] piclaw exited with status $status; restarting in 2s"
     sleep 2

--- a/runtime/skills/builtin/reload/restart-piclaw.sh
+++ b/runtime/skills/builtin/reload/restart-piclaw.sh
@@ -200,6 +200,20 @@ find_port_pid() {
     | awk -F 'pid=' 'NR>1 {split($2,a,","); print a[1]}' | head -1
 }
 
+is_valid_port() {
+  local port="${1:-}"
+  case "$port" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$port" -ge 1 ] 2>/dev/null && [ "$port" -le 65535 ] 2>/dev/null
+}
+
+can_connect_local_port() {
+  local port="$1"
+  is_valid_port "$port" || return 1
+  (exec 3<>/dev/tcp/127.0.0.1/$port) >/dev/null 2>&1
+}
+
 wait_for_agent_idle() {
   command -v curl >/dev/null 2>&1 || { echo "[reload] curl not available; skipping agent status wait."; return 0; }
   local url="http://127.0.0.1:$PORT/agent/status"
@@ -260,8 +274,12 @@ trap handle_signal SIGTERM SIGINT
 notify_ready() {
   local ready_port="${1:-$PORT}"
   [ -f "$NOTIFY_SENT_FILE" ] && return 0
+  if ! is_valid_port "$ready_port"; then
+    echo "[reload] Invalid ready port '$ready_port'; skipping reload notification."
+    return 0
+  fi
   for _ in $(seq 1 40); do
-    if bash -c "</dev/tcp/127.0.0.1/$ready_port" >/dev/null 2>&1; then
+    if can_connect_local_port "$ready_port"; then
       mkdir -p "$IPC_MESSAGES_DIR"
       cat > "$IPC_MESSAGES_DIR/reload_$(date +%s%N).json" <<EOF
 {"type":"message","chatJid":"web:default","text":"Piclaw reload complete."}
@@ -360,6 +378,10 @@ restart_manual() {
 }
 
 # ── Main ─────────────────────────────────────────────────────────────
+
+if [ "${PICLAW_RESTART_TEST_MODE:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 wait_for_agent_idle
 queue_resume_pending

--- a/runtime/skills/builtin/schedule/SKILL.md
+++ b/runtime/skills/builtin/schedule/SKILL.md
@@ -32,7 +32,11 @@ Examples:
 If tool access is unavailable, write an IPC JSON file to `$PICLAW_DATA/ipc/tasks/`:
 
 ```bash
-cat > "$PICLAW_DATA/ipc/tasks/schedule_$(date +%s).json" <<EOF
+mkdir -p "$PICLAW_DATA/ipc/tasks"
+suffix="$(date +%s%N)_$$_${RANDOM:-0}"
+tmp="$PICLAW_DATA/ipc/tasks/.tmp.schedule_${suffix}.json"
+final="$PICLAW_DATA/ipc/tasks/schedule_${suffix}.json"
+cat > "$tmp" <<EOF
 {
   "type": "schedule_task",
   "chatJid": "$PICLAW_CHAT_JID",
@@ -42,12 +46,17 @@ cat > "$PICLAW_DATA/ipc/tasks/schedule_$(date +%s).json" <<EOF
   "schedule_value": "2026-03-09T09:00:00Z"
 }
 EOF
+mv "$tmp" "$final"
 ```
 
 Shell command variant:
 
 ```bash
-cat > "$PICLAW_DATA/ipc/tasks/schedule_$(date +%s).json" <<EOF
+mkdir -p "$PICLAW_DATA/ipc/tasks"
+suffix="$(date +%s%N)_$$_${RANDOM:-0}"
+tmp="$PICLAW_DATA/ipc/tasks/.tmp.schedule_${suffix}.json"
+final="$PICLAW_DATA/ipc/tasks/schedule_${suffix}.json"
+cat > "$tmp" <<EOF
 {
   "type": "schedule_task",
   "chatJid": "$PICLAW_CHAT_JID",
@@ -59,6 +68,7 @@ cat > "$PICLAW_DATA/ipc/tasks/schedule_$(date +%s).json" <<EOF
   "schedule_value": "3600000"
 }
 EOF
+mv "$tmp" "$final"
 ```
 
 ## Verify it was scheduled

--- a/runtime/skills/builtin/send-message/SKILL.md
+++ b/runtime/skills/builtin/send-message/SKILL.md
@@ -11,7 +11,11 @@ Write a JSON file to the piclaw IPC directory to send a message right away.
 ## Usage
 
 ```bash
-cat > "$PICLAW_DATA/ipc/messages/msg_$(date +%s).json" <<EOF
+mkdir -p "$PICLAW_DATA/ipc/messages"
+suffix="$(date +%s%N)_$$_${RANDOM:-0}"
+tmp="$PICLAW_DATA/ipc/messages/.tmp.msg_${suffix}.json"
+final="$PICLAW_DATA/ipc/messages/msg_${suffix}.json"
+cat > "$tmp" <<EOF
 {
   "type": "message",
   "chatJid": "$PICLAW_CHAT_JID",
@@ -25,6 +29,7 @@ cat > "$PICLAW_DATA/ipc/messages/msg_$(date +%s).json" <<EOF
   ]
 }
 EOF
+mv "$tmp" "$final"
 ```
 
 ## When to Use

--- a/runtime/skills/operator/graphite-power-chart/graphite-power-chart.ts
+++ b/runtime/skills/operator/graphite-power-chart/graphite-power-chart.ts
@@ -55,7 +55,8 @@
  * Consumers: Invoked via /skill:graphite-power-chart.
  */
 
-import { mkdirSync, writeFileSync } from "fs";
+import { mkdirSync, renameSync, writeFileSync } from "fs";
+import { randomUUID } from "crypto";
 import { basename, join } from "path";
 
 const args = process.argv.slice(2);
@@ -122,6 +123,21 @@ const dataDir = process.env.PICLAW_DATA || "/workspace/.piclaw/data";
 const messagesDir = join(dataDir, "ipc", "messages");
 const mediaDir = join(dataDir, "ipc", "media");
 
+const buildUniqueFilePath = (dir: string, prefix: string, extension: string): string =>
+  join(dir, `${prefix}-${Date.now()}-${randomUUID()}${extension}`);
+
+const writeTextFileAtomic = (dir: string, prefix: string, extension: string, content: string): string => {
+  mkdirSync(dir, { recursive: true });
+  const finalPath = buildUniqueFilePath(dir, prefix, extension);
+  const tmpPath = join(dir, `.tmp.${basename(finalPath)}`);
+  writeFileSync(tmpPath, content, "utf8");
+  renameSync(tmpPath, finalPath);
+  return finalPath;
+};
+
+const writeJsonFileAtomic = (dir: string, prefix: string, payload: unknown): string =>
+  writeTextFileAtomic(dir, prefix, ".json", JSON.stringify(payload, null, 2));
+
 const chooseResamplePeriod = (hours: number): string => {
   if (hours <= 3) return "1min";
   if (hours <= 6) return "2min";
@@ -158,9 +174,12 @@ const points = datapoints
 if (!points.length) {
   const msg = `No data for ${displayName} (last ${targetHours}h).`;
   if (ipcEnabled) {
-    mkdirSync(messagesDir, { recursive: true });
-    const outPath = join(messagesDir, `msg_${Date.now()}_graphite_power.json`);
-    writeFileSync(outPath, JSON.stringify({ type: "message", chatJid, text: msg, noNudge: !nudgeEnabled }, null, 2));
+    writeJsonFileAtomic(messagesDir, "msg_graphite_power", {
+      type: "message",
+      chatJid,
+      text: msg,
+      noNudge: !nudgeEnabled,
+    });
   } else {
     process.stdout.write(msg);
   }
@@ -360,11 +379,7 @@ const summaryLines = [
 const message = summaryLines.join("\n");
 
 if (ipcEnabled) {
-  mkdirSync(messagesDir, { recursive: true });
-  mkdirSync(mediaDir, { recursive: true });
-  const svgPath = join(mediaDir, `graphite-power-${Date.now()}.svg`);
-  writeFileSync(svgPath, svg, "utf8");
-  const outPath = join(messagesDir, `msg_${Date.now()}_graphite_power.json`);
+  const svgPath = writeTextFileAtomic(mediaDir, "graphite-power", ".svg", svg);
   const payloadOut = {
     type: "message",
     chatJid,
@@ -379,7 +394,7 @@ if (ipcEnabled) {
       },
     ],
   };
-  writeFileSync(outPath, JSON.stringify(payloadOut, null, 2));
+  const outPath = writeJsonFileAtomic(messagesDir, "msg_graphite_power", payloadOut);
   process.stdout.write(outPath);
 } else {
   const dataUrl = `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;

--- a/runtime/skills/operator/token-chart/token-chart.ts
+++ b/runtime/skills/operator/token-chart/token-chart.ts
@@ -53,7 +53,8 @@
  * Consumers: Scheduled by task-scheduler.ts or invoked manually via /skill:token-chart.
  */
 
-import { readdirSync, statSync, readFileSync, mkdirSync, writeFileSync, existsSync } from "fs";
+import { readdirSync, statSync, readFileSync, mkdirSync, renameSync, writeFileSync, existsSync } from "fs";
+import { randomUUID } from "crypto";
 import { basename, dirname, join } from "path";
 import Database from "bun:sqlite";
 import { generateProviderModelChart } from "./token-usage-by-provider-model-chart";
@@ -98,6 +99,21 @@ const outputSvgCandidate = outputSvgArgIndex >= 0 ? args[outputSvgArgIndex + 1] 
 const outputSvg = outputSvgCandidate && !outputSvgCandidate.startsWith("--") ? outputSvgCandidate : undefined;
 const storeDir = process.env.PICLAW_STORE || "/workspace/.piclaw/store";
 const dbPath = join(storeDir, "messages.db");
+
+const buildUniqueFilePath = (dir: string, prefix: string, extension: string): string =>
+  join(dir, `${prefix}-${Date.now()}-${randomUUID()}${extension}`);
+
+const writeTextFileAtomic = (dir: string, prefix: string, extension: string, content: string): string => {
+  mkdirSync(dir, { recursive: true });
+  const finalPath = buildUniqueFilePath(dir, prefix, extension);
+  const tmpPath = join(dir, `.tmp.${basename(finalPath)}`);
+  writeFileSync(tmpPath, content, "utf8");
+  renameSync(tmpPath, finalPath);
+  return finalPath;
+};
+
+const writeJsonFileAtomic = (dir: string, prefix: string, payload: unknown): string =>
+  writeTextFileAtomic(dir, prefix, ".json", JSON.stringify(payload, null, 2));
 
 const now = new Date();
 const start = new Date(now);
@@ -166,11 +182,7 @@ function runProviderModelMode() {
     writeFileSync(outputSvg, result.svg, "utf8");
   }
   if (ipcEnabled) {
-    mkdirSync(messagesDir, { recursive: true });
-    mkdirSync(mediaDir, { recursive: true });
-    const svgPath = outputSvg || join(mediaDir, `token-chart-provider-model-${Date.now()}.svg`);
-    if (!outputSvg) writeFileSync(svgPath, result.svg, "utf8");
-    const outPath = join(messagesDir, `msg_${Date.now()}_tokenchart.json`);
+    const svgPath = outputSvg || writeTextFileAtomic(mediaDir, "token-chart-provider-model", ".svg", result.svg);
     const payload = {
       type: "message",
       chatJid,
@@ -185,7 +197,7 @@ function runProviderModelMode() {
         },
       ],
     };
-    writeFileSync(outPath, JSON.stringify(payload, null, 2));
+    const outPath = writeJsonFileAtomic(messagesDir, "msg_tokenchart", payload);
     process.stdout.write(outPath);
   } else {
     const dataUrl = `data:image/svg+xml;base64,${Buffer.from(result.svg).toString("base64")}`;
@@ -596,15 +608,8 @@ const summaryLines = [
 const message = summaryLines.join("\n");
 
 if (ipcEnabled) {
-  mkdirSync(messagesDir, { recursive: true });
-  mkdirSync(mediaDir, { recursive: true });
+  const svgPath = outputSvg || writeTextFileAtomic(mediaDir, "token-chart", ".svg", svg);
 
-  const svgPath = outputSvg || join(mediaDir, `token-chart-${Date.now()}.svg`);
-  if (!outputSvg) {
-    writeFileSync(svgPath, svg, "utf8");
-  }
-
-  const outPath = join(messagesDir, `msg_${Date.now()}_tokenchart.json`);
   const payload = {
     type: "message",
     chatJid,
@@ -619,7 +624,7 @@ if (ipcEnabled) {
       },
     ],
   };
-  writeFileSync(outPath, JSON.stringify(payload, null, 2));
+  const outPath = writeJsonFileAtomic(messagesDir, "msg_tokenchart", payload);
   process.stdout.write(outPath);
 } else {
   const dataUrl = `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;

--- a/runtime/test/extensions/restart-piclaw-port-validation.test.ts
+++ b/runtime/test/extensions/restart-piclaw-port-validation.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -14,7 +14,7 @@ test("restart-piclaw rejects invalid ready ports without executing shell payload
   try {
     const probe = Bun.spawnSync([
       "bash",
-      "-lc",
+      "-c",
       `
         set -euo pipefail
         export PICLAW_RESTART_TEST_MODE=1
@@ -32,6 +32,100 @@ test("restart-piclaw rejects invalid ready ports without executing shell payload
     expect(probe.exitCode).toBe(0);
     expect(probe.stdout.toString()).toContain("Invalid ready port");
     expect(existsSync(markerPath)).toBe(false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("restart-piclaw keeps the supervisor lock until the child starts and treats SIGTERM exits as graceful", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "piclaw-reload-sigterm-test-"));
+  const releasedPath = join(tempDir, "lock-released");
+  const attemptsPath = join(tempDir, "attempts.log");
+  const pidfilePath = join(tempDir, "piclaw.pid");
+  const supervisorPidfilePath = join(tempDir, "piclaw-supervisor.pid");
+  const childScriptPath = join(tempDir, "self-term.sh");
+
+  try {
+    writeFileSync(
+      childScriptPath,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ -f "$1" ]; then
+  exit 44
+fi
+echo attempt >> "$2"
+kill -TERM "$BASHPID"
+`,
+      "utf8",
+    );
+    chmodSync(childScriptPath, 0o755);
+
+    const probe = Bun.spawnSync([
+      "bash",
+      "-c",
+      `
+        set -euo pipefail
+        export PICLAW_RESTART_TEST_MODE=1
+        export PICLAW_RELOAD_ASYNC=0
+        source ${JSON.stringify(SCRIPT_PATH)}
+        PIDFILE=${JSON.stringify(pidfilePath)}
+        SUPERVISOR_PIDFILE=${JSON.stringify(supervisorPidfilePath)}
+        tidy_lock() { printf 'released\\n' >> ${JSON.stringify(releasedPath)}; }
+        kill_pid() { :; }
+        find_port_pid() { return 0; }
+        notify_ready() { :; }
+        restart_manual bash ${JSON.stringify(childScriptPath)} ${JSON.stringify(releasedPath)} ${JSON.stringify(attemptsPath)}
+      `,
+    ], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(probe.exitCode).toBe(0);
+    expect(probe.stdout.toString()).toContain("received SIGTERM/SIGINT");
+    expect(readFileSync(attemptsPath, "utf8").trim().split("\n")).toHaveLength(1);
+    expect(readFileSync(releasedPath, "utf8")).toContain("released");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("restart-piclaw IPC helper writes unique atomic JSON files", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "piclaw-reload-ipc-test-"));
+  const dataDir = join(tempDir, "data");
+  const messagesDir = join(dataDir, "ipc", "messages");
+
+  try {
+    const probe = Bun.spawnSync([
+      "bash",
+      "-c",
+      `
+        set -euo pipefail
+        export PICLAW_RESTART_TEST_MODE=1
+        export PICLAW_DATA=${JSON.stringify(dataDir)}
+        export PICLAW_RELOAD_ASYNC=0
+        source ${JSON.stringify(SCRIPT_PATH)}
+        write_ipc_json_file "$IPC_MESSAGES_DIR" "reload" '{"type":"message","text":"one"}' >/dev/null
+        write_ipc_json_file "$IPC_MESSAGES_DIR" "reload" '{"type":"message","text":"two"}' >/dev/null
+      `,
+    ], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(probe.exitCode).toBe(0);
+
+    const files = readdirSync(messagesDir);
+    const jsonFiles = files.filter((file) => file.endsWith(".json"));
+    expect(jsonFiles).toHaveLength(2);
+    expect(files.some((file) => file.startsWith(".tmp."))).toBe(false);
+    const payloads = jsonFiles.map((file) => JSON.parse(readFileSync(join(messagesDir, file), "utf8")));
+    expect(payloads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: "one" }),
+        expect.objectContaining({ text: "two" }),
+      ]),
+    );
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/runtime/test/extensions/restart-piclaw-port-validation.test.ts
+++ b/runtime/test/extensions/restart-piclaw-port-validation.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const SCRIPT_PATH = "/workspace/.tmp/piclaw-skl-03/runtime/skills/builtin/reload/restart-piclaw.sh";
+
+test("restart-piclaw rejects invalid ready ports without executing shell payloads", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "piclaw-reload-port-test-"));
+  const markerPath = join(tempDir, "injected");
+  const reloadLog = join(tempDir, "reload.log");
+  const dataDir = join(tempDir, "data");
+
+  try {
+    const probe = Bun.spawnSync([
+      "bash",
+      "-lc",
+      `
+        set -euo pipefail
+        export PICLAW_RESTART_TEST_MODE=1
+        export PICLAW_RELOAD_ASYNC=0
+        export PICLAW_RELOAD_LOG=${JSON.stringify(reloadLog)}
+        export PICLAW_DATA=${JSON.stringify(dataDir)}
+        source ${JSON.stringify(SCRIPT_PATH)}
+        notify_ready ${JSON.stringify(`8080; touch ${markerPath}`)}
+      `,
+    ], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(probe.exitCode).toBe(0);
+    expect(probe.stdout.toString()).toContain("Invalid ready port");
+    expect(existsSync(markerPath)).toBe(false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/runtime/test/scripts/graphite-power-chart-ipc.test.ts
+++ b/runtime/test/scripts/graphite-power-chart-ipc.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import "../helpers.js";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const SCRIPT_PATH = "/workspace/.tmp/piclaw-skl-03/runtime/skills/operator/graphite-power-chart/graphite-power-chart.ts";
+
+test("graphite power chart --ipc writes unique atomic IPC files", async () => {
+  const base = mkdtempSync(join(tmpdir(), "piclaw-graphite-ipc-"));
+  const dataDir = join(base, "data");
+  const now = Math.floor(Date.now() / 1000);
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      return Response.json([
+        {
+          target: "zigbee.server_closet_ups_power.power",
+          datapoints: [
+            [101, now - 300],
+            [111, now],
+          ],
+        },
+      ]);
+    },
+  });
+
+  try {
+    const runChart = async () => {
+      const proc = Bun.spawn([
+        "bun",
+        SCRIPT_PATH,
+        "--device",
+        "server_closet_ups_power",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "--ipc",
+      ], {
+        env: {
+          ...process.env,
+          PICLAW_DATA: dataDir,
+        },
+      });
+      expect(await proc.exited).toBe(0);
+    };
+
+    await runChart();
+    await runChart();
+
+    const messagesDir = join(dataDir, "ipc", "messages");
+    const mediaDir = join(dataDir, "ipc", "media");
+    const files = readdirSync(messagesDir).filter((file) => file.endsWith(".json"));
+    expect(files).toHaveLength(2);
+    expect(readdirSync(messagesDir).some((file) => file.startsWith(".tmp."))).toBe(false);
+    expect(readdirSync(mediaDir).filter((file) => file.endsWith(".svg"))).toHaveLength(2);
+    expect(readdirSync(mediaDir).some((file) => file.startsWith(".tmp."))).toBe(false);
+
+    const payload = JSON.parse(readFileSync(join(messagesDir, files[0]), "utf8"));
+    expect(payload).toMatchObject({
+      type: "message",
+      chatJid: "web:default",
+      noNudge: true,
+    });
+    expect(payload.text).toContain("last 12h");
+    expect(payload.media[0]).toMatchObject({
+      content_type: "image/svg+xml",
+      inline: true,
+    });
+  } finally {
+    server.stop(true);
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/runtime/test/scripts/token-chart-ipc.test.ts
+++ b/runtime/test/scripts/token-chart-ipc.test.ts
@@ -11,7 +11,9 @@ import { mkdirSync, writeFileSync, readdirSync, readFileSync, rmSync } from "fs"
 import { join } from "path";
 import { tmpdir } from "os";
 
-test("token chart --ipc writes JSON message safely", () => {
+const SCRIPT_PATH = "/workspace/.tmp/piclaw-skl-03/runtime/skills/operator/token-chart/token-chart.ts";
+
+test("token chart --ipc writes unique atomic IPC message files", () => {
   const base = join(tmpdir(), `piclaw-ipc-${Date.now()}`);
   const sessionsDir = join(base, "sessions");
   const dataDir = join(base, "data");
@@ -31,26 +33,32 @@ test("token chart --ipc writes JSON message safely", () => {
 
   writeFileSync(join(sessionsDir, "session.jsonl"), JSON.stringify(entry));
 
-  const proc = Bun.spawnSync([
-    "bun",
-    "/workspace/piclaw/runtime/skills/operator/token-chart/token-chart.ts",
-    "--days",
-    "1",
-    "--sessions-dir",
-    sessionsDir,
-    "--ipc",
-  ], {
-    env: {
-      ...process.env,
-      PICLAW_DATA: dataDir,
-    },
-  });
+  const runChart = () =>
+    Bun.spawnSync([
+      "bun",
+      SCRIPT_PATH,
+      "--days",
+      "1",
+      "--sessions-dir",
+      sessionsDir,
+      "--ipc",
+    ], {
+      env: {
+        ...process.env,
+        PICLAW_DATA: dataDir,
+      },
+    });
 
-  expect(proc.exitCode).toBe(0);
+  expect(runChart().exitCode).toBe(0);
+  expect(runChart().exitCode).toBe(0);
 
   const messagesDir = join(dataDir, "ipc", "messages");
+  const mediaDir = join(dataDir, "ipc", "media");
   const files = readdirSync(messagesDir).filter((f) => f.endsWith(".json"));
-  expect(files.length).toBe(1);
+  expect(files.length).toBe(2);
+  expect(readdirSync(messagesDir).some((f) => f.startsWith(".tmp."))).toBe(false);
+  expect(readdirSync(mediaDir).filter((f) => f.endsWith(".svg")).length).toBe(2);
+  expect(readdirSync(mediaDir).some((f) => f.startsWith(".tmp."))).toBe(false);
   const payload = JSON.parse(readFileSync(join(messagesDir, files[0]), "utf8"));
   expect(payload.type).toBe("message");
   expect(payload.chatJid).toBe("web:default");

--- a/runtime/test/scripts/token-chart-provider-model.test.ts
+++ b/runtime/test/scripts/token-chart-provider-model.test.ts
@@ -9,6 +9,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 import Database from "bun:sqlite";
 
+const SCRIPT_PATH = "/workspace/.tmp/piclaw-skl-03/runtime/skills/operator/token-chart/token-chart.ts";
+
 test("token-chart --mode provider-model renders an alternative chart", () => {
   const base = join(tmpdir(), `piclaw-tokenchart-provider-model-${Date.now()}`);
   const storeDir = join(base, "store");
@@ -89,7 +91,7 @@ test("token-chart --mode provider-model renders an alternative chart", () => {
   const proc = Bun.spawnSync(
     [
       "bun",
-      "/workspace/piclaw/runtime/skills/operator/token-chart/token-chart.ts",
+      SCRIPT_PATH,
       "--days",
       "2",
       "--source",

--- a/runtime/test/scripts/token-chart.test.ts
+++ b/runtime/test/scripts/token-chart.test.ts
@@ -12,6 +12,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 import Database from "bun:sqlite";
 
+const SCRIPT_PATH = "/workspace/.tmp/piclaw-skl-03/runtime/skills/operator/token-chart/token-chart.ts";
+
 function formatDay(d: Date) {
   const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   const pad = (n: number) => n.toString().padStart(2, "0");
@@ -50,7 +52,7 @@ test("token chart outputs chart first and summary lines", () => {
 
   const proc = Bun.spawnSync([
     "bun",
-    "/workspace/piclaw/runtime/skills/operator/token-chart/token-chart.ts",
+    SCRIPT_PATH,
     "--days",
     "2",
     "--sessions-dir",
@@ -78,7 +80,7 @@ test("token chart handles empty sessions directory", () => {
 
   const proc = Bun.spawnSync([
     "bun",
-    "/workspace/piclaw/runtime/skills/operator/token-chart/token-chart.ts",
+    SCRIPT_PATH,
     "--days",
     "1",
     "--sessions-dir",
@@ -136,7 +138,7 @@ test("token chart combines normal and autoresearch into one daily stack when rea
 
   const proc = Bun.spawnSync([
     "bun",
-    "/workspace/piclaw/runtime/skills/operator/token-chart/token-chart.ts",
+    SCRIPT_PATH,
     "--days",
     "1",
     "--source",
@@ -187,7 +189,7 @@ test("token chart ignores malformed JSONL lines", () => {
 
   const proc = Bun.spawnSync([
     "bun",
-    "/workspace/piclaw/runtime/skills/operator/token-chart/token-chart.ts",
+    SCRIPT_PATH,
     "--days",
     "1",
     "--sessions-dir",


### PR DESCRIPTION
## Summary
- reject invalid readiness ports before reload probes localhost and preserve the inherited PATH while still preferring the bundled Bun toolchain
- keep the manual restart flock held for the supervisor lifetime, treat child `SIGTERM`/`SIGINT` exits as graceful shutdown, and move reload/resume IPC writes onto atomic temp-file renames
- harden the token-chart and graphite-power-chart IPC writers with collision-resistant filenames plus atomic JSON/SVG writes, and update the fallback IPC skill examples to show the same pattern

## Testing
- `bun test test/extensions/restart-piclaw-port-validation.test.ts test/scripts/token-chart.test.ts test/scripts/token-chart-provider-model.test.ts test/scripts/token-chart-ipc.test.ts test/scripts/graphite-power-chart-ipc.test.ts`
- `bun run typecheck`
