### PR TITLE
[codex] fix(agent-pool): scope attachment registry state per pool

### DIFF
--- a/runtime/src/agent-pool/attachments.ts
+++ b/runtime/src/agent-pool/attachments.ts
@@ -1,8 +1,8 @@
 /**
- * Shared attachment registry – tracks pending file attachments per chat.
+ * Attachment registry – tracks pending file attachments per chat.
  *
- * The attach_file extension tool registers attachments here; AgentPool
- * reads them via take() after a prompt completes.
+ * AgentPool should construct one registry per pool so pending attachments
+ * cannot leak between independent pools that happen to use the same chat JID.
  */
 
 /** Supported attachment categories stored for agent runs. */
@@ -40,7 +40,7 @@ export class AttachmentRegistry {
 }
 
 // ── Module-level singleton ────────────────────────────────
-// Shared between AgentPool and the file-attachments extension.
+// Retained for direct extension tests and legacy callers.
 
 let _instance: AttachmentRegistry | null = null;
 

--- a/runtime/src/agent-pool/service-factory.ts
+++ b/runtime/src/agent-pool/service-factory.ts
@@ -4,7 +4,7 @@
 
 import type { AuthStorage, ExtensionFactory, ModelRegistry, SettingsManager } from "@mariozechner/pi-coding-agent";
 
-import { getAttachmentRegistry } from "./attachments.js";
+import { AttachmentRegistry } from "./attachments.js";
 import { getSshConfig } from "../db.js";
 import { createChatSshCoreExtension, resolveSshCoreConfigFromChatConfig } from "../extensions/ssh-core.js";
 import { AgentBranchManager } from "./branch-manager.js";
