### PR TITLE
[codex] fix(db): coalesce NULL token-usage aggregates to zero

### DIFF
--- a/runtime/src/db/token-usage.ts
+++ b/runtime/src/db/token-usage.ts
@@ -152,12 +152,12 @@ export function getTokenUsageByProvider(chatJid: string, limit = 5): TokenUsageB
   return db.prepare(
     `SELECT
       provider,
-      SUM(input_tokens) AS input_tokens,
-      SUM(output_tokens) AS output_tokens,
-      SUM(cache_read_tokens) AS cache_read_tokens,
-      SUM(cache_write_tokens) AS cache_write_tokens,
-      SUM(total_tokens) AS total_tokens,
-      SUM(cost_total) AS cost_total,
+      COALESCE(SUM(input_tokens), 0) AS input_tokens,
+      COALESCE(SUM(output_tokens), 0) AS output_tokens,
+      COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+      COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+      COALESCE(SUM(total_tokens), 0) AS total_tokens,
+      COALESCE(SUM(cost_total), 0) AS cost_total,
       COUNT(*) AS runs
      FROM token_usage
      WHERE chat_jid = ?
@@ -173,12 +173,12 @@ export function getTokenUsageByModel(chatJid: string, limit = 5): TokenUsageByMo
   return db.prepare(
     `SELECT
       model,
-      SUM(input_tokens) AS input_tokens,
-      SUM(output_tokens) AS output_tokens,
-      SUM(cache_read_tokens) AS cache_read_tokens,
-      SUM(cache_write_tokens) AS cache_write_tokens,
-      SUM(total_tokens) AS total_tokens,
-      SUM(cost_total) AS cost_total,
+      COALESCE(SUM(input_tokens), 0) AS input_tokens,
+      COALESCE(SUM(output_tokens), 0) AS output_tokens,
+      COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+      COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+      COALESCE(SUM(total_tokens), 0) AS total_tokens,
+      COALESCE(SUM(cost_total), 0) AS cost_total,
       COUNT(*) AS runs
      FROM token_usage
      WHERE chat_jid = ?

--- a/runtime/test/db/token-usage.test.ts
+++ b/runtime/test/db/token-usage.test.ts
@@ -148,4 +148,54 @@ describe("token-usage", () => {
     expect(model[0].total_tokens).toBe(280);
     expect(model[0].runs).toBe(2);
   });
+
+  test("coalesces grouped token usage aggregates when legacy rows contain null counts", () => {
+    initDatabase();
+    const db = getDb();
+    const chatJid = "test:aggregate-null";
+    db.prepare(
+      `INSERT INTO token_usage (
+        chat_jid,
+        run_at,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
+        total_tokens,
+        cost_input,
+        cost_output,
+        cost_cache_read,
+        cost_cache_write,
+        cost_total,
+        model,
+        provider,
+        api,
+        turns
+      ) VALUES (?, ?, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, NULL, ?, ?, NULL, NULL)`
+    ).run(chatJid, new Date().toISOString(), "legacy-model", "legacy-provider");
+
+    const provider = getTokenUsageByProvider(chatJid, 10);
+    expect(provider).toEqual([{
+      provider: "legacy-provider",
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      total_tokens: 0,
+      cost_total: 0,
+      runs: 1,
+    }]);
+
+    const model = getTokenUsageByModel(chatJid, 10);
+    expect(model).toEqual([{
+      model: "legacy-model",
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      total_tokens: 0,
+      cost_total: 0,
+      runs: 1,
+    }]);
+  });
 });


### PR DESCRIPTION
## Summary
- coalesce grouped token-usage aggregates to zero for provider and model summaries
- align the grouped queries with the already-safe totals query
- add a regression test covering legacy rows that contain `NULL` token counts

## Root cause
`getTokenUsageTotals()` already wrapped its aggregate sums in `COALESCE(..., 0)`, but the grouped provider/model queries used raw `SUM(...)`. Legacy or partially backfilled rows with `NULL` token counts therefore produced grouped summary fields that were `NULL` even though the TypeScript types promised numbers.

## Impact
Provider/model token-usage summaries now return stable numeric zeroes instead of leaking `NULL` values to callers that treat those fields as numbers.

## Validation
- `bun test runtime/test/db/token-usage.test.ts`
- `bun run typecheck`
