### PR TITLE
[codex] fix(tools): preserve abort signal and toolCallId in exec_batch

### DIFF
--- a/runtime/src/tools/context-tools.ts
+++ b/runtime/src/tools/context-tools.ts
@@ -167,14 +167,25 @@ export function createBatchExecTool(cwd: string, bashTool = createContextBashToo
       commands: Type.Array(Type.String({ description: "Shell commands to execute" })),
       timeout: Type.Optional(Type.Number({ description: "Timeout in seconds per command" })),
     }),
-    execute: async (_toolCallId: string, params: { commands: string[]; timeout?: number }) => {
+    execute: async (
+      toolCallId: string,
+      params: { commands: string[]; timeout?: number },
+      signal?: BashToolSignal,
+      onUpdate?: BashToolUpdate,
+    ) => {
       const outputs: string[] = [];
       for (const command of params.commands || []) {
+        if (signal?.aborted) {
+          throw new Error("aborted");
+        }
         try {
-          const result = await base.execute("", { command, timeout: params.timeout }, undefined, undefined);
+          const result = await base.execute(toolCallId, { command, timeout: params.timeout }, signal, onUpdate);
           const text = extractTextContent(result.content).trim() || "(no output)";
           outputs.push(`Command: ${command}\n${text}`);
         } catch (err) {
+          if (signal?.aborted || (err instanceof Error && err.message === "aborted")) {
+            throw err;
+          }
           const message = err instanceof Error ? err.message : String(err);
           outputs.push(`Command: ${command}\nError: ${message}`);
         }

--- a/runtime/test/tools/context-tools.test.ts
+++ b/runtime/test/tools/context-tools.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+
+import { createBatchExecTool } from "../../src/tools/context-tools.js";
+
+test("exec_batch forwards the original toolCallId and abort signal to each command", async () => {
+  const calls: Array<{ toolCallId: string; params: { command: string; timeout?: number }; signal?: AbortSignal }> = [];
+  const controller = new AbortController();
+  const bashTool = {
+    async execute(toolCallId: string, params: { command: string; timeout?: number }, signal?: AbortSignal) {
+      calls.push({ toolCallId, params, signal });
+      return { content: [{ type: "text", text: `ran ${params.command}` }], details: {} };
+    },
+  } as any;
+
+  const tool = createBatchExecTool(process.cwd(), bashTool);
+  const result = await tool.execute("batch-call-1", { commands: ["pwd", "ls"], timeout: 7 }, controller.signal);
+
+  expect(result.content).toEqual([
+    {
+      type: "text",
+      text: "Command: pwd\nran pwd\n\nCommand: ls\nran ls",
+    },
+  ]);
+  expect(calls).toEqual([
+    {
+      toolCallId: "batch-call-1",
+      params: { command: "pwd", timeout: 7 },
+      signal: controller.signal,
+    },
+    {
+      toolCallId: "batch-call-1",
+      params: { command: "ls", timeout: 7 },
+      signal: controller.signal,
+    },
+  ]);
+});
+
+test("exec_batch stops immediately when the parent abort signal cancels a command", async () => {
+  const controller = new AbortController();
+  let executeCalls = 0;
+  let secondCommandRan = false;
+  const bashTool = {
+    async execute(_toolCallId: string, params: { command: string }, signal?: AbortSignal) {
+      executeCalls += 1;
+      if (params.command === "sleep 10") {
+        return await new Promise((_, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        });
+      }
+      secondCommandRan = true;
+      return { content: [{ type: "text", text: "should not run" }], details: {} };
+    },
+  } as any;
+
+  const tool = createBatchExecTool(process.cwd(), bashTool);
+  const pending = tool.execute("batch-call-2", { commands: ["sleep 10", "echo done"] }, controller.signal);
+  controller.abort();
+
+  await expect(pending).rejects.toThrow("aborted");
+  expect(executeCalls).toBe(1);
+  expect(secondCommandRan).toBe(false);
+});


### PR DESCRIPTION
## Summary

- preserve the parent tool call ID and abort signal when `exec_batch` delegates to the underlying bash tool
- stop the batch immediately when a delegated command is aborted instead of swallowing the cancellation as a per-command error
- add regression tests covering signal forwarding and abort short-circuiting

## Testing

- `bun test runtime/test/tools/context-tools.test.ts`
- `bun run typecheck`
