### PR TITLE
[codex] fix(web): stop extending rate-limit windows on blocked requests

### DIFF
--- a/runtime/src/channels/web/http/rate-limit.ts
+++ b/runtime/src/channels/web/http/rate-limit.ts
@@ -48,9 +48,13 @@ export function isRateLimitedForClient(
   const cutoff = now - windowMs;
   const entries = rateBuckets.get(key) || [];
   const trimmed = entries.filter((ts) => ts > cutoff);
+  if (trimmed.length >= limit) {
+    rateBuckets.set(key, trimmed);
+    return true;
+  }
   trimmed.push(now);
   rateBuckets.set(key, trimmed);
-  return trimmed.length > limit;
+  return false;
 }
 
 /**

--- a/runtime/test/channels/web/http-rate-limit.test.ts
+++ b/runtime/test/channels/web/http-rate-limit.test.ts
@@ -30,4 +30,11 @@ describe("web http rate-limit", () => {
     expect(isRateLimitedForClient("ip1", "bucket", 100, 1, start + 50)).toBe(true);
     expect(isRateLimitedForClient("ip1", "bucket", 100, 1, start + 150)).toBe(false);
   });
+
+  test("blocked requests do not extend the lockout window", () => {
+    const start = 4_000_000;
+    expect(isRateLimitedForClient("ip1", "bucket", 100, 1, start)).toBe(false);
+    expect(isRateLimitedForClient("ip1", "bucket", 100, 1, start + 99)).toBe(true);
+    expect(isRateLimitedForClient("ip1", "bucket", 100, 1, start + 101)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- stop recording blocked requests into the web sliding-window rate-limit bucket
- keep the bucket trimmed to only previously allowed in-window requests when a client is already over limit
- add a regression test proving blocked requests no longer extend the lockout window

## Root cause
The rate limiter always appended the current timestamp before checking whether the bucket was already full. Once a client hit the limit, every blocked request became a fresh in-window entry, which both inflated the stored bucket and prolonged the effective lockout period.

## Impact
Clients are now unblocked as soon as their last allowed request ages out of the window, even if they kept retrying while rate-limited. The limiter also avoids unnecessary bucket growth for blocked traffic.

## Validation
- `bun test runtime/test/channels/web/http-rate-limit.test.ts`
- `bun run typecheck`
