### PR TITLE
[codex] fix(utils): avoid surrogate-pair truncation splits

### DIFF
--- a/runtime/src/utils/azure-tool-call-limit.ts
+++ b/runtime/src/utils/azure-tool-call-limit.ts
@@ -9,6 +9,8 @@
  * staying under the cap.
  */
 
+import { truncateWithEllipsis } from "./preview.js";
+
 type ToolCallEntry = {
   callId: string;
   itemId?: string;
@@ -64,7 +66,7 @@ function formatToolCallSnippet(text: string, maxChars: number): string {
   const collapsed = text.replace(/\s+/g, " ").trim();
   if (!collapsed) return "(no output)";
   if (collapsed.length <= maxChars) return collapsed;
-  return `${collapsed.slice(0, Math.max(1, maxChars - 1))}…`;
+  return truncateWithEllipsis(collapsed, Math.max(1, maxChars - 1));
 }
 
 function parseToolOutputSearchArgs(args?: string): { handle?: string; query?: string } | null {

--- a/runtime/src/utils/preview.ts
+++ b/runtime/src/utils/preview.ts
@@ -36,11 +36,27 @@ export function splitLines(text: string): string[] {
   return normalized.split("\n");
 }
 
+function endsWithHighSurrogate(text: string): boolean {
+  if (!text) return false;
+  const code = text.charCodeAt(text.length - 1);
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+/** Truncate text and append an ellipsis without leaving a dangling surrogate. */
+export function truncateWithEllipsis(text: string, maxLength?: number): string {
+  if (!maxLength || maxLength <= 0) return text;
+  if (text.length <= maxLength) return text;
+
+  let truncated = text.slice(0, maxLength);
+  if (endsWithHighSurrogate(truncated)) {
+    truncated = truncated.slice(0, -1);
+  }
+  return `${truncated}…`;
+}
+
 /** Truncate a single line to `maxLength` characters, adding an ellipsis if cut. */
 export function truncateLine(line: string, maxLength?: number): string {
-  if (!maxLength || maxLength <= 0) return line;
-  if (line.length <= maxLength) return line;
-  return `${line.slice(0, maxLength)}…`;
+  return truncateWithEllipsis(line, maxLength);
 }
 
 /**

--- a/runtime/test/extensions/azure-openai-tool-call-limit.test.ts
+++ b/runtime/test/extensions/azure-openai-tool-call-limit.test.ts
@@ -138,6 +138,24 @@ test("applyToolCallLimit truncates summary output", () => {
   expect(summaryText).toContain("…");
 });
 
+test("applyToolCallLimit keeps truncated summary output surrogate-safe", () => {
+  const messages = [
+    makeReasoning("rs_old"),
+    makeCall("call1", "fc_old", "bash", { command: "echo" }),
+    makeOutput("call1", "😀😀😀"),
+    makeReasoning("rs_keep"),
+    makeCall("call2", "fc_keep", "bash", { command: "ls" }),
+    makeOutput("call2", "short"),
+  ];
+
+  const result = applyToolCallLimit(messages, { ...config, limit: 1, summaryMax: 1, outputChars: 1 });
+  const summary = result.messages.find((item) => item?.type === "message" && item?.role === "assistant");
+  const summaryText = summary?.content?.[0]?.text || "";
+
+  expect(summaryText).toContain("…");
+  expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(summaryText)).toBe(false);
+});
+
 test("applyToolCallLimit proactively trims by estimated token budget", () => {
   const largeOutput = "x".repeat(4000);
   const messages = [

--- a/runtime/test/utils/preview-utils.test.ts
+++ b/runtime/test/utils/preview-utils.test.ts
@@ -11,6 +11,7 @@ import "../helpers.js";
 import {
   splitLines,
   buildPreviewLines,
+  truncateWithEllipsis,
   truncateLine,
   countSoftLines,
   countSoftLine,
@@ -28,6 +29,12 @@ describe("preview utils", () => {
     expect(truncateLine("short", 10)).toBe("short");
     expect(truncateLine("longer", 3)).toBe("lon…");
     expect(truncateLine("same", 0)).toBe("same");
+  });
+
+  test("truncateWithEllipsis avoids dangling surrogate pairs", () => {
+    expect(truncateWithEllipsis("😀emoji", 1)).toBe("…");
+    expect(truncateWithEllipsis("😀emoji", 2)).toBe("😀…");
+    expect(truncateLine("😀emoji", 1)).toBe("…");
   });
 
   test("buildPreviewLines returns preview and omitted count", () => {


### PR DESCRIPTION
## Summary

- add a shared surrogate-safe truncation helper for preview text that never leaves a dangling high surrogate before the ellipsis
- reuse that helper in Azure tool-call summary snippets so emoji and other astral code points stay well-formed when output is trimmed
- add regression coverage for both preview truncation and Azure tool-call summaries

## Testing

- `bun test runtime/test/utils/preview-utils.test.ts runtime/test/extensions/azure-openai-tool-call-limit.test.ts`
- `bun run typecheck`
