### PR TITLE
[codex] fix(remote): harden pair-request admission and first-contact confirm

### DIFF
--- a/runtime/src/db/remote-interop.ts
+++ b/runtime/src/db/remote-interop.ts
@@ -21,7 +21,7 @@ export interface RemotePeerRecord {
   status: RemotePeerStatus;
   mode: RemotePeerMode;
   profile: RemotePeerProfile;
-  trust_epoch: number;
+  trust_epoch: number | null;
   created_at: string;
   updated_at: string;
   last_seen_at: string | null;

--- a/runtime/src/remote/service-pairing.ts
+++ b/runtime/src/remote/service-pairing.ts
@@ -192,7 +192,7 @@ export async function handlePairConfirm(req: Request, context: RemotePairingHand
     status: "pending",
     mode: "mediated",
     profile: "restricted",
-    trust_epoch: 1,
+    trust_epoch: null,
     created_at: pending.created_at,
     updated_at: pending.created_at,
     last_seen_at: null,

--- a/runtime/src/remote/service-pairing.ts
+++ b/runtime/src/remote/service-pairing.ts
@@ -36,6 +36,7 @@ export interface RemotePairingHandlersContext {
   pairLimiter: SlidingWindowLimiter;
   pairConfirmLimiter: SlidingWindowLimiter;
   nonceCache: RemoteNonceCache;
+  validateCallbackUrl?: typeof validateCallbackUrl;
 }
 
 /** Handle `/api/remote/pair-request` validation and pending request creation. */
@@ -69,7 +70,22 @@ export async function handlePairRequest(req: Request, context: RemotePairingHand
     return jsonResponse({ error: "instance_id does not match public_key." }, 400);
   }
 
-  const callbackCheck = await validateCallbackUrl(callbackUrl);
+  const peer = getRemotePeer(instanceId);
+  if (peer?.status === "blocked") {
+    logAudit(peer, "/api/remote/pair-request", "blocked", "blocked");
+    return jsonResponse({ error: "Peer is blocked." }, 403);
+  }
+  if (peer?.status === "paired") {
+    logAudit(peer, "/api/remote/pair-request", "paired", "paired");
+    return jsonResponse({ error: "Peer is already paired." }, 409);
+  }
+
+  const rateKey = `${getClientKey(req)}:${instanceId}`;
+  if (!context.pairLimiter.allow(rateKey)) {
+    return jsonResponse({ error: "Pairing rate limit exceeded." }, 429);
+  }
+
+  const callbackCheck = await (context.validateCallbackUrl ?? validateCallbackUrl)(callbackUrl);
   if (!callbackCheck.ok) {
     return jsonResponse({ error: callbackCheck.error }, 400);
   }
@@ -82,12 +98,6 @@ export async function handlePairRequest(req: Request, context: RemotePairingHand
   const maxExpiry = now + 24 * 60 * 60 * 1000;
   if (expiresAt <= now || expiresAt > maxExpiry) {
     return jsonResponse({ error: "expires_at is out of range." }, 400);
-  }
-
-  const peer = getRemotePeer(instanceId);
-  if (peer?.status === "blocked") {
-    logAudit(peer, "/api/remote/pair-request", "blocked", "blocked");
-    return jsonResponse({ error: "Peer is blocked." }, 403);
   }
 
   const pending = getPendingPairRequest(instanceId);
@@ -104,11 +114,6 @@ export async function handlePairRequest(req: Request, context: RemotePairingHand
       );
     }
     updatePairRequestStatus(pending.id, "expired");
-  }
-
-  const rateKey = `${getClientKey(req)}:${instanceId}`;
-  if (!context.pairLimiter.allow(rateKey)) {
-    return jsonResponse({ error: "Pairing rate limit exceeded." }, 429);
   }
 
   const requestId = createUuid("pair");

--- a/runtime/test/remote/remote-interop.test.ts
+++ b/runtime/test/remote/remote-interop.test.ts
@@ -88,12 +88,19 @@ function installCallbackStub(peer: InteropIdentity): () => void {
   };
 }
 
