### PR TITLE
[codex] fix(agent-pool): bound waitForSessionIdle with a timeout

### DIFF
--- a/runtime/src/agent-pool/prompt-utils.ts
+++ b/runtime/src/agent-pool/prompt-utils.ts
@@ -59,16 +59,25 @@ export interface SessionIdleWaitResult {
 }
 
 export const DEFAULT_SESSION_IDLE_SETTLE_TICKS = 20;
+export const DEFAULT_SESSION_IDLE_MAX_WAIT_MS = 10_000;
 
 /** Wait until a session fully settles after a prompt completes. */
 export async function waitForSessionIdle(
   session: { isStreaming?: boolean; isCompacting?: boolean; isRetrying?: boolean },
   settleTicks = DEFAULT_SESSION_IDLE_SETTLE_TICKS,
   onSettled?: (result: SessionIdleWaitResult) => void,
+  maxWaitMs = DEFAULT_SESSION_IDLE_MAX_WAIT_MS,
 ): Promise<void> {
   let idleTicks = 0;
   const startTime = Date.now();
   while (idleTicks < settleTicks) {
+    const totalWaitMs = Date.now() - startTime;
+    if (maxWaitMs > 0 && totalWaitMs >= maxWaitMs) {
+      throw new Error(
+        `Timed out waiting for session idle after ${formatTimeoutDuration(maxWaitMs)} ` +
+          `(streaming=${Boolean(session.isStreaming)}, compacting=${Boolean(session.isCompacting)}, retrying=${Boolean(session.isRetrying)})`,
+      );
+    }
     if (!session.isStreaming && !session.isCompacting && !session.isRetrying) {
       idleTicks += 1;
     } else {

--- a/runtime/test/agent-pool/prompt-utils.test.ts
+++ b/runtime/test/agent-pool/prompt-utils.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 
 import {
+  DEFAULT_SESSION_IDLE_MAX_WAIT_MS,
   DEFAULT_SESSION_IDLE_SETTLE_TICKS,
   extractAssistantText,
   extractAssistantThinking,
@@ -32,6 +33,7 @@ test("prompt utils extract assistant text and thinking blocks", () => {
 
 test("waitForSessionIdle uses a 1s default settle window", () => {
   expect(DEFAULT_SESSION_IDLE_SETTLE_TICKS).toBe(20);
+  expect(DEFAULT_SESSION_IDLE_MAX_WAIT_MS).toBe(10_000);
 });
 
 test("waitForSessionIdle does not settle during a 600ms mid-run idle gap", async () => {
@@ -64,4 +66,16 @@ test("waitForSessionIdle does not settle during a 600ms mid-run idle gap", async
 
   expect(result).toBe("pending");
   await expect(waitPromise).resolves.toBeUndefined();
+});
+
+test("waitForSessionIdle times out when the session never settles", async () => {
+  const session = {
+    isStreaming: false,
+    isCompacting: false,
+    isRetrying: true,
+  };
+
+  await expect(waitForSessionIdle(session, 2, undefined, 120)).rejects.toThrow(
+    "Timed out waiting for session idle after 0.1s (streaming=false, compacting=false, retrying=true)",
+  );
 });


### PR DESCRIPTION
## Summary
- add an absolute max-wait to `waitForSessionIdle` so stuck retry/streaming states fail instead of polling forever
- keep the existing settle-window behavior for normal runs
- add a regression test covering the timeout path

## Root cause
`waitForSessionIdle` only waited for consecutive idle ticks and never enforced an overall deadline. If a session stayed in `isRetrying` or another active state indefinitely, callers could hang forever.

## Validation
- `bun test runtime/test/agent-pool/prompt-utils.test.ts`
- `bun run typecheck`
