### PR TITLE
[codex] fix(docker): clean up restic installer temp dirs on failure

### DIFF
--- a/runtime/test/scripts/install-restic-release.test.ts
+++ b/runtime/test/scripts/install-restic-release.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const SCRIPT_PATH = "/workspace/.tmp/piclaw-ops-02/scripts/docker/install-restic-release.sh";
+
+test("install-restic-release cleans up its temp dir when curl fails", () => {
+  const root = mkdtempSync(join(tmpdir(), "piclaw-restic-install-"));
+  const fakeBin = join(root, "bin");
+  const tempRoot = join(root, "tmp");
+  const installDir = join(root, "install");
+  mkdirSync(fakeBin, { recursive: true });
+  mkdirSync(tempRoot, { recursive: true });
+  mkdirSync(installDir, { recursive: true });
+
+  try {
+    writeFileSync(
+      join(fakeBin, "curl"),
+      "#!/usr/bin/env bash\nexit 23\n",
+      { mode: 0o755 },
+    );
+
+    const run = Bun.spawnSync(["bash", SCRIPT_PATH], {
+      cwd: "/workspace/.tmp/piclaw-ops-02",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+        TMPDIR: tempRoot,
+        RESTIC_VERSION: "0.17.3",
+        RESTIC_ARCH: "amd64",
+        RESTIC_INSTALL_DIR: installDir,
+      },
+    });
+
+    expect(run.exitCode).not.toBe(0);
+    expect(readdirSync(tempRoot)).toEqual([]);
+    expect(readdirSync(installDir)).toEqual([]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/docker/install-restic-release.sh
+++ b/scripts/docker/install-restic-release.sh
@@ -68,7 +68,7 @@ resolve_restic_version() {
   return 1
 }
 
-install_restic_release() {
+install_restic_release() (
   local restic_version="$1"
   local restic_target="$2"
   local install_dir="${RESTIC_INSTALL_DIR:-/usr/local/bin}"
@@ -83,7 +83,7 @@ install_restic_release() {
   local expected_checksum
   local actual_checksum
 
-  trap "rm -rf '$temp_dir'" RETURN
+  trap 'rm -rf "$temp_dir"' EXIT
 
   curl_download "$url" "$bundle"
   curl_download "${base_url}/SHA256SUMS" "$checksums"
@@ -105,7 +105,7 @@ install_restic_release() {
   mkdir -p "$install_dir"
   bunzip2 -c "$bundle" > "$install_dir/restic"
   chmod 0755 "$install_dir/restic"
-}
+)
 
 main() {
   local restic_version restic_target


### PR DESCRIPTION
## Summary
- run the restic install step in a subshell so its temp dir is always cleaned up via an `EXIT` trap
- keep the existing install flow intact while making cleanup run on `set -e` failures as well as successful exits
- add a regression test that forces curl to fail and verifies the temporary download directory is removed

## Testing
- bun test runtime/test/scripts/install-restic-release.test.ts
- bun run typecheck