-function buildSignedRequest(identity: InteropIdentity, method: string, path: string, body?: unknown) {
+function buildSignedRequest(
+  identity: InteropIdentity,
+  method: string,
+  path: string,
+  body?: unknown,
+  options: { trustEpoch?: string | null } = {},
+) {
   const bodyText = body ? JSON.stringify(body) : "";
   const bodyBytes = new TextEncoder().encode(bodyText);
   const timestamp = new Date().toISOString();
   const nonce = `nonce-${Math.random().toString(36).slice(2, 8)}`;
   const contentType = body ? "application/json" : "";
+  const trustEpoch = options.trustEpoch === undefined ? "1" : options.trustEpoch;
   const canonical = buildCanonicalRequest({
     method,
     pathWithQuery: path,
@@ -103,7 +110,7 @@ function buildSignedRequest(identity: InteropIdentity, method: string, path: str
     nonce,
     instanceId: identity.instance_id,
     sigVersion: "v1",
-    trustEpoch: "1",
+    ...(trustEpoch !== null ? { trustEpoch } : {}),
   });
   const signature = signRequest(identity, canonical);
 
@@ -113,8 +120,8 @@ function buildSignedRequest(identity: InteropIdentity, method: string, path: str
     "X-Nonce": nonce,
     "X-Sig-Version": "v1",
     "X-Signature": signature,
-    "X-Trust-Epoch": "1",
   };
+  if (trustEpoch !== null) headers["X-Trust-Epoch"] = trustEpoch;
   if (body) headers["Content-Type"] = "application/json";
 
   return new Request(`http://localhost${path}`, {
@@ -490,10 +497,16 @@ describe("remote interop", () => {
     expect(pairBody.request_id).toBeTruthy();
 
     const restoreFetch = installCallbackStub(peer);
-    const confirmReq = buildSignedRequest(peer, "POST", "/api/remote/pair-confirm", {
-      request_id: pairBody.request_id,
-      challenge: "challenge",
-    });
+    const confirmReq = buildSignedRequest(
+      peer,
+      "POST",
+      "/api/remote/pair-confirm",
+      {
+        request_id: pairBody.request_id,
+        challenge: "challenge",
+      },
+      { trustEpoch: null },
+    );
 
     const confirmRes = await service.handleRequest(confirmReq);
     restoreFetch();

--- a/runtime/test/remote/remote-interop.test.ts
+++ b/runtime/test/remote/remote-interop.test.ts
@@ -28,8 +28,10 @@ let signRequest: (identity: InteropIdentity, canonical: string) => string;
 let getRemotePeer: (id: string) => any;
 let getRemoteRequestById: (id: string) => any;
 let updatePairRequestStatus: (id: string, status: string) => void;
+let upsertRemotePeer: (peer: any) => void;
 let initDatabase: () => void;
 let RemoteInteropService: any;
+let handlePairRequest: (req: Request, context: any) => Promise<Response>;
 
 let originalFetch: typeof fetch | null = null;
 const TEST_REMOTE_BASE_URL = "https://93.184.216.34";
@@ -151,9 +153,13 @@ describe("remote interop", () => {
     getRemotePeer = remoteDbMod.getRemotePeer;
     getRemoteRequestById = remoteDbMod.getRemoteRequestById;
     updatePairRequestStatus = remoteDbMod.updatePairRequestStatus;
+    upsertRemotePeer = remoteDbMod.upsertRemotePeer;
 
     const serviceMod = await importFresh("../src/remote/service.js");
     RemoteInteropService = serviceMod.RemoteInteropService;
+
+    const pairingMod = await importFresh("../src/remote/service-pairing.js");
+    handlePairRequest = pairingMod.handlePairRequest;
 
     resetInteropIdentityForTests();
     initDatabase();
@@ -306,6 +312,87 @@ describe("remote interop", () => {
     }
 
     expect(lastStatus).toBe(429);
+  });
+
+  test("pair request checks rate limit before callback validation", async () => {
+    const peer = makeIdentity();
+    let validateCalls = 0;
+
+    const res = await handlePairRequest(
+      new Request("http://localhost/api/remote/pair-request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          instance_id: peer.instance_id,
+          public_key: peer.public_key,
+          display_name: "peer",
+          callback_url: `${TEST_REMOTE_BASE_URL}/api/remote/pair-confirm`,
+          protocol_version: "1",
+          nonce: "abc",
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+      }),
+      {
+        pairLimiter: { allow: () => false },
+        pairConfirmLimiter: { allow: () => true },
+        nonceCache: {},
+        validateCallbackUrl: async () => {
+          validateCalls += 1;
+          return { ok: true, url: new URL(`${TEST_REMOTE_BASE_URL}/api/remote/pair-confirm`) };
+        },
+      }
+    );
+
+    expect(res.status).toBe(429);
+    expect(validateCalls).toBe(0);
+  });
+
+  test("pair request rejects already paired peers before callback validation", async () => {
+    const peer = makeIdentity();
+    let validateCalls = 0;
+    const now = new Date().toISOString();
+    upsertRemotePeer({
+      instance_id: peer.instance_id,
+      public_key: peer.public_key,
+      display_name: "peer",
+      status: "paired",
+      mode: "mediated",
+      profile: "restricted",
+      trust_epoch: 1,
+      created_at: now,
+      updated_at: now,
+      last_seen_at: now,
+      blocked_reason: null,
+    });
+
+    const res = await handlePairRequest(
+      new Request("http://localhost/api/remote/pair-request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          instance_id: peer.instance_id,
+          public_key: peer.public_key,
+          display_name: "peer",
+          callback_url: `${TEST_REMOTE_BASE_URL}/api/remote/pair-confirm`,
+          protocol_version: "1",
+          nonce: "abc",
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+        }),
+      }),
+      {
+        pairLimiter: { allow: () => true },
+        pairConfirmLimiter: { allow: () => true },
+        nonceCache: {},
+        validateCallbackUrl: async () => {
+          validateCalls += 1;
+          return { ok: true, url: new URL(`${TEST_REMOTE_BASE_URL}/api/remote/pair-confirm`) };
+        },
+      }
+    );
+
+    expect(res.status).toBe(409);
+    expect(validateCalls).toBe(0);
+    expect(await res.json()).toEqual({ error: "Peer is already paired." });
   });
 
   test("pair confirm rate limit", async () => {


### PR DESCRIPTION
## Summary
- reject already-paired peers at pair-request time instead of letting them re-enter the pending flow
- apply the pair-request rate limiter before callback URL validation so rate-limited requests never trigger DNS resolution work
- allow first-contact pair confirmations to verify without a synthetic `x-trust-epoch` requirement, while keeping epoch enforcement for already-paired peers
- add remote interop regressions covering the rate-limit ordering, paired-peer short-circuit, and header-less first-contact confirm flow

## Root cause
The pair-request handler did callback validation before rate limiting and allowed already-paired peers back into the pending handshake path. Separately, pair-confirm created a synthetic pending peer with `trust_epoch = 1`, which made signature verification require an epoch header even though no trust relationship existed yet.

## Impact
Pair-request now rejects obvious invalid states before expensive callback checks, and first-contact pair-confirm requests can follow the intended handshake without inventing a trust epoch prior to pairing.

## Validation
- `bun test runtime/test/remote/remote-interop.test.ts`
- `bun run typecheck`
