### PR TITLE
[codex] fix(tools): stream tracked-bash output instead of buffering all of it

### DIFF
--- a/runtime/src/secure/shell-secrets.ts
+++ b/runtime/src/secure/shell-secrets.ts
@@ -9,6 +9,7 @@ export interface TextRedactor {
   redact(text: string): string;
   maxNeedleLength: number;
   hasReplacements: boolean;
+  needles?: string[];
 }
 
 export interface StreamingTextRedactor {
@@ -64,6 +65,7 @@ export async function createKeychainOutputRedactor(): Promise<TextRedactor> {
         redact: (text) => text,
         maxNeedleLength: 0,
         hasReplacements: false,
+        needles: [],
       };
     }
 
@@ -77,12 +79,14 @@ export async function createKeychainOutputRedactor(): Promise<TextRedactor> {
       },
       maxNeedleLength: replacements[0]?.secret.length ?? 0,
       hasReplacements: true,
+      needles: replacements.map((replacement) => replacement.secret),
     };
   } catch {
     return {
       redact: (text) => text,
       maxNeedleLength: 0,
       hasReplacements: false,
+      needles: [],
     };
   }
 }
@@ -95,15 +99,35 @@ export function createStreamingTextRedactor(redactor: TextRedactor): StreamingTe
     };
   }
 
-  const tailKeep = redactor.maxNeedleLength - 1;
+  const needles = (redactor.needles ?? []).filter((needle) => needle.length > 1);
+  const prefixes = new Set<string>();
+  for (const needle of needles) {
+    for (let length = 1; length < needle.length; length += 1) {
+      prefixes.add(needle.slice(0, length));
+    }
+  }
+
+  const maxTailLength = redactor.maxNeedleLength - 1;
   let tail = "";
