### PR TITLE
[codex] fix(tool-output): cap chunkText buffering for long lines

### DIFF
--- a/runtime/src/tool-output.ts
+++ b/runtime/src/tool-output.ts
@@ -81,19 +81,49 @@ export function buildPreview(text: string, maxLines = 12, maxLineLength = 200): 
  * Split text into line-aware chunks for FTS indexing.
  * Avoids splitting mid-line when possible.
  */
-function chunkText(text: string, chunkSize = DEFAULT_CHUNK_SIZE): string[] {
-  const lines = text.replace(/\r\n/g, "\n").split("\n");
+export function chunkText(text: string, chunkSize = DEFAULT_CHUNK_SIZE): string[] {
+  const normalized = text.replace(/\r\n/g, "\n");
+  if (!normalized) return [];
+
+  const rawLines = normalized.split("\n");
+  const lines = rawLines.map((line, index) => {
+    const hasTrailingNewline = index < rawLines.length - 1;
+    return hasTrailingNewline ? `${line}\n` : line;
+  });
   const chunks: string[] = [];
   let buffer = "";
+
+  const flushChunk = (chunk: string) => {
+    for (let index = 0; index < chunk.length; index += chunkSize) {
+      chunks.push(chunk.slice(index, index + chunkSize));
+    }
+  };
+
   for (const line of lines) {
-    const next = buffer ? `${buffer}\n${line}` : line;
-    if (next.length > chunkSize && buffer) {
+    if (line.length > chunkSize) {
+      if (buffer) {
+        chunks.push(buffer);
+        buffer = "";
+      }
+      flushChunk(line);
+      continue;
+    }
+
+    if (!buffer) {
+      buffer = line;
+      continue;
+    }
+
+    const next = `${buffer}${line}`;
+    if (next.length > chunkSize) {
       chunks.push(buffer);
       buffer = line;
       continue;
     }
+
     buffer = next;
   }
+
   if (buffer) chunks.push(buffer);
   return chunks;
 }

--- a/runtime/test/tools/tool-output.test.ts
+++ b/runtime/test/tools/tool-output.test.ts
@@ -56,3 +56,29 @@ test("prune removes old outputs", async () => {
   expect(removed).toBeGreaterThan(0);
   expect(existsSync(saved.path)).toBe(false);
 });
+
+test("chunkText hard-splits long lines at the configured chunk size", async () => {
+  const toolOutput = await import("../../src/tool-output.js");
+  const text = `prefix-${"x".repeat(12)}-suffix`;
+
+  const chunks = toolOutput.chunkText(text, 8);
+
+  expect(chunks).toEqual([
+    "prefix-x",
+    "xxxxxxxx",
+    "xxx-suff",
+    "ix",
+  ]);
+  expect(Math.max(...chunks.map((chunk: string) => chunk.length))).toBe(8);
+  expect(chunks.join("")).toBe(text);
+});
+
+test("chunkText preserves newline separators, including a trailing newline", async () => {
+  const toolOutput = await import("../../src/tool-output.js");
+  const text = "alpha\nbeta\n";
+
+  const chunks = toolOutput.chunkText(text, 7);
+
+  expect(chunks).toEqual(["alpha\n", "beta\n"]);
+  expect(chunks.join("")).toBe(text);
+});


### PR DESCRIPTION
## Summary

- hard-split oversized tool-output lines so FTS chunks never grow past the configured chunk size
- preserve newline separators consistently while chunking, including trailing newlines
- add regression coverage for long-line splitting and newline preservation

## Testing

- `bun test runtime/test/tools/tool-output.test.ts`
- `bun run typecheck`
