### PR TITLE
[codex] fix(web): harden markdown sanitization and honor trusted previews

### DIFF
--- a/runtime/test/channels/web/post-link-preview-content.test.ts
+++ b/runtime/test/channels/web/post-link-preview-content.test.ts
@@ -8,7 +8,7 @@
 
 import { expect, test } from "bun:test";
 import "../../helpers.js";
-import { getDisplayContent } from "../../../web/src/components/post.ts";
+import { buildLinkPreviewBackgroundStyle, getDisplayContent } from "../../../web/src/components/post.ts";
 
 test("getDisplayContent keeps URL text when previews are present", () => {
   const content = "Check this out: https://example.com/article";
@@ -32,4 +32,20 @@ test("getDisplayContent preserves exact formatting (no trim/removal)", () => {
 test("getDisplayContent returns empty string for non-string content", () => {
   expect(getDisplayContent(null as any, [])).toBe("");
   expect(getDisplayContent(undefined as any, [])).toBe("");
+});
+
+test("buildLinkPreviewBackgroundStyle keeps image URLs confined to backgroundImage", () => {
+  const style = buildLinkPreviewBackgroundStyle("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>');color:red;/*");
+
+  expect(style).toEqual({
+    backgroundImage: `url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>');color:red;/*")`,
+  });
+
+  if (typeof document !== "undefined") {
+    const node = document.createElement("a");
+    for (const [name, value] of Object.entries(style || {})) {
+      (node.style as any)[name] = value;
+    }
+    expect(node.style.color).toBe("");
+  }
 });

--- a/runtime/test/web/markdown-rendering.test.ts
+++ b/runtime/test/web/markdown-rendering.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, expect, test } from 'bun:test';
 
 const PreviousDOMParser = globalThis.DOMParser;
-
 function decodeEntities(value: string) {
   return String(value || '')
     .replace(/&lt;/g, '<')
@@ -114,4 +113,15 @@ test('applySyntaxHighlighting falls back to escaped plaintext for unsupported la
   expect(highlighted).toContain('&lt;tag&gt;');
   expect(highlighted).not.toContain('tok-keyword');
   expect(highlighted).not.toContain('<span class="tok-');
+});
+
+test('isSanitizedHtmlAttributeAllowed rejects inline style while preserving safe attrs', async () => {
+  const { isSanitizedHtmlAttributeAllowed } = await import('../../web/src/markdown.ts');
+
+  expect(isSanitizedHtmlAttributeAllowed('span', 'style')).toBe(false);
+  expect(isSanitizedHtmlAttributeAllowed('span', 'title')).toBe(true);
+  expect(isSanitizedHtmlAttributeAllowed('a', 'href')).toBe(true);
+  expect(isSanitizedHtmlAttributeAllowed('img', 'src')).toBe(true);
+  expect(isSanitizedHtmlAttributeAllowed('span', 'aria-label')).toBe(true);
+  expect(isSanitizedHtmlAttributeAllowed('span', 'onclick')).toBe(false);
 });

--- a/runtime/test/web/markdown-rendering.test.ts
+++ b/runtime/test/web/markdown-rendering.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, expect, test } from 'bun:test';
 
 const PreviousDOMParser = globalThis.DOMParser;
+const PreviousNodeFilter = globalThis.NodeFilter;
+const PreviousWindow = globalThis.window;
+const PreviousMarked = globalThis.marked;
 function decodeEntities(value: string) {
   return String(value || '')
     .replace(/&lt;/g, '<')
@@ -16,7 +19,92 @@ afterEach(() => {
   } else {
     globalThis.DOMParser = PreviousDOMParser;
   }
+  if (PreviousNodeFilter === undefined) {
+    delete globalThis.NodeFilter;
+  } else {
+    globalThis.NodeFilter = PreviousNodeFilter;
+  }
+  if (PreviousWindow === undefined) {
+    delete globalThis.window;
+  } else {
+    globalThis.window = PreviousWindow;
+  }
+  if (PreviousMarked === undefined) {
+    delete globalThis.marked;
+  } else {
+    globalThis.marked = PreviousMarked;
+  }
 });
+
+function installSimpleHtmlDomParser() {
+  globalThis.NodeFilter = { SHOW_ELEMENT: 1, SHOW_TEXT: 4 } as any;
+  globalThis.DOMParser = class {
+    parseFromString(input: string) {
+      const html = String(input || '');
+      const match = html.match(/^<([a-z0-9]+)([^>]*)>([\s\S]*)<\/\1>$/i);
+      const textContent = decodeEntities(html.replace(/<[^>]+>/g, ''));
+      const body: any = {};
+
+      if (!match) {
+        body.innerHTML = html;
+        return {
+          body,
+          documentElement: { textContent },
+          createTreeWalker: (_root: unknown, whatToShow: number) => ({
+            nextNode: () => null,
+          }),
+        } as any;
+      }
+
+      const [, rawTag = '', rawAttrs = '', rawText = ''] = match;
+      const attrs = Array.from(rawAttrs.matchAll(/([a-zA-Z_:][\w:.-]*)="([^"]*)"/g)).map((entry) => ({
+        name: entry[1] || '',
+        value: entry[2] || '',
+      }));
+      const el: any = {
+        tagName: rawTag.toUpperCase(),
+        attributes: attrs,
+        getAttribute(name: string) {
+          const attr = this.attributes.find((entry: any) => entry.name === name);
+          return attr ? attr.value : null;
+        },
+        setAttribute(name: string, value: string) {
+          const attr = this.attributes.find((entry: any) => entry.name === name);
+          if (attr) {
+            attr.value = value;
+          } else {
+            this.attributes.push({ name, value });
+          }
+        },
+        removeAttribute(name: string) {
+          this.attributes = this.attributes.filter((entry: any) => entry.name !== name);
+        },
+      };
+
+      Object.defineProperty(body, 'innerHTML', {
+        get() {
+          const attrText = el.attributes.map((entry: any) => ` ${entry.name}="${entry.value}"`).join('');
+          return `<${rawTag.toLowerCase()}${attrText}>${rawText}</${rawTag.toLowerCase()}>`;
+        },
+      });
+
+      return {
+        body,
+        documentElement: { textContent },
+        createTreeWalker: (_root: unknown, whatToShow: number) => {
+          let used = false;
+          return {
+            nextNode: () => {
+              if (used) return null;
+              used = true;
+              return whatToShow === globalThis.NodeFilter.SHOW_ELEMENT ? el : null;
+            },
+          };
+        },
+      } as any;
+    }
+  } as any;
+}
 
 test('prepareMarkdownSource preserves blockquote markers while escaping raw tags', async () => {
   globalThis.DOMParser = class {
@@ -124,4 +212,19 @@ test('isSanitizedHtmlAttributeAllowed rejects inline style while preserving safe
   expect(isSanitizedHtmlAttributeAllowed('img', 'src')).toBe(true);
   expect(isSanitizedHtmlAttributeAllowed('span', 'aria-label')).toBe(true);
   expect(isSanitizedHtmlAttributeAllowed('span', 'onclick')).toBe(false);
+});
+
+test('renderMarkdown honors sanitize: false for trusted surfaces', async () => {
+  installSimpleHtmlDomParser();
+  globalThis.window = {
+    marked: {
+      parse: () => '<a href="javascript:alert(1)">trusted</a>',
+    },
+  } as any;
+  globalThis.marked = globalThis.window.marked;
+
+  const { renderMarkdown } = await import('../../web/src/markdown.ts');
+
+  expect(renderMarkdown('trusted', null)).toBe('<a>trusted</a>');
+  expect(renderMarkdown('trusted', null, { sanitize: false })).toBe('<a href="javascript:alert(1)">trusted</a>');
 });

--- a/runtime/web/src/components/post.ts
+++ b/runtime/web/src/components/post.ts
@@ -293,18 +293,22 @@ function getMimeIcon(mimeType) {
 /**
  * Link preview component - card with image background
  */
+export function buildLinkPreviewBackgroundStyle(imageUrl) {
+    const safeImage = sanitizeUrl(imageUrl, { allowDataImage: true });
+    return safeImage
+        ? { backgroundImage: `url("${safeImage}")` }
+        : undefined;
+}
+
 function LinkPreview({ preview }) {
     const safeUrl = sanitizeUrl(preview.url);
-    const safeImage = sanitizeUrl(preview.image, { allowDataImage: true });
-    const bgStyle = safeImage
-        ? `background-image: url('${safeImage}')`
-        : '';
+    const bgStyle = buildLinkPreviewBackgroundStyle(preview.image);
     const siteName = resolveLinkPreviewSiteName(preview.site_name, safeUrl);
 
     return html`
         <a
             href=${safeUrl || '#'}
-            class="link-preview ${safeImage ? 'has-image' : ''}"
+            class="link-preview ${bgStyle ? 'has-image' : ''}"
             target=${safeUrl ? "_blank" : undefined}
             rel=${safeUrl ? "noopener noreferrer" : undefined}
             onClick=${(e) => e.stopPropagation()}

--- a/runtime/web/src/markdown.ts
+++ b/runtime/web/src/markdown.ts
@@ -99,7 +99,6 @@ const SAFE_TAGS = new Set([
 
 const GLOBAL_ALLOWED_ATTRS = new Set([
     'class',
-    'style',
     'title',
     'role',
     'aria-hidden',
@@ -117,6 +116,17 @@ const TAG_ALLOWED_ATTRS = {
 };
 
 const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', '']);
+
+export function isSanitizedHtmlAttributeAllowed(tagName, attrName) {
+    const normalizedTag = String(tagName || '').toLowerCase();
+    const normalizedAttr = String(attrName || '').toLowerCase();
+    if (!normalizedAttr || normalizedAttr.startsWith('on')) return false;
+    if (normalizedAttr.startsWith('data-') || normalizedAttr.startsWith('aria-')) {
+        return true;
+    }
+    const allowedAttrs = TAG_ALLOWED_ATTRS[normalizedTag] || new Set();
+    return allowedAttrs.has(normalizedAttr) || GLOBAL_ALLOWED_ATTRS.has(normalizedAttr);
+}
 
 function escapeHtmlAttr(value) {
     return String(value || '')
@@ -182,10 +192,7 @@ function sanitizeHtml(html, options = {}) {
                 el.removeAttribute(attr.name);
                 continue;
             }
-            if (name.startsWith('data-') || name.startsWith('aria-')) {
-                continue;
-            }
-            if (allowedAttrs.has(name) || GLOBAL_ALLOWED_ATTRS.has(name)) {
+            if (isSanitizedHtmlAttributeAllowed(tag, name)) {
                 if (name === 'href') {
                     const safe = sanitizeUrl(value);
                     if (!safe) {

--- a/runtime/web/src/markdown.ts
+++ b/runtime/web/src/markdown.ts
@@ -164,6 +164,7 @@ export function sanitizeUrl(url, options = {}) {
 
 function sanitizeHtml(html, options = {}) {
     if (!html) return '';
+    if (options?.sanitize === false) return html;
     const doc = new DOMParser().parseFromString(html, 'text/html');
     const nodes = [];
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);


### PR DESCRIPTION
## Summary
- stop allowing inline `style` attributes through the markdown HTML sanitizer
- route link preview background images through a CSSOM style object instead of concatenating a raw style string
- honor `renderMarkdown(..., { sanitize: false })` for trusted surfaces like the live markdown preview and BTW answer panel
- add regressions for the sanitizer allowlist, link preview background handling, and trusted-surface sanitize bypass

## Root cause
The markdown sanitizer branch already narrowed attribute handling, but `renderMarkdown` still always funneled output through `sanitizeHtml()` because that helper ignored the `sanitize` option entirely. That meant trusted callers were passing `{ sanitize: false }` with no effect.

## Impact
Untrusted markdown still goes through the sanitizer by default, while explicitly trusted surfaces can now opt out as intended without changing every call site.

## Testing
- `bun test runtime/test/web/markdown-rendering.test.ts runtime/test/channels/web/post-link-preview-content.test.ts`
- `bun run typecheck`
