### PR TITLE
[codex] fix(web-sse): require chat scope matches for chat events

### DIFF
--- a/runtime/src/channels/web/sse/sse.ts
+++ b/runtime/src/channels/web/sse/sse.ts
@@ -135,7 +135,7 @@ export function broadcastEvent(channel: SseClientContainer, eventType: string, d
   const payload = `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
   const bytes = encoder.encode(payload);
   for (const client of channel.clients) {
-    if (eventChatJid && client.chatJid && client.chatJid !== eventChatJid) {
+    if (eventChatJid && client.chatJid !== eventChatJid) {
       continue;
     }
     try {

--- a/runtime/test/channels/web/security-hardening.test.ts
+++ b/runtime/test/channels/web/security-hardening.test.ts
@@ -242,7 +242,7 @@ describe("SSE client cap", () => {
     }
   });
 
-  test("broadcastEvent filters chat-scoped SSE events per subscribed chat", () => {
+  test("broadcastEvent only delivers chat-scoped SSE events to matching chat subscribers", () => {
     const seenA: Uint8Array[] = [];
     const seenB: Uint8Array[] = [];
     const seenGlobal: Uint8Array[] = [];
@@ -258,7 +258,7 @@ describe("SSE client cap", () => {
 
     expect(seenA.length).toBe(1);
     expect(seenB.length).toBe(0);
-    expect(seenGlobal.length).toBe(1);
+    expect(seenGlobal.length).toBe(0);
 
     for (const client of channel.clients) {
       clearTimeout(client.heartbeat);


### PR DESCRIPTION
## Summary
- require chat-scoped SSE events to match a subscriber's declared `chat_jid`
- stop treating clients without a subscribed chat as wildcards for chat-scoped broadcasts
- update the SSE regression to verify unmatched and chatless subscribers do not receive another chat's events

## Root cause
`broadcastEvent` only filtered mismatches when a client already had a non-null `chatJid`. That meant a subscriber with no `chat_jid` received every chat-scoped event, including drafts, thoughts, and extension UI traffic for other chats.

## Validation
- `bun test runtime/test/channels/web/security-hardening.test.ts runtime/test/channels/web/web-utils.test.ts`
- `bun run typecheck`
