### PR TITLE
[codex] fix(keychain): preserve colon refs and scope injected shell secrets

### DIFF
--- a/runtime/src/extensions/ssh-core.ts
+++ b/runtime/src/extensions/ssh-core.ts
@@ -727,6 +727,7 @@ function createRemoteBashOps(transport: RemoteTransport): BashOperations {
       const resolvedEnv = await buildInjectedShellEnv({
         explicitEnv: env,
         includeProcessEnv: false,
+        referencedTexts: [command],
       });
       return transport.exec(resolvedCommand, cwd, { onData, signal, timeout, env: resolvedEnv });
     },

--- a/runtime/src/portainer/client.ts
+++ b/runtime/src/portainer/client.ts
@@ -967,6 +967,9 @@ export class PortainerClient {
         AttachStderr: true,
         Tty: false,
         Cmd: [wrappedCommand.command, ...wrappedCommand.commandArgs],
+        ...(Object.keys(wrappedCommand.env).length > 0
+          ? { Env: Object.entries(wrappedCommand.env).map(([key, value]) => `${key}=${value}`) }
+          : {}),
       },
       body_mode: "json",
     });

--- a/runtime/src/proxmox/client.ts
+++ b/runtime/src/proxmox/client.ts
@@ -1339,6 +1339,9 @@ export class ProxmoxClient {
       path: `/nodes/${encodeURIComponent(node)}/qemu/${vmid}/agent/exec`,
       body: {
         command: [wrappedCommand.command, ...wrappedCommand.commandArgs],
+        ...(Object.keys(wrappedCommand.env).length > 0
+          ? { env: Object.entries(wrappedCommand.env).map(([key, value]) => `${key}=${value}`) }
+          : {}),
         ...(typeof resolvedInputData === "string" && resolvedInputData.length > 0 ? { "input-data": resolvedInputData } : {}),
       },
       body_mode: "form",

--- a/runtime/src/secure/keychain.ts
+++ b/runtime/src/secure/keychain.ts
@@ -350,8 +350,30 @@ export function listInjectableKeychainEnvNames(): string[] {
   return listInjectableKeychainEntries().map((entry) => entry.envName);
 }
 
-export async function loadAutoInjectedKeychainEnv(): Promise<Record<string, string>> {
-  const injectable = listInjectableKeychainEntries();
+function collectReferencedShellEnvNames(texts: string[]): Set<string> {
+  const names = new Set<string>();
+  const regexes = [
+    /\$env:([A-Za-z_][A-Za-z0-9_]*)/g,
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g,
+    /\$([A-Za-z_][A-Za-z0-9_]*)/g,
+    /%([A-Za-z_][A-Za-z0-9_]*)%/g,
+  ];
+
+  for (const text of texts) {
+    for (const regex of regexes) {
+      regex.lastIndex = 0;
+      for (const match of text.matchAll(regex)) {
+        const name = match[1];
+        if (name) names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+export async function loadAutoInjectedKeychainEnv(referencedTexts?: string[]): Promise<Record<string, string>> {
+  const referencedEnvNames = Array.isArray(referencedTexts) ? collectReferencedShellEnvNames(referencedTexts) : null;
+  const injectable = listInjectableKeychainEntries().filter((entry) => referencedEnvNames === null || referencedEnvNames.has(entry.envName));
   const resolved: Record<string, string> = {};
   for (const { envName, keychainName } of injectable) {
     const entry = await getKeychainEntry(keychainName);
@@ -363,11 +385,12 @@ export async function loadAutoInjectedKeychainEnv(): Promise<Record<string, stri
 export async function buildInjectedShellEnv(options: {
   explicitEnv?: Record<string, string | undefined>;
   includeProcessEnv?: boolean;
+  referencedTexts?: string[];
 } = {}): Promise<Record<string, string>> {
   const merged: Record<string, string> = options.includeProcessEnv ? { ...process.env } as Record<string, string> : {};
 
   try {
-    const autoInjected = await loadAutoInjectedKeychainEnv();
+    const autoInjected = await loadAutoInjectedKeychainEnv(options.referencedTexts);
     for (const [key, value] of Object.entries(autoInjected)) {
       if (merged[key] === undefined) merged[key] = value;
     }

--- a/runtime/src/secure/keychain.ts
+++ b/runtime/src/secure/keychain.ts
@@ -29,12 +29,13 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 const KEYCHAIN_PREFIX = "keychain:";
-const KEYCHAIN_PLACEHOLDER = /keychain:[A-Za-z0-9._\/-]+(?::[A-Za-z0-9._-]+)?/g;
 const SHELL_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const KDF_ALGO = "pbkdf2-sha256";
 const KDF_ITERATIONS = 150_000;
 const SALT_BYTES = 16;
 const NONCE_BYTES = 12;
+const USERNAME_REF_FIELDS = new Set(["username", "user"]);
+const SECRET_REF_FIELDS = new Set(["secret", "password", "token"]);
 
 const toArrayBuffer = (value: Uint8Array): ArrayBuffer =>
   value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
@@ -236,17 +237,66 @@ export function deleteKeychainEntry(name: string): boolean {
 
 function parseKeychainReference(value: string): { name: string; field: "secret" | "username" } {
   const raw = value.slice(KEYCHAIN_PREFIX.length);
-  const [name, field = "secret"] = raw.split(":");
+  if (!raw || raw.startsWith(":")) {
+    throw new Error(`Invalid keychain reference: ${value}`);
+  }
+
+  const lastColon = raw.lastIndexOf(":");
+  if (lastColon < 0) {
+    return { name: raw, field: "secret" };
+  }
+
+  const name = raw.slice(0, lastColon);
+  const field = raw.slice(lastColon + 1);
   if (!name) {
     throw new Error(`Invalid keychain reference: ${value}`);
   }
-  if (field === "username" || field === "user") {
+
+  if (USERNAME_REF_FIELDS.has(field)) {
     return { name, field: "username" };
   }
-  if (field === "secret" || field === "password" || field === "token") {
+  if (SECRET_REF_FIELDS.has(field)) {
     return { name, field: "secret" };
   }
-  throw new Error(`Invalid keychain reference: ${value}`);
+
+  if (!name.includes(":")) {
+    throw new Error(`Invalid keychain reference: ${value}`);
+  }
+
+  return { name: raw, field: "secret" };
+}
+
+function isKeychainReferenceChar(char: string): boolean {
+  return /[A-Za-z0-9._\/:-]/.test(char);
+}
+
+function findKeychainPlaceholders(input: string): string[] {
+  const matches: string[] = [];
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const start = input.indexOf(KEYCHAIN_PREFIX, cursor);
+    if (start < 0) break;
+
+    let end = start + KEYCHAIN_PREFIX.length;
+    const firstChar = input[end];
+    if (!firstChar || !/[A-Za-z0-9._\/-]/.test(firstChar)) {
+      cursor = end;
+      continue;
+    }
+
+    while (end < input.length) {
+      if (input.startsWith(`:${KEYCHAIN_PREFIX}`, end)) break;
+      const char = input[end];
+      if (!isKeychainReferenceChar(char)) break;
+      end += 1;
+    }
+
+    matches.push(input.slice(start, end));
+    cursor = end;
+  }
+
+  return matches;
 }
 
 export function isInjectableKeychainEnvName(name: string): boolean {
@@ -361,7 +411,7 @@ export async function resolveKeychainPlaceholders(input: string): Promise<string
     return input;
   }
 
-  const matches = input.match(KEYCHAIN_PLACEHOLDER);
+  const matches = findKeychainPlaceholders(input);
   if (!matches?.length) {
     return input;
   }
@@ -382,5 +432,9 @@ export async function resolveKeychainPlaceholders(input: string): Promise<string
     }
   }
 
-  return input.replace(KEYCHAIN_PLACEHOLDER, (match) => replacements.get(match) ?? match);
+  let output = input;
+  for (const placeholder of Array.from(replacements.keys()).sort((a, b) => b.length - a.length)) {
+    output = output.replaceAll(placeholder, replacements.get(placeholder) ?? placeholder);
+  }
+  return output;
 }

--- a/runtime/src/secure/shell-secrets.ts
+++ b/runtime/src/secure/shell-secrets.ts
@@ -136,34 +136,38 @@ export async function redactKeychainSecretsInValue(value: unknown): Promise<unkn
 async function resolveInjectedExecParts(command: string, args: string[]): Promise<{ resolvedCommand: string; resolvedArgs: string[]; injectedEnv: Record<string, string> }> {
   const resolvedCommand = await resolveKeychainPlaceholders(command);
   const resolvedArgs = await Promise.all(args.map((value) => resolveKeychainPlaceholders(value)));
-  const injectedEnv = await buildInjectedShellEnv({ includeProcessEnv: false });
+  const injectedEnv = await buildInjectedShellEnv({
+    includeProcessEnv: false,
+    referencedTexts: [command, ...args],
+  });
   return { resolvedCommand, resolvedArgs, injectedEnv };
 }
 
-export async function buildInjectedExecCommand(shellFamily: InjectedShellFamily, command: string, args: string[] = []): Promise<{ command: string; commandArgs: string[] }> {
+export async function buildInjectedExecCommand(
+  shellFamily: InjectedShellFamily,
+  command: string,
+  args: string[] = [],
+): Promise<{ command: string; commandArgs: string[]; env: Record<string, string> }> {
   const { resolvedCommand, resolvedArgs, injectedEnv } = await resolveInjectedExecParts(command, args);
-  const envEntries = Object.entries(injectedEnv);
 
   if (shellFamily === "powershell") {
     const lines = [
       "$ErrorActionPreference = 'Stop'",
-      ...envEntries.map(([key, value]) => `$env:${key} = ${powerShellQuote(value)}`),
       `& ${[resolvedCommand, ...resolvedArgs].map(powerShellQuote).join(" ")}`,
       "if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE }",
     ];
     return {
       command: "powershell",
       commandArgs: ["-NoProfile", "-Command", lines.join("; ")],
+      env: injectedEnv,
     };
   }
 
   const execCommand = `exec ${[resolvedCommand, ...resolvedArgs].map(shellQuote).join(" ")}`;
-  const shellCommand = envEntries.length > 0
-    ? `${envEntries.map(([key, value]) => `${key}=${shellQuote(value)}`).join(" ")} ${execCommand}`
-    : execCommand;
   return {
     command: "sh",
-    commandArgs: ["-lc", shellCommand],
+    commandArgs: ["-lc", execCommand],
+    env: injectedEnv,
   };
 }
 

--- a/runtime/src/tools/tracked-bash.ts
+++ b/runtime/src/tools/tracked-bash.ts
@@ -107,6 +107,7 @@ function createTrackedShellOperations(resolveCandidates: () => ShellConfig[]): B
             resolvedEnv = await buildInjectedShellEnv({
               explicitEnv: env,
               includeProcessEnv: true,
+              referencedTexts: [command],
             });
             resolvedCommand = await resolveKeychainPlaceholders(command);
             outputRedactor = await createKeychainOutputRedactor();

--- a/runtime/test/keychain.test.ts
+++ b/runtime/test/keychain.test.ts
@@ -274,6 +274,38 @@ test("resolves keychain env references and inline placeholders", async () => {
   });
 });
 
+test("resolves keychain references whose entry names contain colons", async () => {
+  await withKeychainContext(async ({ keychain }) => {
+    await keychain.setKeychainEntry({
+      name: "service:api",
+      type: "basic",
+      secret: "api-secret",
+      username: "api-user",
+    });
+    await keychain.setKeychainEntry({
+      name: "service:api:staging",
+      type: "secret",
+      secret: "staging-secret",
+    });
+
+    const env = await keychain.resolveKeychainEnv({
+      TOKEN: "keychain:service:api:token",
+      USERNAME: "keychain:service:api:username",
+      STAGING: "keychain:service:api:staging",
+    });
+    expect(env).toEqual({
+      TOKEN: "api-secret",
+      USERNAME: "api-user",
+      STAGING: "staging-secret",
+    });
+
+    const placeholderText = await keychain.resolveKeychainPlaceholders(
+      "curl -u keychain:service:api:username:keychain:service:api:token keychain:service:api:staging"
+    );
+    expect(placeholderText).toBe("curl -u api-user:api-secret staging-secret");
+  });
+});
+
 test("rejects invalid entry shapes, invalid references, missing usernames, and unsupported KDFs", async () => {
   await withKeychainContext(async ({ db, keychain }) => {
     await expect(

--- a/runtime/test/keychain.test.ts
+++ b/runtime/test/keychain.test.ts
@@ -149,7 +149,7 @@ test("buildInjectedShellEnv ignores auto-injected keychain env when the database
   );
 });
 
-test("auto-injects env-style keychain entries for shell use", async () => {
+test("auto-injects only referenced env-style keychain entries for shell use", async () => {
   await withKeychainContext(async ({ keychain }) => {
     await keychain.setKeychainEntry({
       name: "STRIPE_KEY",
@@ -166,15 +166,20 @@ test("auto-injects env-style keychain entries for shell use", async () => {
     expect(keychain.isInjectableKeychainEnvName("ssh/prod")).toBe(false);
     expect(keychain.toShellEnvName("ssh/prod")).toBe("SSH_PROD");
     expect(keychain.listInjectableKeychainEnvNames()).toEqual(["STRIPE_KEY", "SSH_PROD"]);
-    await expect(keychain.loadAutoInjectedKeychainEnv()).resolves.toEqual({
+    await expect(keychain.loadAutoInjectedKeychainEnv(["echo $STRIPE_KEY ${SSH_PROD}"])).resolves.toEqual({
       STRIPE_KEY: "stripe-secret",
       SSH_PROD: "PRIVATE_KEY_DATA",
     });
+    await expect(keychain.loadAutoInjectedKeychainEnv(["echo $STRIPE_KEY"])).resolves.toEqual({
+      STRIPE_KEY: "stripe-secret",
+    });
 
-    const env = await keychain.buildInjectedShellEnv({ includeProcessEnv: false });
+    const env = await keychain.buildInjectedShellEnv({
+      includeProcessEnv: false,
+      referencedTexts: ["echo $STRIPE_KEY"],
+    });
     expect(env).toEqual({
       STRIPE_KEY: "stripe-secret",
-      SSH_PROD: "PRIVATE_KEY_DATA",
     });
   });
 });
@@ -197,19 +202,22 @@ test("builds injected POSIX and PowerShell exec commands and redacts secret valu
     expect(wrapped.command).toBe("sh");
     expect(wrapped.commandArgs).toHaveLength(2);
     expect(wrapped.commandArgs[0]).toBe("-lc");
-    expect(wrapped.commandArgs[1]).toContain("STRIPE_KEY='stripe-secret' exec 'echo' '$STRIPE_KEY' 'stripe-secret'");
+    expect(wrapped.commandArgs[1]).toBe("exec 'echo' '$STRIPE_KEY' 'stripe-secret'");
+    expect(wrapped.env).toEqual({ STRIPE_KEY: "stripe-secret" });
 
     const wrappedWithQuote = await shellSecrets.buildInjectedPosixCommand("printf", ["%s", "keychain:QUOTE_KEY"]);
+    expect(wrappedWithQuote.env).toEqual({});
 
     const wrappedPowerShell = await shellSecrets.buildInjectedPowerShellCommand("Write-Output", ["$env:STRIPE_KEY", "keychain:STRIPE_KEY"]);
     expect(wrappedPowerShell.command).toBe("powershell");
     expect(wrappedPowerShell.commandArgs).toHaveLength(3);
     expect(wrappedPowerShell.commandArgs[0]).toBe("-NoProfile");
     expect(wrappedPowerShell.commandArgs[1]).toBe("-Command");
-    expect(wrappedPowerShell.commandArgs[2]).toContain("$env:STRIPE_KEY = 'stripe-secret'");
     expect(wrappedPowerShell.commandArgs[2]).toContain("& 'Write-Output' '$env:STRIPE_KEY' 'stripe-secret'");
+    expect(wrappedPowerShell.env).toEqual({ STRIPE_KEY: "stripe-secret" });
 
     const proc = Bun.spawn([wrapped.command, ...wrapped.commandArgs], {
+      env: { ...process.env, ...wrapped.env },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -223,6 +231,7 @@ test("builds injected POSIX and PowerShell exec commands and redacts secret valu
     expect(stdout.trim()).toBe("$STRIPE_KEY stripe-secret");
 
     const procQuoted = Bun.spawn([wrappedWithQuote.command, ...wrappedWithQuote.commandArgs], {
+      env: { ...process.env, ...wrappedWithQuote.env },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/runtime/test/portainer/client.test.ts
+++ b/runtime/test/portainer/client.test.ts
@@ -92,7 +92,8 @@ test("container exec injects env-style keychain entries and redacts output", asy
 
     expect(seenExecBody?.Cmd?.[0]).toBe("sh");
     expect(seenExecBody?.Cmd?.[1]).toBe("-lc");
-    expect(seenExecBody?.Cmd?.[2]).toContain("STRIPE_KEY='stripe-secret'");
+    expect(seenExecBody?.Cmd?.[2]).toBe(`exec 'sh' '-lc' 'printf %s "$STRIPE_KEY"'`);
+    expect(seenExecBody?.Env).toEqual(["STRIPE_KEY=stripe-secret"]);
   });
 });
 
@@ -189,7 +190,10 @@ test("container exec supports PowerShell wrappers", async () => {
     expect(seenExecBody?.Cmd?.[0]).toBe("powershell");
     expect(seenExecBody?.Cmd?.[1]).toBe("-NoProfile");
     expect(seenExecBody?.Cmd?.[2]).toBe("-Command");
-    expect(seenExecBody?.Cmd?.[3]).toContain("$env:STRIPE_KEY = 'stripe-secret'");
+    expect(seenExecBody?.Cmd?.[3]).toBe(
+      "$ErrorActionPreference = 'Stop'; & 'Write-Output' '$env:STRIPE_KEY'; if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE }",
+    );
+    expect(seenExecBody?.Env).toEqual(["STRIPE_KEY=stripe-secret"]);
   });
 });
 

--- a/runtime/test/proxmox/client.test.ts
+++ b/runtime/test/proxmox/client.test.ts
@@ -122,8 +122,9 @@ test("guest agent exec injects env-style keychain entries and redacts output", a
     expect(seenExecBody?.getAll("command")).toEqual([
       "sh",
       "-lc",
-      expect.stringContaining("STRIPE_KEY='stripe-secret'"),
+      `exec 'sh' '-lc' 'printf %s "$STRIPE_KEY"'`,
     ]);
+    expect(seenExecBody?.getAll("env")).toEqual(["STRIPE_KEY=stripe-secret"]);
   });
 });
 
@@ -173,8 +174,9 @@ test("guest agent exec supports PowerShell wrappers", async () => {
       "powershell",
       "-NoProfile",
       "-Command",
-      expect.stringContaining("$env:STRIPE_KEY = 'stripe-secret'"),
+      "$ErrorActionPreference = 'Stop'; & 'Write-Output' '$env:STRIPE_KEY'; if ($null -ne $LASTEXITCODE) { exit $LASTEXITCODE }",
     ]);
+    expect(seenExecBody?.getAll("env")).toEqual(["STRIPE_KEY=stripe-secret"]);
   });
 });
 

--- a/runtime/test/secure/shell-secrets.test.ts
+++ b/runtime/test/secure/shell-secrets.test.ts
@@ -117,6 +117,7 @@ describe("buildInjectedExecCommand", () => {
     expect(result.commandArgs[1]).toContain("exec");
     expect(result.commandArgs[1]).toContain("echo");
     expect(result.commandArgs[1]).toContain("hello");
+    expect(result.env).toEqual({});
   });
 
   test("powershell command wraps in powershell -NoProfile -Command", async () => {
@@ -127,6 +128,7 @@ describe("buildInjectedExecCommand", () => {
     const cmd = result.commandArgs[result.commandArgs.length - 1];
     expect(cmd).toContain("Get-Date");
     expect(cmd).toContain("$ErrorActionPreference");
+    expect(result.env).toEqual({});
   });
 
   test("posix quotes arguments with single quotes", async () => {
@@ -134,6 +136,7 @@ describe("buildInjectedExecCommand", () => {
     expect(result.commandArgs[1]).toContain("it");
     // Should be shell-quoted
     expect(result.command).toBe("sh");
+    expect(result.env).toEqual({});
   });
 
   test("command with no args works", async () => {
@@ -141,5 +144,6 @@ describe("buildInjectedExecCommand", () => {
     expect(result.command).toBe("sh");
     expect(result.commandArgs[1]).toContain("exec");
     expect(result.commandArgs[1]).toContain("ls");
+    expect(result.env).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary
- preserve keychain entry names that contain `:` when resolving `keychain:` references and inline placeholders
- auto-inject only the shell-style env names actually referenced by a command instead of decrypting every injectable keychain entry for every shell launch
- pass those referenced secrets through separate exec environment payloads for tracked local shells, Docker exec, and Proxmox guest-agent exec instead of serializing them into the shell command string
- add regressions covering colon-bearing references, referenced-only env injection, and remote exec payload shapes

## Root cause
Keychain references were parsed with a naive split strategy, so names containing `:` were misread as malformed field suffixes. Separately, shell injection helpers decrypted every injectable keychain entry up front and, for wrapped exec flows, embedded those secrets directly into the generated shell command string.

## Impact
Colon-bearing keychain names now resolve correctly, shell launches only receive the secrets they explicitly reference, and those secrets no longer need to appear in wrapped shell command text for the supported exec transports.

## Validation
- `bun test runtime/test/keychain.test.ts runtime/test/secure/shell-secrets.test.ts runtime/test/tools/tracked-bash.test.ts runtime/test/portainer/client.test.ts runtime/test/proxmox/client.test.ts`
- `bun run typecheck`
