### PR TITLE
[codex] fix(ui-bridge): bound idle waits and stale chat state

### DIFF
--- a/runtime/src/channels/web/auth/request-origin.ts
+++ b/runtime/src/channels/web/auth/request-origin.ts
@@ -8,15 +8,33 @@
 import { createLogger, debugSuppressedError } from "../../../utils/logger.js";
 import { getRequestOriginParts } from "../http/client.js";
 
-const originByChatJid = new Map<string, string>();
+interface RequestOriginRecord {
+  origin: string;
+  touchedAt: number;
+}
+
+const originByChatJid = new Map<string, RequestOriginRecord>();
+const REQUEST_ORIGIN_TTL_MS = 24 * 60 * 60 * 1000;
 const log = createLogger("web.request-origin");
+
+function pruneExpiredOrigins(now = Date.now()): void {
+  for (const [chatJid, record] of originByChatJid) {
+    if (now - record.touchedAt < REQUEST_ORIGIN_TTL_MS) continue;
+    originByChatJid.delete(chatJid);
+  }
+}
 
 /** Persist the latest request origin for a web chat thread. */
 export function rememberWebOrigin(chatJid: string, req: Request): void {
   try {
+    const now = Date.now();
+    pruneExpiredOrigins(now);
     const { proto, host } = getRequestOriginParts(req);
     if (!host) return;
-    originByChatJid.set(chatJid, `${proto}://${host}`);
+    originByChatJid.set(chatJid, {
+      origin: `${proto}://${host}`,
+      touchedAt: now,
+    });
   } catch (error) {
     debugSuppressedError(log, "Failed to remember the last seen web request origin.", error, {
       chatJid,
@@ -27,5 +45,6 @@ export function rememberWebOrigin(chatJid: string, req: Request): void {
 
 /** Return the remembered browser origin for a web chat, if available. */
 export function getWebOrigin(chatJid: string): string | null {
-  return originByChatJid.get(chatJid) || null;
+  pruneExpiredOrigins();
+  return originByChatJid.get(chatJid)?.origin || null;
 }

--- a/runtime/src/channels/web/theming/ui-bridge.ts
+++ b/runtime/src/channels/web/theming/ui-bridge.ts
@@ -56,6 +56,10 @@ export interface UiBridgeChannel {
   broadcastEvent(eventType: string, data: unknown): void;
 }
 
+interface UiBridgeOptions {
+  waitForIdleTimeoutMs?: number;
+}
+
 interface PendingUiRequest {
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
@@ -72,7 +76,10 @@ export class UiBridge {
   themeByChat = new Map<string, WebThemePayload>();
   fallbackTheme = createFallbackTheme();
 
-  constructor(private channel: UiBridgeChannel) {}
+  constructor(
+    private channel: UiBridgeChannel,
+    private readonly options: UiBridgeOptions = {},
+  ) {}
 
   async bindSession(runtime: AgentSessionRuntime, chatJid: string): Promise<void> {
     if (!chatJid.startsWith("web:")) return;
@@ -81,14 +88,43 @@ export class UiBridge {
 
     const waitForIdle = async (): Promise<void> => {
       if (!session.isStreaming) return;
-      await new Promise<void>((resolve) => {
-        const unsub = session.subscribe((event) => {
-          if (event.type === "agent_end") {
-            unsub();
-            resolve();
-          }
-        });
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      let settled = false;
+      const timeoutMs = this.getWaitForIdleTimeoutMs();
+      let finish = () => {};
+      const unsubscribe = session.subscribe((event) => {
+        if (event.type === "agent_end" || !session.isStreaming) {
+          finish();
+        }
       });
+
+      try {
+        const waitForSession = new Promise<void>((resolve) => {
+          finish = () => {
+            if (settled) return;
+            settled = true;
+            if (timeoutId) {
+              clearTimeout(timeoutId);
+              timeoutId = null;
+            }
+            resolve();
+          };
+
+          timeoutId = setTimeout(() => {
+            log.warn("Timed out waiting for web session to go idle", {
+              operation: "web_theming_ui_bridge.wait_for_idle_timeout",
+              chatJid,
+              timeoutMs,
+            });
+            finish();
+          }, timeoutMs);
+        });
+
+        await waitForSession;
+      } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+        unsubscribe();
+      }
     };
 
     const uiContext = this.createUiContext(chatJid);
@@ -261,5 +297,11 @@ export class UiBridge {
       }
     }
     this.pendingUiRequests.clear();
+  }
+
+  private getWaitForIdleTimeoutMs(): number {
+    const rawTimeout = this.options.waitForIdleTimeoutMs;
+    if (!Number.isFinite(rawTimeout)) return 15000;
+    return Math.max(1, Math.floor(rawTimeout as number));
   }
 }

--- a/runtime/src/channels/web/theming/ui-bridge.ts
+++ b/runtime/src/channels/web/theming/ui-bridge.ts
@@ -58,6 +58,7 @@ export interface UiBridgeChannel {
 
 interface UiBridgeOptions {
   waitForIdleTimeoutMs?: number;
+  chatStateTtlMs?: number;
 }
 
 interface PendingUiRequest {
@@ -68,12 +69,15 @@ interface PendingUiRequest {
   chatJid: string;
 }
 
+const DEFAULT_CHAT_STATE_TTL_MS = 24 * 60 * 60 * 1000;
+
 /** Bridges extension UI prompts (confirm/input) to SSE events and API responses. */
 export class UiBridge {
   pendingUiRequests = new Map<string, PendingUiRequest>();
   uiRequestCounter = 0;
   editorTextByChat = new Map<string, string>();
   themeByChat = new Map<string, WebThemePayload>();
+  private readonly chatStateTouchedAtByChat = new Map<string, number>();
   fallbackTheme = createFallbackTheme();
 
   constructor(
@@ -83,6 +87,7 @@ export class UiBridge {
 
   async bindSession(runtime: AgentSessionRuntime, chatJid: string): Promise<void> {
     if (!chatJid.startsWith("web:")) return;
+    this.touchChat(chatJid);
 
     const session = runtime.session;
 
@@ -161,11 +166,13 @@ export class UiBridge {
   }
 
   createUiContext(chatJid: string): ExtensionUIContext {
+    this.touchChat(chatJid);
     const requestUiResponse = async (
       kind: string,
       payload: Record<string, unknown>,
       timeoutMs = 120000
     ): Promise<unknown> => {
+      this.touchChat(chatJid);
       const requestId = `ui-${Date.now()}-${++this.uiRequestCounter}`;
       return new Promise((resolve, reject) => {
         const timeoutId = setTimeout(() => {
@@ -233,16 +240,21 @@ export class UiBridge {
         return result as T;
       },
       pasteToEditor: (text) => {
+        this.touchChat(chatJid);
         const current = this.editorTextByChat.get(chatJid) || "";
         const updated = current + text;
         this.editorTextByChat.set(chatJid, updated);
         this.channel.broadcastEvent("extension_ui_editor_text", { chat_jid: chatJid, text: updated });
       },
       setEditorText: (text) => {
+        this.touchChat(chatJid);
         this.editorTextByChat.set(chatJid, text);
         this.channel.broadcastEvent("extension_ui_editor_text", { chat_jid: chatJid, text });
       },
-      getEditorText: () => this.editorTextByChat.get(chatJid) || "",
+      getEditorText: () => {
+        this.touchChat(chatJid);
+        return this.editorTextByChat.get(chatJid) || "";
+      },
       editor: async (title, prefill) => {
         const result = await requestUiResponse("editor", { title, prefill });
         return typeof result === "string" ? result : undefined;
@@ -259,6 +271,7 @@ export class UiBridge {
         return undefined;
       },
       setTheme: (nextTheme) => {
+        this.touchChat(chatJid);
         const payload = normalizeThemePayload(nextTheme);
         if (!payload) return { success: false, error: "Invalid theme payload" };
         this.themeByChat.set(chatJid, payload);
@@ -278,10 +291,32 @@ export class UiBridge {
     if (normalizedChatJid && pending.chatJid !== normalizedChatJid) {
       return { status: "unknown_request" };
     }
+    this.touchChat(pending.chatJid);
     clearTimeout(pending.timeoutId);
     this.pendingUiRequests.delete(requestId);
     pending.resolve(outcome);
     return { status: "ok" };
+  }
+
+  clearChatState(chatJid: string, reason = "Web UI chat state expired"): void {
+    const normalizedChatJid = String(chatJid || "").trim();
+    if (!normalizedChatJid) return;
+    this.editorTextByChat.delete(normalizedChatJid);
+    this.themeByChat.delete(normalizedChatJid);
+    this.chatStateTouchedAtByChat.delete(normalizedChatJid);
+    for (const [requestId, pending] of this.pendingUiRequests) {
+      if (pending.chatJid !== normalizedChatJid) continue;
+      clearTimeout(pending.timeoutId);
+      this.pendingUiRequests.delete(requestId);
+      try {
+        pending.reject(new Error(reason));
+      } catch (error) {
+        debugSuppressedError(log, "Failed to reject a stale web UI request during chat-state cleanup.", error, {
+          chatJid: pending.chatJid,
+          kind: pending.kind,
+        });
+      }
+    }
   }
 
   stop(): void {
@@ -297,11 +332,36 @@ export class UiBridge {
       }
     }
     this.pendingUiRequests.clear();
+    this.editorTextByChat.clear();
+    this.themeByChat.clear();
+    this.chatStateTouchedAtByChat.clear();
   }
 
   private getWaitForIdleTimeoutMs(): number {
     const rawTimeout = this.options.waitForIdleTimeoutMs;
     if (!Number.isFinite(rawTimeout)) return 15000;
     return Math.max(1, Math.floor(rawTimeout as number));
+  }
+
+  private getChatStateTtlMs(): number {
+    const rawTtl = this.options.chatStateTtlMs;
+    if (!Number.isFinite(rawTtl)) return DEFAULT_CHAT_STATE_TTL_MS;
+    return Math.max(1, Math.floor(rawTtl as number));
+  }
+
+  private touchChat(chatJid: string): void {
+    const normalizedChatJid = String(chatJid || "").trim();
+    if (!normalizedChatJid) return;
+    const now = Date.now();
+    this.pruneExpiredChatState(now);
+    this.chatStateTouchedAtByChat.set(normalizedChatJid, now);
+  }
+
+  private pruneExpiredChatState(now = Date.now()): void {
+    const ttlMs = this.getChatStateTtlMs();
+    for (const [chatJid, touchedAt] of this.chatStateTouchedAtByChat) {
+      if (now - touchedAt < ttlMs) continue;
+      this.clearChatState(chatJid, "Web UI chat state expired");
+    }
   }
 }

--- a/runtime/test/channels/web/request-origin.test.ts
+++ b/runtime/test/channels/web/request-origin.test.ts
@@ -20,3 +20,19 @@ test("rememberWebOrigin suppresses invalid request URLs without clobbering state
 
   expect(getWebOrigin("chat:origin-stable")).toBe("https://stable.example.com");
 });
+
+test("rememberWebOrigin prunes stale origins after the TTL window", () => {
+  const originalNow = Date.now;
+  try {
+    Date.now = () => 0;
+    rememberWebOrigin("chat:origin-stale", new Request("https://stale.example.com/path"));
+
+    Date.now = () => 24 * 60 * 60 * 1000 + 1;
+    rememberWebOrigin("chat:origin-fresh", new Request("https://fresh.example.com/path"));
+
+    expect(getWebOrigin("chat:origin-stale")).toBeNull();
+    expect(getWebOrigin("chat:origin-fresh")).toBe("https://fresh.example.com");
+  } finally {
+    Date.now = originalNow;
+  }
+});

--- a/runtime/test/channels/web/ui-context.test.ts
+++ b/runtime/test/channels/web/ui-context.test.ts
@@ -11,12 +11,15 @@ import type { AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
 import { UiBridge } from "../../../src/channels/web/theming/ui-bridge.js";
 import { bindSessionUiContext, createUiContext } from "../../../src/channels/web/ui-context.js";
 
-function makeChannel(waitForIdleTimeoutMs?: number) {
+function makeChannel(options: { waitForIdleTimeoutMs?: number; chatStateTtlMs?: number } = {}) {
   const events: Array<{ type: string; payload: any }> = [];
   const channel = {
     broadcastEvent: (type: string, payload: any) => events.push({ type, payload }),
   };
-  const uiBridge = new UiBridge(channel as any, waitForIdleTimeoutMs == null ? undefined : { waitForIdleTimeoutMs });
+  const uiBridge = new UiBridge(channel as any, {
+    ...(options.waitForIdleTimeoutMs == null ? {} : { waitForIdleTimeoutMs: options.waitForIdleTimeoutMs }),
+    ...(options.chatStateTtlMs == null ? {} : { chatStateTtlMs: options.chatStateTtlMs }),
+  });
   (channel as any).uiBridge = uiBridge;
   return { channel, events, uiBridge };
 }
@@ -160,7 +163,7 @@ describe("ui-context", () => {
   });
 
   test("bindSessionUiContext waitForIdle unsubscribes after a bounded timeout when agent_end never arrives", async () => {
-    const { channel } = makeChannel(10);
+    const { channel } = makeChannel({ waitForIdleTimeoutMs: 10 });
     let boundArgs: any = null;
     let unsubscribeCalled = false;
 
@@ -182,7 +185,7 @@ describe("ui-context", () => {
   });
 
   test("bindSessionUiContext waitForIdle resolves when streaming stops before agent_end", async () => {
-    const { channel } = makeChannel(1000);
+    const { channel } = makeChannel({ waitForIdleTimeoutMs: 1000 });
     let boundArgs: any = null;
     let unsubscribeCalled = false;
     let listener: ((event: any) => void) | null = null;
@@ -222,5 +225,24 @@ describe("ui-context", () => {
 
     await bindSessionUiContext(channel as any, createRuntime(session), "whatsapp:123");
     expect(bindCalled).toBe(false);
+  });
+
+  test("UiBridge prunes stale per-chat state and rejects stale pending requests", async () => {
+    const { uiBridge } = makeChannel({ chatStateTtlMs: 10 });
+    const staleUi = uiBridge.createUiContext("web:stale");
+    staleUi.setEditorText("Alpha");
+    staleUi.setTheme("tango");
+    const pendingConfirm = staleUi.confirm("Confirm", "Are you sure?", { timeout: 1000 });
+
+    await Bun.sleep(20);
+
+    const freshUi = uiBridge.createUiContext("web:fresh");
+    freshUi.setEditorText("Beta");
+
+    await expect(pendingConfirm).rejects.toThrow("Web UI chat state expired");
+    expect(uiBridge.pendingUiRequests.size).toBe(0);
+    expect(uiBridge.editorTextByChat.has("web:stale")).toBe(false);
+    expect(uiBridge.themeByChat.has("web:stale")).toBe(false);
+    expect(uiBridge.editorTextByChat.get("web:fresh")).toBe("Beta");
   });
 });

--- a/runtime/test/channels/web/ui-context.test.ts
+++ b/runtime/test/channels/web/ui-context.test.ts
@@ -11,12 +11,12 @@ import type { AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
 import { UiBridge } from "../../../src/channels/web/theming/ui-bridge.js";
 import { bindSessionUiContext, createUiContext } from "../../../src/channels/web/ui-context.js";
 
-function makeChannel() {
+function makeChannel(waitForIdleTimeoutMs?: number) {
   const events: Array<{ type: string; payload: any }> = [];
   const channel = {
     broadcastEvent: (type: string, payload: any) => events.push({ type, payload }),
   };
-  const uiBridge = new UiBridge(channel as any);
+  const uiBridge = new UiBridge(channel as any, waitForIdleTimeoutMs == null ? undefined : { waitForIdleTimeoutMs });
   (channel as any).uiBridge = uiBridge;
   return { channel, events, uiBridge };
 }
@@ -115,13 +115,17 @@ describe("ui-context", () => {
     let boundArgs: any = null;
     let reloadCalled = false;
     let subscribeCalled = false;
+    let unsubscribeCalled = false;
 
     const session = {
       isStreaming: true,
       subscribe: (cb: (event: any) => void) => {
         subscribeCalled = true;
         const timer = setTimeout(() => cb({ type: "agent_end" }), 0);
-        return () => clearTimeout(timer);
+        return () => {
+          unsubscribeCalled = true;
+          clearTimeout(timer);
+        };
       },
       bindExtensions: async (args: any) => {
         boundArgs = args;
@@ -138,6 +142,7 @@ describe("ui-context", () => {
     const actions = boundArgs.commandContextActions;
     await actions.waitForIdle();
     expect(subscribeCalled).toBe(true);
+    expect(unsubscribeCalled).toBe(true);
     expect(await actions.newSession({})).toEqual({ cancelled: false });
     expect(await actions.fork("abc")).toEqual({ cancelled: false });
     expect(await actions.navigateTree("abc", {})).toEqual({ cancelled: true });
@@ -152,6 +157,57 @@ describe("ui-context", () => {
     const errorEvent = events.find((event) => event.type === "extension_ui_error");
     expect(errorEvent).toBeDefined();
     expect(errorEvent?.payload?.chat_jid).toBe("web:default");
+  });
+
+  test("bindSessionUiContext waitForIdle unsubscribes after a bounded timeout when agent_end never arrives", async () => {
+    const { channel } = makeChannel(10);
+    let boundArgs: any = null;
+    let unsubscribeCalled = false;
+
+    const session = {
+      isStreaming: true,
+      subscribe: () => () => {
+        unsubscribeCalled = true;
+      },
+      bindExtensions: async (args: any) => {
+        boundArgs = args;
+      },
+      navigateTree: async () => ({ cancelled: false }),
+      reload: async () => {},
+    } as any;
+
+    await bindSessionUiContext(channel as any, createRuntime(session), "web:default");
+    await boundArgs.commandContextActions.waitForIdle();
+    expect(unsubscribeCalled).toBe(true);
+  });
+
+  test("bindSessionUiContext waitForIdle resolves when streaming stops before agent_end", async () => {
+    const { channel } = makeChannel(1000);
+    let boundArgs: any = null;
+    let unsubscribeCalled = false;
+    let listener: ((event: any) => void) | null = null;
+
+    const session = {
+      isStreaming: true,
+      subscribe: (cb: (event: any) => void) => {
+        listener = cb;
+        return () => {
+          unsubscribeCalled = true;
+        };
+      },
+      bindExtensions: async (args: any) => {
+        boundArgs = args;
+      },
+      navigateTree: async () => ({ cancelled: false }),
+      reload: async () => {},
+    } as any;
+
+    await bindSessionUiContext(channel as any, createRuntime(session), "web:default");
+    const waitForIdle = boundArgs.commandContextActions.waitForIdle();
+    session.isStreaming = false;
+    listener?.({ type: "message_end" });
+    await waitForIdle;
+    expect(unsubscribeCalled).toBe(true);
   });
 
   test("bindSessionUiContext ignores non-web chats", async () => {

--- a/runtime/test/channels/web/web-utils.test.ts
+++ b/runtime/test/channels/web/web-utils.test.ts
@@ -116,6 +116,8 @@ test("static helpers serve files and not-found", async () => {
 test("ui bridge stop clears pending requests even when a pending reject throws", () => {
   const channel = { broadcastEvent: () => undefined } as any;
   const uiBridge = new UiBridge(channel);
+  uiBridge.editorTextByChat.set("web:default", "draft");
+  uiBridge.themeByChat.set("web:default", { theme: "tango" });
   uiBridge.pendingUiRequests.set("req-1", {
     chatJid: "web:default",
     kind: "input",
@@ -126,6 +128,8 @@ test("ui bridge stop clears pending requests even when a pending reject throws",
 
   expect(() => uiBridge.stop()).not.toThrow();
   expect(uiBridge.pendingUiRequests.size).toBe(0);
+  expect(uiBridge.editorTextByChat.size).toBe(0);
+  expect(uiBridge.themeByChat.size).toBe(0);
 });
 
 test("ui context emits requests and resolves", async () => {


### PR DESCRIPTION
## Summary
- harden `UiBridge.waitForIdle()` so it always tears down its session subscription
- stop waiting only for `agent_end` by also resolving when the session is no longer streaming, with a bounded timeout fallback
- prune stale per-chat `UiBridge` editor/theme/request state and remembered web origins with TTL-based eviction
- add regressions for the timeout path, non-`agent_end` idle transition, stale UI chat-state pruning, and stale origin eviction

## Root Cause
The web UI bridge kept two different kinds of state alive indefinitely. `waitForIdle()` could leave a subscription behind if a session stopped without emitting `agent_end`, and the per-chat editor/theme/request-origin maps had no eviction path for long-lived processes that touched many chats.

## Impact
Extension UI command actions no longer leak listeners or hang forever when a session stops unexpectedly, and stale per-chat bridge/origin state is now bounded over time instead of accumulating for the lifetime of the process.

## Validation
- `bun test runtime/test/channels/web/ui-context.test.ts runtime/test/channels/web/request-origin.test.ts runtime/test/channels/web/web-utils.test.ts`
- `bun run typecheck`
