### PR TITLE
[codex] fix(agent-pool): route async binder failures through onError

### DIFF
--- a/runtime/src/agent-pool/session-binder.ts
+++ b/runtime/src/agent-pool/session-binder.ts
@@ -24,25 +24,21 @@ export class AgentSessionBinder {
     this.binder = binder;
     if (!binder) return;
     for (const [jid, entry] of this.options.pool) {
-      try {
-        void binder(entry.runtime, jid);
-      } catch (err) {
-        this.options.onError?.("Failed to bind session", {
-          operation: "set_session_binder.bind_existing_session",
-          chatJid: jid,
-          err,
-        });
-      }
+      void this.runBinder(entry.runtime, jid, "set_session_binder.bind_existing_session");
     }
   }
 
   async bindSession(runtime: AgentSessionRuntime, chatJid: string): Promise<void> {
+    await this.runBinder(runtime, chatJid, "bind_session");
+  }
+
+  private async runBinder(runtime: AgentSessionRuntime, chatJid: string, operation: string): Promise<void> {
     if (!this.binder) return;
     try {
       await this.binder(runtime, chatJid);
     } catch (err) {
       this.options.onError?.("Failed to bind session", {
-        operation: "bind_session",
+        operation,
         chatJid,
         err,
       });

--- a/runtime/test/agent-pool/session-binder.test.ts
+++ b/runtime/test/agent-pool/session-binder.test.ts
@@ -46,3 +46,24 @@ test("AgentSessionBinder binds existing sessions and handles binder failures", a
   ]);
   expect(errors).toEqual(["Failed to bind session"]);
 });
+
+test("AgentSessionBinder reports async binder failures for existing sessions", async () => {
+  const pool = new Map<string, { runtime: any; lastUsed: number }>();
+  const errors: string[] = [];
+
+  pool.set("web:one", { runtime: createRuntime({ id: "one" }), lastUsed: Date.now() });
+  pool.set("web:two", { runtime: createRuntime({ id: "two" }), lastUsed: Date.now() });
+
+  const binder = new AgentSessionBinder({
+    pool: pool as any,
+    onError: (message) => errors.push(message),
+  });
+
+  binder.setBinder(async (_runtime: any, chatJid) => {
+    if (chatJid === "web:two") throw new Error("async boom");
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(errors).toEqual(["Failed to bind session"]);
+});


### PR DESCRIPTION
## Summary
- route existing-session binder calls through the same async error handling path as `bindSession`
- report rejected binder promises through the configured `onError` hook instead of letting them escape as unhandled rejections
- add a regression test covering an async binder failure during `setBinder`

## Root cause
`setBinder` invoked the binder for already-pooled sessions inside a synchronous `try`/`catch` and discarded the returned promise. That meant synchronous throws were reported, but async rejections bypassed `onError` entirely.

## Validation
- `bun test runtime/test/agent-pool/session-binder.test.ts`
- `bun run typecheck`
