### PR TITLE
[codex] fix(web): harden static containment and origin tracking

### DIFF
--- a/runtime/src/channels/web/http/static.ts
+++ b/runtime/src/channels/web/http/static.ts
@@ -7,7 +7,7 @@
  * Consumers: web/http/response-service.ts and web/request-router.ts.
  */
 
-import { extname, resolve } from "path";
+import { extname, isAbsolute, relative, resolve } from "path";
 import { statSync } from "fs";
 
 import { createLogger, debugSuppressedError } from "../../../utils/logger.js";
@@ -75,6 +75,11 @@ function renderHtmlTemplate(relPath: string, html: string): string {
   return html;
 }
 
+function isPathWithin(baseDir: string, filePath: string): boolean {
+  const rel = relative(baseDir, filePath);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
 /**
  * Serve a file from the web static asset directory.
  * @param relPath Relative path inside `web/static`.
@@ -83,7 +88,7 @@ function renderHtmlTemplate(relPath: string, html: string): string {
  */
 export async function serveStatic(relPath: string, notFound: () => Response): Promise<Response> {
   const filePath = resolve(STATIC_DIR, relPath);
-  if (!filePath.startsWith(STATIC_DIR)) return notFound();
+  if (!isPathWithin(STATIC_DIR, filePath)) return notFound();
 
   const file = Bun.file(filePath);
   if (!(await file.exists())) return notFound();
@@ -129,7 +134,7 @@ export async function serveStatic(relPath: string, notFound: () => Response): Pr
  */
 export async function serveDocsStatic(relPath: string, notFound: () => Response): Promise<Response> {
   const filePath = resolve(DOCS_DIR, relPath);
-  if (!filePath.startsWith(DOCS_DIR)) return notFound();
+  if (!isPathWithin(DOCS_DIR, filePath)) return notFound();
 
   const file = Bun.file(filePath);
   if (!(await file.exists())) return notFound();

--- a/runtime/src/channels/web/request-router-service.ts
+++ b/runtime/src/channels/web/request-router-service.ts
@@ -121,9 +121,6 @@ export class RequestRouterService {
       return await this.channel.handleRemote(req);
     }
 
-    // Track the last seen origin so slash commands can build absolute links.
-    rememberWebOrigin("web:default", req);
-
     const flags = getRouteFlags(req, pathname);
     const guardResponse = await enforceRequestGuards(this.channel, req, pathname, flags);
     if (guardResponse) {
@@ -134,6 +131,9 @@ export class RequestRouterService {
     if (authRouteResponse) {
       return authRouteResponse;
     }
+
+    // Track the last seen origin only after the request clears guard/auth checks.
+    rememberWebOrigin("web:default", req);
 
     const shellResponse = await handleShellRoutes(
       this.channel,

--- a/runtime/src/channels/web/request-router-service.ts
+++ b/runtime/src/channels/web/request-router-service.ts
@@ -24,7 +24,7 @@
  * Consumers: channels/web.ts delegates each request to handle().
  */
 
-import { extname, resolve } from "path";
+import { extname, isAbsolute, relative, resolve } from "path";
 import { createUuid } from "../../utils/ids.js";
 import type { WebChannelLike } from "./core/web-channel-contracts.js";
 import { rememberWebOrigin } from "./auth/request-origin.js";
@@ -53,6 +53,11 @@ const STATIC_MIME_TYPES: Record<string, string> = {
   ".json": "application/manifest+json; charset=utf-8",
 };
 
+function isPathWithin(baseDir: string, filePath: string): boolean {
+  const rel = relative(baseDir, filePath);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
 /** Business logic for handling compose-box submissions and agent runs. */
 export class RequestRouterService {
   constructor(private channel: WebChannelLike) {}
@@ -60,7 +65,7 @@ export class RequestRouterService {
   private async serveStaticAsset(req: Request, relPath: string): Promise<Response> {
     const filePath = resolve(STATIC_DIR, relPath);
 
-    if (!filePath.startsWith(STATIC_DIR)) {
+    if (!isPathWithin(STATIC_DIR, filePath)) {
       return this.channel.json({ error: "Not found" }, 404);
     }
 

--- a/runtime/test/channels/web/security-hardening.test.ts
+++ b/runtime/test/channels/web/security-hardening.test.ts
@@ -9,6 +9,8 @@
  * - Agent message content length limits
  */
 import { describe, test, expect } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
 import { getTestWorkspace, setEnv } from "../../helpers.js";
 
 // ── Post content length validation ──
@@ -684,6 +686,26 @@ describe("CSRF origin checks", () => {
 
     const res = await router.handle(req);
     expect(res.status).toBe(403);
+  });
+
+  test("serveStaticAsset rejects same-prefix sibling traversal paths", async () => {
+    const runtimeRoot = join(import.meta.dir, "..", "..", "..");
+    const staticSiblingDir = join(runtimeRoot, "web", "static-backup");
+    const staticSiblingFile = join(staticSiblingDir, "router-secret.txt");
+
+    mkdirSync(staticSiblingDir, { recursive: true });
+    writeFileSync(staticSiblingFile, "router secret", "utf8");
+
+    try {
+      const router = new RequestRouterService(new StubChannel() as any);
+      const res = await (router as any).serveStaticAsset(
+        new Request("http://localhost/favicon.ico"),
+        "../static-backup/router-secret.txt",
+      );
+      expect(res.status).toBe(404);
+    } finally {
+      rmSync(staticSiblingDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/runtime/test/channels/web/security-hardening.test.ts
+++ b/runtime/test/channels/web/security-hardening.test.ts
@@ -390,6 +390,7 @@ describe("SSE client cap", () => {
 
 // ── CSRF origin checks ──
 import { RequestRouterService } from "../../../src/channels/web/request-router-service.js";
+import { getWebOrigin, rememberWebOrigin } from "../../../src/channels/web/auth/request-origin.js";
 
 describe("CSRF origin checks", () => {
   class StubChannel {
@@ -472,6 +473,36 @@ describe("CSRF origin checks", () => {
     const res = await router.handle(req);
     expect(res.status).toBe(401);
     expect(reached).toBe(false);
+  });
+
+  test("blocked unauthenticated requests do not overwrite the remembered web origin", async () => {
+    rememberWebOrigin("web:default", new Request("https://safe.example/app", {
+      headers: { host: "safe.example" },
+    }));
+
+    class AuthChannel extends StubChannel {
+      authGateway = {
+        isAuthEnabled: () => true,
+        isInternalSecretEnabled: () => false,
+        verifyInternalSecret: () => false,
+        isAuthenticated: () => false,
+      };
+    }
+
+    const router = new RequestRouterService(new AuthChannel() as any);
+    const req = new Request("https://evil.example/agent/queue-steer", {
+      method: "POST",
+      headers: {
+        Origin: "https://evil.example",
+        Host: "evil.example",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ row_id: 1 }),
+    });
+
+    const res = await router.handle(req);
+    expect(res.status).toBe(401);
+    expect(getWebOrigin("web:default")).toBe("https://safe.example");
   });
 
   test("auth-gates /agent/active-chats before route dispatch", async () => {

--- a/runtime/test/channels/web/web-utils.test.ts
+++ b/runtime/test/channels/web/web-utils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect, test } from "bun:test";
-import { existsSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 
 import { clampInt, errorJson, jsonResponse, okJson, parseOptionalInt } from "../../../src/channels/web/http/http-utils.js";
@@ -111,6 +111,30 @@ test("static helpers serve files and not-found", async () => {
 
   const notFound = await serveDocsStatic("missing.html", () => new Response("nope", { status: 404 }));
   expect(notFound.status).toBe(404);
+});
+
+test("static helpers reject same-prefix sibling traversal paths", async () => {
+  const root = join(import.meta.dir, "..", "..", "..");
+  const staticSiblingDir = join(root, "web", "static-backup");
+  const docsSiblingDir = join(root, "docs-backup");
+  const staticSiblingFile = join(staticSiblingDir, "secret.txt");
+  const docsSiblingFile = join(docsSiblingDir, "secret.txt");
+
+  mkdirSync(staticSiblingDir, { recursive: true });
+  mkdirSync(docsSiblingDir, { recursive: true });
+  writeFileSync(staticSiblingFile, "static secret", "utf8");
+  writeFileSync(docsSiblingFile, "docs secret", "utf8");
+
+  try {
+    const staticRes = await serveStatic("../static-backup/secret.txt", () => new Response("nope", { status: 404 }));
+    expect(staticRes.status).toBe(404);
+
+    const docsRes = await serveDocsStatic("../docs-backup/secret.txt", () => new Response("nope", { status: 404 }));
+    expect(docsRes.status).toBe(404);
+  } finally {
+    rmSync(staticSiblingDir, { recursive: true, force: true });
+    rmSync(docsSiblingDir, { recursive: true, force: true });
+  }
 });
 
 test("ui bridge stop clears pending requests even when a pending reject throws", () => {


### PR DESCRIPTION
## Summary
- replace raw `startsWith()` prefix checks for static/docs assets with path containment checks based on `path.relative()`
- apply the same containment hardening to the router's direct static-asset helper
- remember the web origin only after a request clears guard/auth checks so blocked unauthenticated requests cannot poison stored absolute-link origins
- add regressions for same-prefix sibling traversal and blocked-origin overwrite attempts

## Root Cause
The web surface had two trust-boundary weaknesses. Static helpers relied on same-prefix string checks instead of true path containment, and the router remembered browser origins before authentication and guard checks had accepted the request.

## Validation
- `bun test runtime/test/channels/web/web-utils.test.ts runtime/test/channels/web/security-hardening.test.ts`
- `bun run typecheck`
