### PR TITLE
[codex] fix(queue): track retrying items in dedupe checks

### DIFF
--- a/runtime/src/queue.ts
+++ b/runtime/src/queue.ts
@@ -56,6 +56,7 @@ export interface QueueMetrics {
  */
 export class AgentQueue {
   private lanes = new Map<string, LaneState>();
+  private retryingIds = new Set<string>();
   private shuttingDown = false;
   private metrics: QueueMetrics = {
     enqueued: 0,
@@ -87,6 +88,7 @@ export class AgentQueue {
   }
 
   private hasQueuedId(id: string): boolean {
+    if (this.retryingIds.has(id)) return true;
     for (const lane of this.lanes.values()) {
       if (lane.current?.id === id) return true;
       if (lane.pending.some((item) => item.id === id)) return true;
@@ -127,6 +129,7 @@ export class AgentQueue {
 
   /** Start executing an item inside a lane. */
   private runItem(lane: LaneState, item: QueueItem): void {
+    if (item.id) this.retryingIds.delete(item.id);
     lane.running = true;
     lane.current = item;
     this.metrics.started += 1;
@@ -165,6 +168,7 @@ export class AgentQueue {
     if (!shouldRetry(item.retries, DEFAULT_MAX_RETRIES, this.shuttingDown)) return;
     item.retries++;
     this.metrics.retriesScheduled += 1;
+    if (item.id) this.retryingIds.add(item.id);
     const delay = getRetryDelay(item.retries, DEFAULT_BASE_RETRY_MS);
     log.info("Scheduling queue retry", {
       operation: "schedule_retry",
@@ -174,6 +178,7 @@ export class AgentQueue {
       itemId: item.id ?? null,
     });
     setTimeout(() => {
+      if (item.id) this.retryingIds.delete(item.id);
       if (this.shuttingDown) return;
       const lane = this.getLane(item.laneKey);
       if (lane.running) {

--- a/runtime/src/queue.ts
+++ b/runtime/src/queue.ts
@@ -57,6 +57,7 @@ export interface QueueMetrics {
 export class AgentQueue {
   private lanes = new Map<string, LaneState>();
   private retryingIds = new Set<string>();
+  private retryTimers = new Set<ReturnType<typeof setTimeout>>();
   private shuttingDown = false;
   private metrics: QueueMetrics = {
     enqueued: 0,
@@ -177,7 +178,8 @@ export class AgentQueue {
       delayMs: delay,
       itemId: item.id ?? null,
     });
-    setTimeout(() => {
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(timer);
       if (item.id) this.retryingIds.delete(item.id);
       if (this.shuttingDown) return;
       const lane = this.getLane(item.laneKey);
@@ -187,6 +189,7 @@ export class AgentQueue {
         this.runItem(lane, item);
       }
     }, delay);
+    this.retryTimers.add(timer);
   }
 
   /**
@@ -195,6 +198,11 @@ export class AgentQueue {
    */
   async shutdown(ms = 5000): Promise<void> {
     this.shuttingDown = true;
+    for (const timer of this.retryTimers) {
+      clearTimeout(timer);
+    }
+    this.retryTimers.clear();
+    this.retryingIds.clear();
     const runningPromises: Promise<void>[] = [];
     for (const lane of this.lanes.values()) {
       lane.pending = [];

--- a/runtime/test/queue/queue.test.ts
+++ b/runtime/test/queue/queue.test.ts
@@ -216,6 +216,31 @@ describe("AgentQueue", () => {
     }
   });
 
+  test("shutdown cancels pending retry timers", async () => {
+    const queue = new AgentQueue();
+    let attempts = 0;
+
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((fn: (...args: any[]) => void, ms?: number, ...args: any[]) =>
+      originalSetTimeout(fn, Math.min(ms ?? 0, 20), ...args)) as typeof setTimeout;
+
+    try {
+      queue.enqueue(async () => {
+        attempts += 1;
+        throw new Error("fail");
+      }, "task-1");
+
+      await Bun.sleep(5);
+      await queue.shutdown(100);
+      await new Promise((resolve) => originalSetTimeout(resolve, 80));
+
+      expect(attempts).toBe(1);
+      expect(queue.getMetrics().retriesScheduled).toBe(1);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
   test("shutdown returns after timeout and clears pending", async () => {
     const queue = new AgentQueue();
     let ran = false;

--- a/runtime/test/queue/queue.test.ts
+++ b/runtime/test/queue/queue.test.ts
@@ -180,6 +180,42 @@ describe("AgentQueue", () => {
     }
   });
 
+  test("deduplicates items while a retry is waiting on its backoff timer", async () => {
+    const queue = new AgentQueue();
+    const order: string[] = [];
+    let attempts = 0;
+
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((fn: (...args: any[]) => void, ms?: number, ...args: any[]) =>
+      originalSetTimeout(fn, Math.min(ms ?? 0, 20), ...args)) as typeof setTimeout;
+
+    try {
+      queue.enqueue(async () => {
+        order.push(attempts === 0 ? "first" : "retry");
+        if (attempts === 0) {
+          attempts += 1;
+          throw new Error("fail");
+        }
+      }, "task-1");
+
+      await Bun.sleep(5);
+
+      queue.enqueue(async () => {
+        order.push("duplicate");
+      }, "task-1");
+
+      await new Promise((resolve) => originalSetTimeout(resolve, 80));
+      expect(order).toEqual(["first", "retry"]);
+
+      const metrics = queue.getMetrics();
+      expect(metrics.deduplicated).toBe(1);
+      expect(metrics.retriesScheduled).toBeGreaterThanOrEqual(1);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+      await queue.shutdown(100);
+    }
+  });
+
   test("shutdown returns after timeout and clears pending", async () => {
     const queue = new AgentQueue();
     let ran = false;


### PR DESCRIPTION
## Summary
- track retry-sleeping item ids separately from active and pending lane entries
- consult that retry-tracking state in `hasQueuedId` so duplicate enqueues are rejected during backoff
- add a regression test that enqueues a duplicate while a retry timer is still waiting

## Root cause
Once a failing item moved into its backoff `setTimeout`, its id was no longer present in `lane.current` or `lane.pending`. `hasQueuedId` would therefore miss it and allow another item with the same id to enter the queue before the retry fired.

## Validation
- `bun test runtime/test/queue/queue.test.ts`
- `bun run typecheck`
