### PR TITLE
[codex] fix(scheduler): anchor cron timezone calculations to next_run

### DIFF
--- a/runtime/src/task-scheduler-utils.ts
+++ b/runtime/src/task-scheduler-utils.ts
@@ -8,6 +8,11 @@
 import { CronExpressionParser } from "cron-parser";
 import { getRuntimeTimingConfig } from "./core/config.js";
 
+export interface ComputeNextRunOptions {
+  currentDate?: string | Date | null;
+  timezone?: string | null;
+}
+
 /**
  * Compute the next execution time for a scheduled task.
  *
@@ -15,11 +20,19 @@ import { getRuntimeTimingConfig } from "./core/config.js";
  * - interval: add the interval (ms) to now.
  * - once: return null (no repeat).
  */
-export function computeNextRun(scheduleType: string, scheduleValue: string): string | null {
+export function computeNextRun(
+  scheduleType: string,
+  scheduleValue: string,
+  options: ComputeNextRunOptions = {},
+): string | null {
   if (scheduleType === "cron") {
     try {
-      const timezone = process.env.TZ || getRuntimeTimingConfig().timezone;
-      return CronExpressionParser.parse(scheduleValue, { tz: timezone }).next().toISOString();
+      const timezone = options.timezone || process.env.TZ || getRuntimeTimingConfig().timezone;
+      const currentDate = options.currentDate ? new Date(options.currentDate) : undefined;
+      return CronExpressionParser.parse(scheduleValue, {
+        tz: timezone,
+        ...(currentDate && !Number.isNaN(currentDate.getTime()) ? { currentDate } : {}),
+      }).next().toISOString();
     } catch {
       return null;
     }

--- a/runtime/src/task-scheduler.ts
+++ b/runtime/src/task-scheduler.ts
@@ -348,7 +348,9 @@ export async function runScheduledTask(task: ScheduledTask, deps: SchedulerDeps)
   });
 
   // Compute and persist the next execution time (null for one-shot tasks).
-  const nextRun = computeNextRun(task.schedule_type, task.schedule_value);
+  const nextRun = computeNextRun(task.schedule_type, task.schedule_value, {
+    currentDate: task.next_run,
+  });
   updateTaskAfterRun(task.id, nextRun, error ? `Error: ${error}` : (result?.slice(0, 200) || "Completed"));
 }
 

--- a/runtime/test/runtime/scheduler.test.ts
+++ b/runtime/test/runtime/scheduler.test.ts
@@ -53,6 +53,23 @@ test("computeNextRun handles invalid cron and timezone", async () => {
   expect(onceFuture).toBeNull();
 });
 
+test("computeNextRun can anchor cron schedules to a prior next_run", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({
+    PICLAW_WORKSPACE: ws.workspace,
+    PICLAW_STORE: ws.store,
+    PICLAW_DATA: ws.data,
+    TZ: "UTC",
+  });
+
+  const scheduler = await importFresh<typeof import("../src/task-scheduler.js")>("../src/task-scheduler.js");
+
+  const cronNext = scheduler.computeNextRun("cron", "*/5 * * * *", {
+    currentDate: "2024-01-01T00:00:00.000Z",
+  });
+  expect(cronNext).toBe("2024-01-01T00:05:00.000Z");
+});
+
 test("runScheduledTask logs run and updates task", async () => {
   const ws = getTestWorkspace();
   restoreEnv = setEnv({ PICLAW_WORKSPACE: ws.workspace, PICLAW_STORE: ws.store, PICLAW_DATA: ws.data });
@@ -106,6 +123,52 @@ test("runScheduledTask logs run and updates task", async () => {
   expect(metrics.taskRunsStarted).toBe(1);
   expect(metrics.taskRunsSucceeded).toBe(1);
   expect(metrics.taskRunsFailed).toBe(0);
+});
+
+test("runScheduledTask computes the next cron run from the task next_run anchor", async () => {
+  const ws = getTestWorkspace();
+  restoreEnv = setEnv({
+    PICLAW_WORKSPACE: ws.workspace,
+    PICLAW_STORE: ws.store,
+    PICLAW_DATA: ws.data,
+    TZ: "UTC",
+  });
+
+  const db = await import("../../src/db.js");
+  db.initDatabase();
+
+  const scheduler = await import("../../src/task-scheduler.js");
+  scheduler.resetSchedulerMetricsForTests();
+
+  const taskId = `task-cron-${Date.now()}`;
+  db.createTask({
+    id: taskId,
+    chat_jid: "web:default",
+    prompt: "say hi",
+    schedule_type: "cron",
+    schedule_value: "*/5 * * * *",
+    next_run: "2024-01-01T00:00:00.000Z",
+    status: "active",
+    created_at: new Date().toISOString(),
+  });
+
+  const deps = {
+    queue: { enqueueTask: (_id: string, fn: () => Promise<void>) => fn() } as any,
+    agentPool: {
+      runAgent: async () => ({ status: "success", result: "Hello" }),
+      saveSessionPosition: async () => "leaf-123",
+      restoreSessionPosition: async () => {},
+      getCurrentModelLabel: async () => null,
+      applyControlCommand: async () => ({ status: "success", message: "" }),
+    } as any,
+    sendMessage: async () => {},
+  };
+
+  const task = db.getTaskById(taskId)!;
+  await scheduler.runScheduledTask(task, deps as any);
+
+  const updated = db.getTaskById(taskId)!;
+  expect(updated.next_run).toBe("2024-01-01T00:05:00.000Z");
 });
 
 test("runScheduledTask switches and restores models", async () => {


### PR DESCRIPTION
## Summary
- let `computeNextRun` accept an anchor date for cron calculations
- compute recurring task `next_run` values from the task's recorded `next_run` instead of the wall clock at completion time
- add regressions covering anchored cron parsing and cron task rescheduling

## Root cause
Recurring cron tasks recomputed their next run from the current wall clock when a run finished. If a task ran late or crossed timezone/DST boundaries, that could drift the schedule away from the cadence implied by the stored `next_run`.

## Validation
- `bun test runtime/test/runtime/scheduler.test.ts`
- `bun run typecheck`
