### PR TITLE
[codex] fix(webauthn): stop login enumeration and preserve challenges

### DIFF
--- a/runtime/src/channels/web/auth/webauthn-auth.ts
+++ b/runtime/src/channels/web/auth/webauthn-auth.ts
@@ -17,9 +17,9 @@ import {
   createWebSession,
   DEFAULT_WEB_USER_ID,
   consumeWebauthnEnrollment,
+  getWebauthnEnrollment,
   getWebauthnCredentialById,
   getWebauthnCredentialsForRpId,
-  getWebauthnEnrollment,
   storeWebauthnCredential,
   updateWebauthnCredentialCounter,
 } from "../../../db.js";
@@ -58,23 +58,8 @@ export async function handleWebauthnLoginStart(req: Request, ctx: WebauthnAuthCo
   if (!ctx.isPasskeyEnabled()) return ctx.json({ error: "Passkeys disabled" }, 404);
 
   const { rpId } = resolveWebauthnRpInfo(req);
-  const credentials = getWebauthnCredentialsForRpId(DEFAULT_WEB_USER_ID, rpId);
-  if (credentials.length === 0) {
-    ctx.logAuthEvent(req, "WebAuthn login requested but no passkeys registered");
-    return ctx.json({ error: "No passkeys registered" }, 404);
-  }
-
-  const allowCredentials = credentials.map((cred) => {
-    const transports = cred.transports ? JSON.parse(cred.transports) : undefined;
-    return {
-      id: cred.credential_id,
-      transports: Array.isArray(transports) ? transports : undefined,
-    };
-  });
-
   const options = await generateAuthenticationOptions({
     rpID: rpId,
-    allowCredentials,
     userVerification: "preferred",
   });
 
@@ -235,13 +220,14 @@ export async function handleWebauthnRegisterFinish(req: Request, ctx: WebauthnAu
     return ctx.json({ error: "Missing credential" }, 400);
   }
 
-  const pending = ctx.challenges.consumeRegistration(token, (ctx.now ?? Date.now)());
+  const now = (ctx.now ?? Date.now)();
+  const pending = ctx.challenges.getRegistration(token, now);
   if (!pending) {
     ctx.logAuthEvent(req, "WebAuthn registration expired or unknown token");
     return ctx.json({ error: "Registration expired" }, 400);
   }
 
-  const enrollment = consumeWebauthnEnrollment(token);
+  const enrollment = getWebauthnEnrollment(token);
   if (!enrollment) {
     ctx.logAuthEvent(req, "WebAuthn registration invalid or expired enrol token");
     return ctx.json({ error: "Invalid or expired enrol token" }, 400);
@@ -276,6 +262,16 @@ export async function handleWebauthnRegisterFinish(req: Request, ctx: WebauthnAu
   }
 
   const info = result.registrationInfo;
+  const consumedPending = ctx.challenges.consumeRegistration(token, now);
+  if (!consumedPending) {
+    ctx.logAuthEvent(req, "WebAuthn registration expired or unknown token");
+    return ctx.json({ error: "Registration expired" }, 400);
+  }
+  const consumedEnrollment = consumeWebauthnEnrollment(token);
+  if (!consumedEnrollment) {
+    ctx.logAuthEvent(req, "WebAuthn registration invalid or expired enrol token");
+    return ctx.json({ error: "Invalid or expired enrol token" }, 400);
+  }
   const transports = Array.isArray(credential.response.transports)
     ? JSON.stringify(credential.response.transports)
     : null;

--- a/runtime/src/channels/web/auth/webauthn-challenges.ts
+++ b/runtime/src/channels/web/auth/webauthn-challenges.ts
@@ -78,6 +78,17 @@ export class WebauthnChallengeTracker {
   }
 
   /**
+   * Read a pending WebAuthn registration challenge without consuming it.
+   * @param token Challenge token key used for lookup.
+   * @param now Optional timestamp override for deterministic tests.
+   * @returns The pending challenge when found, otherwise null.
+   */
+  getRegistration(token: string, now = Date.now()): PendingWebauthnChallenge | null {
+    this.prune(now);
+    return this.pendingRegistrations.get(token) ?? null;
+  }
+
+  /**
    * Consume and remove a pending WebAuthn registration challenge.
    * @param token Challenge token key used for lookup.
    * @param now Optional timestamp override for deterministic tests.

--- a/runtime/test/channels/web/auth/webauthn-auth.test.ts
+++ b/runtime/test/channels/web/auth/webauthn-auth.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { getTestWorkspace, setEnv } from "../../../helpers.js";
 import {
   handleWebauthnLoginFinish,
   handleWebauthnLoginStart,
@@ -7,6 +8,13 @@ import {
   type WebauthnAuthContext,
 } from "../../../../src/channels/web/auth/webauthn-auth.js";
 import { WebauthnChallengeTracker } from "../../../../src/channels/web/auth/webauthn-challenges.js";
+
+let restoreEnv: (() => void) | null = null;
+
+afterEach(() => {
+  restoreEnv?.();
+  restoreEnv = null;
+});
 
 function createContext(passkeyEnabled = true) {
   const authEvents: string[] = [];
@@ -26,6 +34,58 @@ function createContext(passkeyEnabled = true) {
 }
 
 describe("webauthn auth handlers", () => {
+  test("login start returns generic options even when no passkeys are registered", async () => {
+    const ws = getTestWorkspace();
+    restoreEnv?.();
+    restoreEnv = setEnv({
+      PICLAW_WORKSPACE: ws.workspace,
+      PICLAW_STORE: ws.store,
+      PICLAW_DATA: ws.data,
+    });
+
+    const db = await import("../../../../src/db.js");
+    db.initDatabase();
+
+    const { ctx } = createContext(true);
+    const req = new Request("https://example.com/auth/webauthn/login/start", { method: "POST" });
+    const res = await handleWebauthnLoginStart(req, ctx);
+    const body = await res.json() as any;
+
+    expect(res.status).toBe(200);
+    expect(body.token).toBeString();
+    expect(body.options?.challenge).toBeString();
+    expect(body.options?.allowCredentials ?? []).toEqual([]);
+  });
+
+  test("login start does not expose stored credential ids", async () => {
+    const ws = getTestWorkspace();
+    restoreEnv?.();
+    restoreEnv = setEnv({
+      PICLAW_WORKSPACE: ws.workspace,
+      PICLAW_STORE: ws.store,
+      PICLAW_DATA: ws.data,
+    });
+
+    const db = await import("../../../../src/db.js");
+    db.initDatabase();
+    db.storeWebauthnCredential({
+      user_id: "default",
+      rp_id: "example.com",
+      credential_id: "cred-public-id",
+      public_key: "ZmFrZS1rZXk",
+      sign_count: 0,
+      transports: JSON.stringify(["internal"]),
+    });
+
+    const { ctx } = createContext(true);
+    const req = new Request("https://example.com/auth/webauthn/login/start", { method: "POST" });
+    const res = await handleWebauthnLoginStart(req, ctx);
+    const body = await res.json() as any;
+
+    expect(res.status).toBe(200);
+    expect(body.options?.allowCredentials ?? []).toEqual([]);
+  });
+
   test("rejects passkey endpoints when passkeys are disabled", async () => {
     const { ctx } = createContext(false);
 
@@ -97,5 +157,48 @@ describe("webauthn auth handlers", () => {
 
     expect(authEvents).toContain("WebAuthn registration missing enrol token");
     expect(authEvents).toContain("WebAuthn registration missing credential payload");
+  });
+
+  test("register finish keeps challenge and enrollment when verification fails", async () => {
+    const ws = getTestWorkspace();
+    restoreEnv?.();
+    restoreEnv = setEnv({
+      PICLAW_WORKSPACE: ws.workspace,
+      PICLAW_STORE: ws.store,
+      PICLAW_DATA: ws.data,
+    });
+
+    const db = await import("../../../../src/db.js");
+    db.initDatabase();
+    const { ctx } = createContext(true);
+    const enrollment = db.createWebauthnEnrollment("default", 300);
+    ctx.challenges.trackRegistration(enrollment.token, {
+      challenge: "challenge-value",
+      rpId: "example.com",
+      userId: "default",
+    });
+
+    const req = new Request("https://example.com/auth/webauthn/register/finish", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        token: enrollment.token,
+        credential: {
+          id: "cred-id",
+          rawId: "cred-id",
+          type: "public-key",
+          response: {
+            clientDataJSON: "",
+            attestationObject: "",
+            transports: ["internal"],
+          },
+        },
+      }),
+    });
+
+    const res = await handleWebauthnRegisterFinish(req, ctx);
+    expect(res.status).toBe(401);
+    expect(ctx.challenges.getRegistration(enrollment.token)).not.toBeNull();
+    expect(db.getWebauthnEnrollment(enrollment.token)).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- stop returning credential-specific WebAuthn login hints to unauthenticated callers
- always return generic login options so passkey availability is not exposed via status code or credential ids
- keep registration challenges and enrollment tokens intact when registration verification fails, and add regressions for both behaviors

## Root cause
The login-start endpoint returned `404` when no passkeys were registered and returned a populated `allowCredentials` list when they were. That leaked both passkey presence and credential ids. Separately, registration finish consumed the pending challenge and enrollment token before verification completed, so a failed finish request could permanently burn a valid registration token.

## Validation
- `bun test runtime/test/channels/web/auth/webauthn-auth.test.ts runtime/test/channels/web/auth/webauthn-challenges.test.ts`
- `bun run typecheck`