@@ -40,7 +40,7 @@ export interface AgentPoolServiceFactoryOptions extends AgentPoolLogHooks {
 
 /** Concrete helper instances composed into AgentPool. */
 export interface AgentPoolServices {
-  attachments: ReturnType<typeof getAttachmentRegistry>;
+  attachments: AttachmentRegistry;
   sessionBinder: AgentSessionBinder;
   toolFactory: AgentToolFactory;
   turnCoordinator: AgentTurnCoordinator;
@@ -49,7 +49,9 @@ export interface AgentPoolServices {
   branchManager: AgentBranchManager;
 }
 
-async function resolveSessionExtensionFactories(chatJid: string): Promise<ExtensionFactory[]> {
+async function resolveSessionExtensionFactories(
+  chatJid: string,
+): Promise<ExtensionFactory[]> {
   let sshConfig: ReturnType<typeof getSshConfig> | undefined;
   try {
     sshConfig = getSshConfig(chatJid);
@@ -69,7 +71,7 @@ async function resolveSessionExtensionFactories(chatJid: string): Promise<Extens
  * Keeps constructor wiring in one place so AgentPool itself remains a thin façade.
  */
 export function createAgentPoolServices(options: AgentPoolServiceFactoryOptions): AgentPoolServices {
-  const attachments = getAttachmentRegistry();
+  const attachments = new AttachmentRegistry();
   const sessionBinder = new AgentSessionBinder({
     pool: options.pool,
     onError: options.onError,
@@ -120,6 +122,7 @@ export function createAgentPoolServices(options: AgentPoolServiceFactoryOptions)
     authStorage: options.authStorage,
     modelRegistry: options.modelRegistry,
     settingsManager: options.settingsManager,
+    attachmentRegistry: attachments,
     createDefaultTools: () => toolFactory.createDefaultTools(),
     createCustomToolOverrides: () => toolFactory.createCustomToolOverrides(),
     getSessionExtensionFactories: (chatJid) => resolveSessionExtensionFactories(chatJid),

--- a/runtime/src/agent-pool/session-manager.ts
+++ b/runtime/src/agent-pool/session-manager.ts
@@ -16,6 +16,7 @@ import {
   restoreClaimedDeferredBranchSeed,
   seedSessionManagerFromDeferredBranchSeed,
 } from "./branch-seeding.js";
+import type { AttachmentRegistry } from "./attachments.js";
 import { getChatBranchByChatJid } from "../db.js";
 import { createDefaultSession, createSessionInDir, ensureNamedSessionDir, ensureSessionDir } from "./session.js";
 import { forcePersistSessionFile, seedRotatedSession } from "../session-rotation.js";
@@ -35,6 +36,7 @@ export interface AgentSessionManagerOptions {
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
   settingsManager: SettingsManager;
+  attachmentRegistry?: AttachmentRegistry;
   createDefaultTools: () => NonNullable<Parameters<typeof createDefaultSession>[1]["tools"]>;
   createCustomToolOverrides?: () => unknown[];
   getSessionExtensionFactories?: (chatJid: string) => Promise<ExtensionFactory[]>;
@@ -126,6 +128,7 @@ export class AgentSessionManager {
             authStorage: this.options.authStorage,
             modelRegistry: this.options.modelRegistry,
             settingsManager: this.options.settingsManager,
+            attachmentRegistry: this.options.attachmentRegistry,
             tools: this.options.createDefaultTools(),
             customTools: this.options.createCustomToolOverrides?.() ?? [],
             extensionFactories,
@@ -176,6 +179,7 @@ export class AgentSessionManager {
           authStorage: this.options.authStorage,
           modelRegistry: this.options.modelRegistry,
           settingsManager: this.options.settingsManager,
+          attachmentRegistry: this.options.attachmentRegistry,
           tools: this.options.createDefaultTools(),
           customTools: this.options.createCustomToolOverrides?.() ?? [],
           extensionFactories,

--- a/runtime/src/agent-pool/session.ts
+++ b/runtime/src/agent-pool/session.ts
@@ -30,10 +30,11 @@ import {
   type SettingsManager,
 } from "@mariozechner/pi-coding-agent";
 
+import type { AttachmentRegistry } from "./attachments.js";
 import { SESSIONS_DIR, WORKSPACE_DIR } from "../core/config.js";
 import { buildChannelSystemPromptAppendix } from "../channels/formatting.js";
 import { detectChannel } from "../router.js";
-import { builtinExtensionFactories } from "../extensions/index.js";
+import { createBuiltinExtensionFactories } from "../extensions/index.js";
 import { bindImmediateToolActivation } from "./tool-activation-live-update.js";
 import { ensureExtensionNodeModulesLink } from "./session-node-modules-link.js";
 
@@ -146,6 +147,7 @@ export async function createSessionInDir(
     tools: NonNullable<AgentSessionCreateOptions["tools"]>;
     customTools?: unknown[];
     extensionFactories?: ExtensionFactory[];
+    attachmentRegistry?: AttachmentRegistry;
     chatJid?: string;
   }
 ): Promise<AgentSessionRuntime> {
@@ -161,7 +163,10 @@ export async function createSessionInDir(
       modelRegistry: options.modelRegistry,
       settingsManager: options.settingsManager,
       resourceLoaderOptions: {
-        extensionFactories: [...builtinExtensionFactories, ...(options.extensionFactories ?? [])],
+        extensionFactories: [
+          ...createBuiltinExtensionFactories({ attachmentRegistry: options.attachmentRegistry }),
+          ...(options.extensionFactories ?? []),
+        ],
         additionalExtensionPaths: getBundledExtensionPaths(),
         ...(channelSystemPromptAppendix
           ? {
@@ -203,6 +208,7 @@ export async function createDefaultSession(
     tools: NonNullable<AgentSessionCreateOptions["tools"]>;
     customTools?: unknown[];
     extensionFactories?: ExtensionFactory[];
+    attachmentRegistry?: AttachmentRegistry;
   }
 ): Promise<AgentSessionRuntime> {
   const chatSessionDir = ensureSessionDir(chatJid);

--- a/runtime/src/extensions/file-attachments.ts
+++ b/runtime/src/extensions/file-attachments.ts
@@ -18,7 +18,7 @@ import type {
 
 import { createMedia, getMediaById } from "../db.js";
 import { WORKSPACE_DIR } from "../core/config.js";
-import { getAttachmentRegistry } from "../agent-pool/attachments.js";
+import { AttachmentRegistry, getAttachmentRegistry } from "../agent-pool/attachments.js";
 import { getChatJid } from "../core/chat-context.js";
 import { createLogger, debugSuppressedError } from "../utils/logger.js";
 
@@ -103,6 +103,7 @@ function buildExportPath(id: number, filename: string): string {
 // ── Tool execute ──────────────────────────────────────────
 
 async function execute(
+  registry: AttachmentRegistry,
   _toolCallId: string,
   params: AttachmentParams,
   _signal?: AbortSignal,
@@ -127,7 +128,6 @@ async function execute(
 
   const mediaId = createMedia(filename, contentType, data, null, { size, source_path: resolved, kind });
 
-  const registry = getAttachmentRegistry();
   registry.register(getChatJid("web:default"), {
     id: mediaId,
     name: filename,
@@ -319,94 +319,99 @@ async function validateAndNormalizeImage(
   }
 }
 
-/** Extension factory that registers the attach_file tool. */
-export const fileAttachments: ExtensionFactory = (pi: ExtensionAPI) => {
-  pi.on("before_agent_start", async (event) => {
-    return { systemPrompt: `${event.systemPrompt}\n\n${ATTACHMENT_HINT}` };
-  });
+/** Build a file-attachments extension bound to a specific registry instance. */
+export function createFileAttachmentsExtension(registry: AttachmentRegistry = getAttachmentRegistry()): ExtensionFactory {
+  return (pi: ExtensionAPI) => {
+    pi.on("before_agent_start", async (event) => {
+      return { systemPrompt: `${event.systemPrompt}\n\n${ATTACHMENT_HINT}` };
+    });
 
-  // Sanitize session context before each API call: strip image blocks with
-  // invalid MIME types that would cause permanent 400 errors. This recovers
-  // poisoned sessions automatically without manual JSONL editing.
-  pi.on("context", async (event) => {
-    let modified = false;
-    const sanitizeBlocks = (blocks: unknown[]): { blocks: unknown[]; modified: boolean } => {
-      let blockModified = false;
-      const cleaned = blocks.map((block: any) => {
-        if (block?.type === "image") {
-          const mime = block.mimeType || block.source?.media_type || "";
-          if (typeof mime === "string" && mime && !VALID_IMAGE_MIMES.has(mime)) {
-            blockModified = true;
-            return { type: "text", text: `[Invalid image block removed: unsupported MIME ${mime}]` };
-          }
-          // Light sync validation: check that base64 data decodes to something
-          // with recognizable image magic bytes. Heavy validation via sharp
-          // happens at ingest (read_attachment); this catches corruption that
-          // slipped through or was introduced by manual session edits.
-          const b64 = typeof block.data === "string" ? block.data : (typeof block.source?.data === "string" ? block.source.data : null);
-          if (b64) {
-            try {
-              const buf = Buffer.from(b64, "base64");
-              if (buf.length < 4) {
-                blockModified = true;
-                return { type: "text", text: "[Corrupt image block removed: data too short]" };
-              }
-            } catch {
+    // Sanitize session context before each API call: strip image blocks with
+    // invalid MIME types that would cause permanent 400 errors. This recovers
+    // poisoned sessions automatically without manual JSONL editing.
+    pi.on("context", async (event) => {
+      let modified = false;
+      const sanitizeBlocks = (blocks: unknown[]): { blocks: unknown[]; modified: boolean } => {
+        let blockModified = false;
+        const cleaned = blocks.map((block: any) => {
+          if (block?.type === "image") {
+            const mime = block.mimeType || block.source?.media_type || "";
+            if (typeof mime === "string" && mime && !VALID_IMAGE_MIMES.has(mime)) {
               blockModified = true;
-              return { type: "text", text: "[Corrupt image block removed: invalid base64]" };
+              return { type: "text", text: `[Invalid image block removed: unsupported MIME ${mime}]` };
+            }
+            // Light sync validation: check that base64 data decodes to something
+            // with recognizable image magic bytes. Heavy validation via sharp
+            // happens at ingest (read_attachment); this catches corruption that
+            // slipped through or was introduced by manual session edits.
+            const b64 = typeof block.data === "string" ? block.data : (typeof block.source?.data === "string" ? block.source.data : null);
+            if (b64) {
+              try {
+                const buf = Buffer.from(b64, "base64");
+                if (buf.length < 4) {
+                  blockModified = true;
+                  return { type: "text", text: "[Corrupt image block removed: data too short]" };
+                }
+              } catch {
+                blockModified = true;
+                return { type: "text", text: "[Corrupt image block removed: invalid base64]" };
+              }
             }
           }
-        }
-        if (block?.type === "tool_result" && Array.isArray(block.content)) {
-          const nested = sanitizeBlocks(block.content);
-          if (nested.modified) {
-            blockModified = true;
-            return { ...block, content: nested.blocks };
+          if (block?.type === "tool_result" && Array.isArray(block.content)) {
+            const nested = sanitizeBlocks(block.content);
+            if (nested.modified) {
+              blockModified = true;
+              return { ...block, content: nested.blocks };
+            }
           }
-        }
-        return block;
+          return block;
+        });
+        return { blocks: cleaned, modified: blockModified };
+      };
+
+      const messages = event.messages.map((msg: any) => {
+        if (!Array.isArray(msg?.content)) return msg;
+        const cleaned = sanitizeBlocks(msg.content);
+        if (!cleaned.modified) return msg;
+        modified = true;
+        return { ...msg, content: cleaned.blocks };
       });
-      return { blocks: cleaned, modified: blockModified };
-    };
-
-    const messages = event.messages.map((msg: any) => {
-      if (!Array.isArray(msg?.content)) return msg;
-      const cleaned = sanitizeBlocks(msg.content);
-      if (!cleaned.modified) return msg;
-      modified = true;
-      return { ...msg, content: cleaned.blocks };
+      if (modified) {
+        log.warn("Stripped invalid image blocks from session context to prevent API errors");
+        return { messages };
+      }
+      return {};
     });
-    if (modified) {
-      log.warn("Stripped invalid image blocks from session context to prevent API errors");
-      return { messages };
-    }
-    return {};
-  });
 
-  pi.registerTool({
-    name: "attach_file",
-    label: "attach_file",
-    description: "Attach a file from the workspace so the user can download it in the web UI. Returns an attachment handle.",
-    promptSnippet: "attach_file: upload a workspace file so the user gets a download card.",
-    parameters: AttachmentSchema,
-    execute,
-  });
+    pi.registerTool({
+      name: "attach_file",
+      label: "attach_file",
+      description: "Attach a file from the workspace so the user can download it in the web UI. Returns an attachment handle.",
+      promptSnippet: "attach_file: upload a workspace file so the user gets a download card.",
+      parameters: AttachmentSchema,
+      execute: (toolCallId, params, signal, onUpdate, ctx) => execute(registry, toolCallId, params, signal, onUpdate, ctx),
+    });
 
-  pi.registerTool({
-    name: "read_attachment",
-    label: "read_attachment",
-    description: "Load an attachment by id and return its contents (text/image/base64).",
-    promptSnippet: "read_attachment: load attachment bytes/text/image data by media id.",
-    parameters: ReadAttachmentSchema,
-    execute: executeReadAttachment,
-  });
+    pi.registerTool({
+      name: "read_attachment",
+      label: "read_attachment",
+      description: "Load an attachment by id and return its contents (text/image/base64).",
+      promptSnippet: "read_attachment: load attachment bytes/text/image data by media id.",
+      parameters: ReadAttachmentSchema,
+      execute: executeReadAttachment,
+    });
 
-  pi.registerTool({
-    name: "export_attachment",
-    label: "export_attachment",
-    description: "Export an attachment by id to /workspace/tmp for shell tools.",
-    promptSnippet: "export_attachment: write attachment content to /workspace/tmp and return the file path.",
-    parameters: ExportAttachmentSchema,
-    execute: executeExportAttachment,
-  });
-};
+    pi.registerTool({
+      name: "export_attachment",
+      label: "export_attachment",
+      description: "Export an attachment by id to /workspace/tmp for shell tools.",
+      promptSnippet: "export_attachment: write attachment content to /workspace/tmp and return the file path.",
+      parameters: ExportAttachmentSchema,
+      execute: executeExportAttachment,
+    });
+  };
+}
+
+/** Extension factory that registers the attach_file tool. */
+export const fileAttachments = createFileAttachmentsExtension(getAttachmentRegistry());

--- a/runtime/src/extensions/index.ts
+++ b/runtime/src/extensions/index.ts
@@ -28,7 +28,8 @@
  *   - agent-pool/session.ts passes builtinExtensionFactories to the resource loader.
  */
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
-import { fileAttachments } from "./file-attachments.js";
+import type { AttachmentRegistry } from "../agent-pool/attachments.js";
+import { createFileAttachmentsExtension } from "./file-attachments.js";
 import { messagesCrud } from "./messages-crud.js";
 import { modelControl } from "./model-control.js";
 import { internalTools } from "./internal-tools.js";
@@ -48,25 +49,32 @@ import { exitProcess } from "./exit-process.js";
 import { autoresearchSupervisor } from "./autoresearch-supervisor.js";
 import { imageProcessing } from "./image-processing.js";
 
+/** Build the built-in extension factory list used for session creation. */
+export function createBuiltinExtensionFactories(options?: {
+  attachmentRegistry?: AttachmentRegistry;
+}): ExtensionFactory[] {
+  return [
+    createFileAttachmentsExtension(options?.attachmentRegistry),
+    messagesCrud,
+    modelControl,
+    internalTools,
+    runtimeScripts,
+    toolActivation,
+    sqlIntrospect,
+    scheduledTasks,
+    workspaceSearch,
+    workspaceMemoryBootstrap,
+    dreamMaintenance,
+    uiThemeExtension,
+    smartCompaction,
+    sendAdaptiveCard,
+    sendDashboardWidget,
+    openWorkspaceFile,
+    exitProcess,
+    autoresearchSupervisor,
+    imageProcessing,
+  ];
+}
+
 /** Array of all built-in extension factories to register on session creation. */
-export const builtinExtensionFactories: ExtensionFactory[] = [
-  fileAttachments,
-  messagesCrud,
-  modelControl,
-  internalTools,
-  runtimeScripts,
-  toolActivation,
-  sqlIntrospect,
-  scheduledTasks,
-  workspaceSearch,
-  workspaceMemoryBootstrap,
-  dreamMaintenance,
-  uiThemeExtension,
-  smartCompaction,
-  sendAdaptiveCard,
-  sendDashboardWidget,
-  openWorkspaceFile,
-  exitProcess,
-  autoresearchSupervisor,
-  imageProcessing,
-];
+export const builtinExtensionFactories: ExtensionFactory[] = createBuiltinExtensionFactories();

--- a/runtime/test/agent-pool/service-factory.test.ts
+++ b/runtime/test/agent-pool/service-factory.test.ts
@@ -35,3 +35,40 @@ test("createAgentPoolServices wires the extracted helper services together", () 
   expect(services.branchManager).toBeDefined();
   expect(services.runtimeFacade.isStreaming("web:default")).toBe(false);
 });
+
+test("createAgentPoolServices scopes attachment registries per pool", () => {
+  const authStorage = AuthStorage.create();
+  const modelRegistry = ModelRegistry.inMemory(authStorage);
+  const settingsManager = createSettingsManager();
+
+  const first = createAgentPoolServices({
+    pool: new Map(),
+    sidePool: new Map(),
+    activeForkBaseLeafByChat: new Map(),
+    authStorage,
+    modelRegistry,
+    settingsManager,
+    workspaceDir: "/workspace",
+  });
+  const second = createAgentPoolServices({
+    pool: new Map(),
+    sidePool: new Map(),
+    activeForkBaseLeafByChat: new Map(),
+    authStorage,
+    modelRegistry,
+    settingsManager,
+    workspaceDir: "/workspace",
+  });
+
+  first.attachments.register("web:default", {
+    id: 1,
+    name: "report.txt",
+    contentType: "text/plain",
+    size: 6,
+    kind: "file",
+    sourcePath: "/tmp/report.txt",
+  });
+
+  expect(first.attachments.take("web:default")).toHaveLength(1);
+  expect(second.attachments.take("web:default")).toHaveLength(0);
+});

--- a/runtime/test/extensions/attachments.test.ts
+++ b/runtime/test/extensions/attachments.test.ts
@@ -92,6 +92,39 @@ test("attach_file tool stores media and registers attachment", async () => {
   expect(media?.metadata?.kind).toBe("file");
 });
 
+test("attach_file can register attachments in an injected registry", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({
+    PICLAW_WORKSPACE: ws.workspace,
+    PICLAW_STORE: ws.store,
+    PICLAW_DATA: ws.data,
+  });
+
+  const db = await import("../../src/db.js");
+  db.initDatabase();
+
+  const { WORKSPACE_DIR } = await import("../../src/core/config.js");
+  mkdirSync(WORKSPACE_DIR, { recursive: true });
+  const filePath = join(WORKSPACE_DIR, "injected.txt");
+  writeFileSync(filePath, "hello", "utf8");
+
+  const { AttachmentRegistry } = await import("../../src/agent-pool/attachments.js");
+  const { createFileAttachmentsExtension } = await import("../../src/extensions/file-attachments.js");
+
+  const registry = new AttachmentRegistry();
+  const unrelatedRegistry = new AttachmentRegistry();
+  const fake = makeFakeApi();
+  createFileAttachmentsExtension(registry)(fake.api);
+
+  const tool = fake.tools.get("attach_file");
+  expect(tool).toBeDefined();
+
+  await withChatContext("web:default", "web", () => tool.execute("call", { path: "injected.txt" }));
+
+  expect(registry.take("web:default")).toHaveLength(1);
+  expect(unrelatedRegistry.take("web:default")).toHaveLength(0);
+});
+
 test("attach_file reports missing file", async () => {
   const ws = getTestWorkspace();
   restoreEnv = setEnv({


### PR DESCRIPTION
## Summary
- give each `AgentPool` its own `AttachmentRegistry` instead of sharing one module-global instance
- inject the pool-scoped registry into session extension loading so `attach_file` writes into the right pool
- add regressions for injected attachment registries and for pool-to-pool attachment isolation

## Root cause
The `attach_file` extension and `AgentPool` both read from a process-wide singleton registry. When two pools in the same process used the same chat JID, pending attachments from one pool could be consumed by the other.

## Validation
- `bun test runtime/test/agent-pool/service-factory.test.ts runtime/test/extensions/attachments.test.ts --test-name-pattern 'createAgentPoolServices|attach_file'`
- `bun run typecheck`
