### PR TITLE
[codex] fix(web): revoke stale TOTP sessions and keep side-prompt streams alive

### DIFF
--- a/runtime/src/channels/web/cards/adaptive-card-side-prompt-service.ts
+++ b/runtime/src/channels/web/cards/adaptive-card-side-prompt-service.ts
@@ -28,6 +28,7 @@ import { handleAgentMessage as handleAgentMessageRequest } from "../handlers/age
 import type { WebChannelLike } from "../core/web-channel-contracts.js";
 
 const log = createLogger("web");
+const SIDE_PROMPT_STREAM_HEARTBEAT_MS = 30000;
 
 type SidePromptResult = {
   status: "success" | "error";
@@ -602,9 +603,14 @@ export class WebAdaptiveCardSidePromptService {
     const stream = new ReadableStream<Uint8Array>({
       start: (controller) => {
         let closed = false;
+        let heartbeat: ReturnType<typeof setInterval> | null = null;
         const close = () => {
           if (closed) return;
           closed = true;
+          if (heartbeat) {
+            clearInterval(heartbeat);
+            heartbeat = null;
+          }
           try {
             controller.close();
           } catch (error) {
@@ -625,8 +631,21 @@ export class WebAdaptiveCardSidePromptService {
             close();
           }
         };
+        const sendHeartbeat = () => {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(": heartbeat\n\n"));
+            controller.enqueue(encoder.encode(formatSseEvent("heartbeat", { ts: Date.now(), chat_jid: chatJid })));
+          } catch (error) {
+            debugSuppressedError(log, "Adaptive-card side-prompt heartbeat enqueue raced a closed controller.", error, {
+              chatJid,
+            });
+            close();
+          }
+        };
 
         req.signal.addEventListener("abort", close, { once: true });
+        heartbeat = setInterval(sendHeartbeat, SIDE_PROMPT_STREAM_HEARTBEAT_MS);
 
         send("side_prompt_start", { chat_jid: chatJid });
         void runSidePrompt(chatJid, prompt, {

--- a/runtime/src/channels/web/cards/adaptive-card-side-prompt-service.ts
+++ b/runtime/src/channels/web/cards/adaptive-card-side-prompt-service.ts
@@ -478,7 +478,8 @@ export class WebAdaptiveCardSidePromptService {
         ? (() => {
             setWebTotpSecret(parsedTotp.state.secret);
             this.options.authGateway.setTotpSecret(parsedTotp.state.secret);
-            return "TOTP setup confirmed. Secret saved. This browser is now TOTP-authenticated.";
+            deleteAllWebSessions();
+            return "TOTP setup confirmed. Secret saved. Existing web sessions were invalidated. This browser is now TOTP-authenticated.";
           })()
         : parsedTotp.state.flow === "reset"
           ? (() => {

--- a/runtime/test/channels/web/cards/adaptive-card-side-prompt-service.test.ts
+++ b/runtime/test/channels/web/cards/adaptive-card-side-prompt-service.test.ts
@@ -515,4 +515,69 @@ describe("Web adaptive-card/side-prompt service", () => {
     expect(errorBody).toContain("event: side_prompt_error");
     expect(errorBody).toContain('"error":"stream exploded"');
   });
+
+  test("keeps side-prompt SSE streams alive with heartbeats and clears them on abort", async () => {
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+    const intervals: Array<{ fn: TimerHandler; ms?: number; token: object }> = [];
+    const cleared: object[] = [];
+
+    globalThis.setInterval = ((fn: TimerHandler, ms?: number) => {
+      const token = {};
+      intervals.push({ fn, ms, token });
+      return token as ReturnType<typeof setInterval>;
+    }) as typeof setInterval;
+
+    globalThis.clearInterval = ((token: object) => {
+      cleared.push(token);
+    }) as typeof clearInterval;
+
+    try {
+      const abortController = new AbortController();
+      const fixture = createFixture({
+        agentPool: {
+          runSidePrompt: async () => await new Promise<never>(() => {}),
+        },
+      });
+
+      const response = await fixture.service.handleAgentSidePromptStream(createRequest("/agent/side-prompt/stream", {
+        method: "POST",
+        body: JSON.stringify({ prompt: "Keepalive?", chat_jid: "web:stream" }),
+        signal: abortController.signal,
+      }));
+      expect(response.status).toBe(200);
+
+      const reader = response.body?.getReader();
+      expect(reader).toBeDefined();
+
+      const startChunk = await reader!.read();
+      const startBody = new TextDecoder().decode(startChunk.value);
+      expect(startBody).toContain("event: side_prompt_start");
+      expect(intervals).toHaveLength(1);
+      expect(intervals[0]?.ms).toBe(30000);
+
+      const heartbeatHandler = intervals[0]?.fn;
+      expect(typeof heartbeatHandler).toBe("function");
+      if (typeof heartbeatHandler === "function") {
+        heartbeatHandler();
+      }
+
+      const heartbeatCommentChunk = await reader!.read();
+      const heartbeatCommentBody = new TextDecoder().decode(heartbeatCommentChunk.value);
+      expect(heartbeatCommentBody).toContain(": heartbeat");
+
+      const heartbeatEventChunk = await reader!.read();
+      const heartbeatEventBody = new TextDecoder().decode(heartbeatEventChunk.value);
+      expect(heartbeatEventBody).toContain("event: heartbeat");
+      expect(heartbeatEventBody).toContain('"chat_jid":"web:stream"');
+
+      abortController.abort();
+      const doneChunk = await reader!.read();
+      expect(doneChunk.done).toBe(true);
+      expect(cleared).toContain(intervals[0]?.token);
+    } finally {
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    }
+  });
 });

--- a/runtime/test/channels/web/web-channel.test.ts
+++ b/runtime/test/channels/web/web-channel.test.ts
@@ -3230,6 +3230,50 @@ test("web channel commits TOTP setup only after successful same-card confirmatio
   expect(verifyRes.status).toBe(200);
 });
 
+test("web channel invalidates existing sessions when TOTP setup is first confirmed", async () => {
+  const fixture = await createStoredTotpCardFixture({
+    command: { type: "totp", action: "enrol" },
+  });
+  expect(fixture.parsed.ok).toBe(true);
+  if (!fixture.parsed.ok) return;
+
+  fixture.db.createWebSession("pre-setup-session", fixture.db.DEFAULT_WEB_USER_ID, 3600, "passkey");
+
+  const req = new Request("http://test/agent/card-action", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Cookie": "piclaw_session=pre-setup-session" },
+    body: JSON.stringify({
+      post_id: fixture.sourceRowId,
+      thread_id: fixture.sourceRowId,
+      card_id: fixture.cardId,
+      action: {
+        type: "Action.Submit",
+        title: "Confirm setup",
+        data: {
+          intent: "totp-confirm",
+          __totp_token: fixture.token,
+          confirmation_code: totpCode(fixture.parsed.state.secret),
+        },
+      },
+    }),
+  });
+
+  const res = await (fixture.web as any).handleRequest(req);
+  expect(res.status).toBe(200);
+  const setCookie = res.headers.get("Set-Cookie");
+  expect(setCookie).toContain("piclaw_session=");
+  expect(fixture.config.WEB_RUNTIME_CONFIG.totpSecret).toBe(fixture.parsed.state.secret);
+  expect(fixture.db.getWebSession("pre-setup-session")).toBeNull();
+
+  const nextSessionToken = setCookie?.match(/piclaw_session=([^;]+)/)?.[1];
+  expect(nextSessionToken).toBeTruthy();
+  expect(fixture.db.getWebSession(decodeURIComponent(nextSessionToken || ""))?.auth_method).toBe("totp");
+
+  const timeline = fixture.db.getTimeline("web:default", 10);
+  const feedback = timeline.find((entry: any) => entry.id !== fixture.sourceRowId && entry.data?.content?.includes("Existing web sessions were invalidated."));
+  expect(feedback).toBeDefined();
+});
+
 test("web channel leaves TOTP setup unchanged on invalid same-card confirmation", async () => {
   const fixture = await createStoredTotpCardFixture({
     command: { type: "totp", action: "enrol" },


### PR DESCRIPTION
## Summary
- invalidate existing web sessions when a first-time TOTP setup is confirmed, matching the reset flow while preserving a fresh authenticated session for the confirming browser
- emit periodic SSE heartbeats for adaptive-card side-prompt streams so slow runs survive idle proxy timeouts and client disconnects clean up their timer state
- add regressions covering both TOTP setup invalidation and side-prompt stream heartbeat cleanup

## Root cause
The TOTP setup-confirmation path saved the new secret without revoking older web sessions, unlike the reset flow. Separately, the adaptive-card side-prompt SSE endpoint exposed a long-lived `text/event-stream` response but never emitted heartbeats, so slow runs could be dropped by intermediaries and the stream had no explicit keepalive lifecycle to clean up.

## Impact
New TOTP enablement now rotates the deployment into an authenticated state consistently, and long-running side prompts keep their SSE connection alive until completion or client abort.

## Validation
- `bun test runtime/test/channels/web/web-channel.test.ts -t "web channel commits TOTP setup only after successful same-card confirmation|web channel invalidates existing sessions when TOTP setup is first confirmed|web channel leaves TOTP setup unchanged on invalid same-card confirmation|web channel commits TOTP reset only after successful new-secret confirmation|web channel preserves existing secret and sessions when reset confirmation fails"`
- `bun test runtime/test/channels/web/cards/adaptive-card-side-prompt-service.test.ts`
- `bun run typecheck`
