### PR TITLE
[codex] fix(supervisor): stop managed process groups cleanly

### DIFF
--- a/runtime/test/scripts/supervisor-run-piclaw.test.ts
+++ b/runtime/test/scripts/supervisor-run-piclaw.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { waitFor } from "../helpers.js";
+
+const RUN_SCRIPT = "/workspace/.tmp/piclaw-ops-01/supervisor/run-piclaw.sh";
+const SUPERVISOR_CONF = "/workspace/.tmp/piclaw-ops-01/supervisor/conf.d/piclaw.conf";
+
+function processExists(pid: number): boolean {
+  const probe = Bun.spawnSync(["bash", "-lc", `kill -0 ${pid}`], { stdout: "pipe", stderr: "pipe" });
+  return probe.exitCode === 0;
+}
+
+test("supervisor idle wrapper terminates its tail child on SIGTERM", async () => {
+  const tempHome = mkdtempSync(join(tmpdir(), "piclaw-supervisor-home-"));
+  const proc = Bun.spawn(["bash", RUN_SCRIPT], {
+    cwd: "/workspace/.tmp/piclaw-ops-01",
+    env: {
+      ...process.env,
+      HOME: tempHome,
+      PICLAW_AUTOSTART: "0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let childPid = 0;
+
+  try {
+    await waitFor(() => {
+      const result = Bun.spawnSync(["bash", "-lc", `ps -o pid= --ppid ${proc.pid} | head -n 1`], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const value = result.stdout.toString().trim();
+      childPid = value ? Number(value) : 0;
+      return childPid > 0;
+    }, 5000, 100);
+
+    expect(processExists(childPid)).toBe(true);
+
+    proc.kill("SIGTERM");
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+
+    await Bun.sleep(150);
+    expect(processExists(childPid)).toBe(false);
+  } finally {
+    if (!proc.killed) {
+      proc.kill("SIGKILL");
+      await proc.exited.catch(() => {});
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test("supervisor config stops and kills the full process group", () => {
+  const conf = readFileSync(SUPERVISOR_CONF, "utf8");
+  expect(conf).toContain("stopasgroup=true");
+  expect(conf).toContain("killasgroup=true");
+});

--- a/supervisor/conf.d/piclaw.conf
+++ b/supervisor/conf.d/piclaw.conf
@@ -13,6 +13,8 @@ startsecs=3
 startretries=10
 stopsignal=INT
 stopwaitsecs=60
+stopasgroup=true
+killasgroup=true
 stdout_logfile=/var/log/piclaw/piclaw.stdout.log
 stderr_logfile=/var/log/piclaw/piclaw.stderr.log
 environment=HOME="/home/agent",BUN_INSTALL="/usr/local/lib/bun",PATH="/usr/local/lib/bun/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",PICLAW_WEB_TERMINAL_ENABLED="1"

--- a/supervisor/run-piclaw.sh
+++ b/supervisor/run-piclaw.sh
@@ -23,7 +23,11 @@ fi
 
 if [ "${PICLAW_AUTOSTART:-1}" != "1" ]; then
   echo "[run-piclaw] PICLAW_AUTOSTART=0; supervisor service is idle."
-  tail -f /dev/null & wait $!
+  tail -f /dev/null &
+  IDLE_CHILD_PID=$!
+  trap 'kill "$IDLE_CHILD_PID" 2>/dev/null || true; wait "$IDLE_CHILD_PID" 2>/dev/null || true; exit 0' TERM INT
+  wait "$IDLE_CHILD_PID"
+  exit 0
 fi
 
 PORT="${PICLAW_WEB_PORT:-8080}"


### PR DESCRIPTION
## Summary
- forward TERM/INT from the supervisor wrapper to the idle child instead of orphaning it under PID 1
- enable `stopasgroup` and `killasgroup` in the shipped supervisor program config
- add regression coverage for idle-child shutdown and the supervisor config flags

## Testing
- bun test runtime/test/scripts/supervisor-run-piclaw.test.ts
- bun run typecheck