+
+  const longestPotentialPrefixSuffixLength = (text: string): number => {
+    if (prefixes.size === 0) {
+      return Math.min(text.length, maxTailLength);
+    }
+
+    const maxLength = Math.min(text.length, maxTailLength);
+    for (let length = maxLength; length > 0; length -= 1) {
+      if (prefixes.has(text.slice(text.length - length))) {
+        return length;
+      }
+    }
+    return 0;
+  };
+
   return {
     push(text) {
       const raw = `${tail}${text}`;
-      if (raw.length <= tailKeep) {
-        tail = raw;
-        return "";
-      }
+      const tailKeep = longestPotentialPrefixSuffixLength(raw);
       const emitRaw = raw.slice(0, raw.length - tailKeep);
       tail = raw.slice(raw.length - tailKeep);
       return redactor.redact(emitRaw);

--- a/runtime/src/tools/tracked-bash.ts
+++ b/runtime/src/tools/tracked-bash.ts
@@ -20,7 +20,7 @@ import { spawn } from "child_process";
 import { existsSync } from "fs";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
 import { buildInjectedShellEnv, resolveKeychainPlaceholders } from "../secure/keychain.js";
-import { createKeychainOutputRedactor, type TextRedactor } from "../secure/shell-secrets.js";
+import { createKeychainOutputRedactor, createStreamingTextRedactor, type StreamingTextRedactor } from "../secure/shell-secrets.js";
 import { killProcessTree, registerProcess, unregisterProcess } from "../utils/process-tracker.js";
 import { shouldDetachChildProcess } from "../utils/process-spawn.js";
 
@@ -39,6 +39,8 @@ interface ResolveShellConfigOptions {
 const POWERSHELL_ARGS = ["-NoProfile", "-Command"];
 const POSIX_ARGS = ["-c"];
 const CMD_ARGS = ["/c"];
+export const TRACKED_BASH_OUTPUT_LIMIT_BYTES = 256 * 1024;
+export const TRACKED_BASH_OUTPUT_TRUNCATION_NOTICE = "\n[output truncated]\n";
 
 function pushUniqueShell(candidates: ShellConfig[], candidate: ShellConfig): void {
   if (!candidate.shell.trim()) return;
@@ -102,14 +104,17 @@ function createTrackedShellOperations(resolveCandidates: () => ShellConfig[]): B
 
           let resolvedEnv: NodeJS.ProcessEnv;
           let resolvedCommand: string;
-          let outputRedactor: TextRedactor;
+          let stdoutRedactor: StreamingTextRedactor;
+          let stderrRedactor: StreamingTextRedactor;
           try {
             resolvedEnv = await buildInjectedShellEnv({
               explicitEnv: env,
               includeProcessEnv: true,
             });
             resolvedCommand = await resolveKeychainPlaceholders(command);
-            outputRedactor = await createKeychainOutputRedactor();
+            const outputRedactor = await createKeychainOutputRedactor();
+            stdoutRedactor = createStreamingTextRedactor(outputRedactor);
+            stderrRedactor = createStreamingTextRedactor(outputRedactor);
           } catch (error) {
             reject(error as Error);
             return;
@@ -120,6 +125,8 @@ function createTrackedShellOperations(resolveCandidates: () => ShellConfig[]): B
           let child: ReturnType<typeof spawn> | null = null;
           let settled = false;
           let attemptedShells: string[] = [];
+          let emittedBytes = 0;
+          let outputTruncated = false;
 
           let timeoutHandle: NodeJS.Timeout | undefined;
           const onAbort = () => {
@@ -165,6 +172,27 @@ function createTrackedShellOperations(resolveCandidates: () => ShellConfig[]): B
             resolve({ exitCode });
           };
 
+          const emitChunk = (text: string) => {
+            if (!text || outputTruncated || settled) return;
+            const buffer = Buffer.from(text, "utf8");
+            const remaining = TRACKED_BASH_OUTPUT_LIMIT_BYTES - emittedBytes;
+            if (remaining <= 0) {
+              onData(Buffer.from(TRACKED_BASH_OUTPUT_TRUNCATION_NOTICE, "utf8"));
+              outputTruncated = true;
+              return;
+            }
+            if (buffer.length <= remaining) {
+              emittedBytes += buffer.length;
+              onData(buffer);
+              return;
+            }
+
+            onData(buffer.subarray(0, remaining));
+            emittedBytes += remaining;
+            onData(Buffer.from(TRACKED_BASH_OUTPUT_TRUNCATION_NOTICE, "utf8"));
+            outputTruncated = true;
+          };
+
           const trySpawn = (candidateIndex: number) => {
             if (settled) return;
             const candidate = shellCandidates[candidateIndex];
@@ -187,15 +215,14 @@ function createTrackedShellOperations(resolveCandidates: () => ShellConfig[]): B
               registerProcess(spawned.pid);
             }
 
-            let capturedOutput = "";
             if (spawned.stdout) {
               spawned.stdout.on("data", (chunk) => {
-                capturedOutput += chunk.toString("utf8");
+                emitChunk(stdoutRedactor.push(chunk.toString("utf8")));
               });
             }
             if (spawned.stderr) {
               spawned.stderr.on("data", (chunk) => {
-                capturedOutput += chunk.toString("utf8");
+                emitChunk(stderrRedactor.push(chunk.toString("utf8")));
               });
             }
 
@@ -214,9 +241,8 @@ function createTrackedShellOperations(resolveCandidates: () => ShellConfig[]): B
             spawned.on("close", (code) => {
               if (spawned.pid) unregisterProcess(spawned.pid);
               if (shellUnavailable) return;
-
-              const redactedOutput = outputRedactor.redact(capturedOutput);
-              if (redactedOutput) onData(Buffer.from(redactedOutput, "utf8"));
+              emitChunk(stdoutRedactor.flush());
+              emitChunk(stderrRedactor.flush());
 
               if (aborted || signal?.aborted) {
                 settleError(new Error("aborted"));

--- a/runtime/test/secure/shell-secrets.test.ts
+++ b/runtime/test/secure/shell-secrets.test.ts
@@ -34,6 +34,7 @@ describe("createStreamingTextRedactor", () => {
       redact: (t) => t,
       maxNeedleLength: 0,
       hasReplacements: false,
+      needles: [],
     };
     const stream = createStreamingTextRedactor(noOp);
     expect(stream.push("hello")).toBe("hello");
@@ -47,35 +48,19 @@ describe("createStreamingTextRedactor", () => {
       redact: (t) => t.replaceAll(secret, "[REDACTED]"),
       maxNeedleLength: secret.length,
       hasReplacements: true,
+      needles: [secret],
     };
     const stream = createStreamingTextRedactor(redactor);
 
-    // Push less than tail length — held in buffer
     const r1 = stream.push("Hi ");
-    // "Hi " is 3 chars, tail keep is 5 (maxNeedleLength - 1)
-    // raw = "Hi ", length 3 <= tailKeep 5 → all buffered
-    expect(r1).toBe("");
+    expect(r1).toBe("Hi ");
 
-    // Push more — some emitted
     const r2 = stream.push("there ABCDEF end");
-    // raw = "Hi there ABCDEF end" (19 chars), tail keep = 5
-    // emit raw[0..14] = "Hi there ABCDE" → redacted: "Hi there ABCDE"
-    // tail = "F end" — hmm, the secret is split across emit and tail
-    // Actually: emitRaw = raw.slice(0, 19-5) = raw.slice(0,14) = "Hi there ABCDE"
-    // tail = raw.slice(14) = "F end"
-    // So the secret "ABCDEF" is split across emit and tail — this is expected
-    // because streaming can't redact across chunk boundaries perfectly
-    expect(typeof r2).toBe("string");
-
-    // Flush remainder
     const r3 = stream.flush();
-    expect(typeof r3).toBe("string");
-
-    // Full output should not contain the secret
     const full = r1 + r2 + r3;
-    // The streaming redactor may miss split-boundary secrets — that's the trade-off
-    // But a non-split secret should be caught
     expect(full).toContain("Hi there");
+    expect(full).toContain("[REDACTED]");
+    expect(full).not.toContain(secret);
   });
 
   test("redacts secret fully contained in a single push", () => {
@@ -84,6 +69,7 @@ describe("createStreamingTextRedactor", () => {
       redact: (t) => t.replaceAll(secret, "[REDACTED]"),
       maxNeedleLength: secret.length,
       hasReplacements: true,
+      needles: [secret],
     };
     const stream = createStreamingTextRedactor(redactor);
 
@@ -101,6 +87,7 @@ describe("createStreamingTextRedactor", () => {
       redact: (t) => t,
       maxNeedleLength: 10,
       hasReplacements: true,
+      needles: ["placeholder"],
     };
     const stream = createStreamingTextRedactor(redactor);
     expect(stream.flush()).toBe("");

--- a/runtime/test/tools/tracked-bash.test.ts
+++ b/runtime/test/tools/tracked-bash.test.ts
@@ -9,7 +9,12 @@ import { expect, test } from "bun:test";
 import { getTestWorkspace, setEnv } from "../helpers.js";
 import { initDatabase } from "../../src/db.js";
 import { deleteKeychainEntry, setKeychainEntry } from "../../src/secure/keychain.js";
-import { createTrackedBashOperations, resolveShellCandidates } from "../../src/tools/tracked-bash.js";
+import {
+  createTrackedBashOperations,
+  resolveShellCandidates,
+  TRACKED_BASH_OUTPUT_LIMIT_BYTES,
+  TRACKED_BASH_OUTPUT_TRUNCATION_NOTICE,
+} from "../../src/tools/tracked-bash.js";
 import { buildSubprocessExecutionHint, shouldDetachChildProcess } from "../../src/utils/process-spawn.js";
 
 test("tracked bash executes commands and captures output", async () => {
@@ -199,4 +204,53 @@ test("tracked bash resolves keychain placeholders in commands", async () => {
     deleteKeychainEntry("bash-cmd");
     restore();
   }
+});
+
+test("tracked bash streams output before process exit", async () => {
+  const ws = getTestWorkspace();
+  const ops = createTrackedBashOperations();
+  let execSettled = false;
+  let resolveFirstChunk: ((value: string) => void) | null = null;
+  const firstChunkReady = new Promise<string>((resolve) => {
+    resolveFirstChunk = resolve;
+  });
+
+  const execPromise = ops.exec("printf first; sleep 0.2; printf second", ws.workspace, {
+    onData: (data) => {
+      const text = data.toString("utf8");
+      if (text && resolveFirstChunk) {
+        resolveFirstChunk(text);
+        resolveFirstChunk = null;
+      }
+    },
+    timeout: 5,
+  }).finally(() => {
+    execSettled = true;
+  });
+
+  const first = await Promise.race([firstChunkReady, execPromise.then(() => "__resolved__")]);
+  expect(first).toBe("first");
+  expect(execSettled).toBe(false);
+
+  const result = await execPromise;
+  expect(result.exitCode).toBe(0);
+});
+
+test("tracked bash caps streamed output and appends a truncation marker", async () => {
+  const ws = getTestWorkspace();
+  const ops = createTrackedBashOperations();
+  let output = "";
+
+  const result = await ops.exec("yes x | head -c 400000", ws.workspace, {
+    onData: (data) => {
+      output += data.toString("utf8");
+    },
+    timeout: 5,
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(output).toContain(TRACKED_BASH_OUTPUT_TRUNCATION_NOTICE.trim());
+  expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(
+    TRACKED_BASH_OUTPUT_LIMIT_BYTES + Buffer.byteLength(TRACKED_BASH_OUTPUT_TRUNCATION_NOTICE, "utf8")
+  );
 });


### PR DESCRIPTION
## Summary
- stream tracked-bash stdout/stderr incrementally instead of buffering the entire process output until exit
- cap forwarded output with a truncation marker so pathological commands cannot grow the in-memory tool buffer without bound
- harden the shared streaming redactor so secrets that begin at chunk boundaries are still redacted correctly

## Root cause
`tracked-bash` concatenated every stdout/stderr chunk into one string and only called `onData` in the process `close` handler. That meant no live tool output, unbounded in-memory growth for large commands, and lossy reconstruction of stdout/stderr event ordering.

## Impact
Tracked shell commands now stream redacted output as it arrives, remain bounded under large-output workloads, and preserve much better event ordering between stdout and stderr while still protecting keychain-backed secrets.

## Validation
- `bun test runtime/test/secure/shell-secrets.test.ts runtime/test/tools/tracked-bash.test.ts`
- `bun run typecheck`
