### PR TITLE
[codex] fix(web): guard remote display websocket sends by readyState

### DIFF
--- a/runtime/test/web/remote-display-socket.test.ts
+++ b/runtime/test/web/remote-display-socket.test.ts
@@ -49,3 +49,74 @@ test("WebSocketRemoteDisplayBoundary tolerates close races during reconnect and 
   expect(sockets).toHaveLength(2);
   expect(() => boundary.dispose()).not.toThrow();
 });
+
+test("WebSocketRemoteDisplayBoundary queues outbound payloads until the socket opens", () => {
+  const sockets: FakeWebSocket[] = [];
+  const metricSnapshots: Array<{ bytesIn: number; bytesOut: number }> = [];
+
+  class FakeWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+
+    url: string;
+    binaryType: BinaryType = "blob";
+    readyState = FakeWebSocket.CONNECTING;
+    listeners = new Map<string, Array<(...args: any[]) => void>>();
+    sent: Array<string | ArrayBuffer | ArrayBufferView | Blob> = [];
+
+    constructor(url: string) {
+      this.url = url;
+      sockets.push(this);
+    }
+
+    addEventListener(type: string, listener: (...args: any[]) => void) {
+      const current = this.listeners.get(type) || [];
+      current.push(listener);
+      this.listeners.set(type, current);
+    }
+
+    close() {
+      this.readyState = FakeWebSocket.CLOSED;
+    }
+
+    send(payload: string | ArrayBuffer | ArrayBufferView | Blob) {
+      this.sent.push(payload);
+    }
+
+    emit(type: string, event: any = {}) {
+      for (const listener of this.listeners.get(type) || []) {
+        listener(event);
+      }
+    }
+  }
+
+  (globalThis as any).WebSocket = FakeWebSocket;
+
+  const boundary = new WebSocketRemoteDisplayBoundary({
+    url: "wss://example.test/remote-display",
+    onMetrics: (metrics) => {
+      metricSnapshots.push(metrics);
+    },
+  });
+
+  boundary.connect();
+  expect(sockets).toHaveLength(1);
+
+  boundary.send("queued-before-open");
+  boundary.sendControl({ kind: "queued-control" });
+
+  expect(sockets[0].sent).toEqual([]);
+  expect(boundary.getMetrics()).toEqual({ bytesIn: 0, bytesOut: 0 });
+
+  sockets[0].readyState = FakeWebSocket.OPEN;
+  sockets[0].emit("open");
+
+  expect(sockets[0].sent).toEqual([
+    "queued-before-open",
+    JSON.stringify({ kind: "queued-control" }),
+  ]);
+  expect(boundary.getMetrics().bytesOut).toBeGreaterThan(0);
+  expect(metricSnapshots.at(-1)?.bytesOut).toBe(boundary.getMetrics().bytesOut);
+});

--- a/runtime/web/src/panes/remote-display-socket.ts
+++ b/runtime/web/src/panes/remote-display-socket.ts
@@ -80,6 +80,7 @@ export class WebSocketRemoteDisplayBoundary {
     private readonly options: RemoteDisplaySocketBoundaryOptions;
     private bytesIn = 0;
     private bytesOut = 0;
+    private pendingOutbound: Array<string | ArrayBuffer | ArrayBufferView | Blob> = [];
 
     constructor(options: RemoteDisplaySocketBoundaryOptions) {
         this.options = options;
@@ -92,6 +93,7 @@ export class WebSocketRemoteDisplayBoundary {
         socket.binaryType = this.options.binaryType || 'arraybuffer';
         socket.addEventListener('open', () => {
             if (this.disposed || this.socket !== socket) return;
+            this.flushPendingOutbound(socket);
             this.options.onOpen?.();
         });
         socket.addEventListener('message', (event) => {
@@ -129,11 +131,13 @@ export class WebSocketRemoteDisplayBoundary {
     }
 
     send(data: string | ArrayBuffer | ArrayBufferView | Blob): void {
-        if (this.disposed || !this.socket) return;
-        const size = measureOutboundSize(data);
-        this.bytesOut += size;
-        this.emitMetrics();
-        this.socket.send(data);
+        if (this.disposed) return;
+        const socket = this.socket;
+        if (!socket || socket.readyState !== WebSocket.OPEN) {
+            this.pendingOutbound.push(data);
+            return;
+        }
+        this.sendNow(socket, data);
     }
 
     sendControl(payload: unknown): void {
@@ -156,5 +160,24 @@ export class WebSocketRemoteDisplayBoundary {
 
     private emitMetrics(): void {
         this.options.onMetrics?.(this.getMetrics());
+    }
+
+    private sendNow(socket: WebSocket, data: string | ArrayBuffer | ArrayBufferView | Blob): void {
+        const size = measureOutboundSize(data);
+        this.bytesOut += size;
+        this.emitMetrics();
+        socket.send(data);
+    }
+
+    private flushPendingOutbound(socket: WebSocket): void {
+        if (this.pendingOutbound.length === 0) return;
+        const pending = this.pendingOutbound.splice(0);
+        for (let index = 0; index < pending.length; index += 1) {
+            if (this.disposed || this.socket !== socket || socket.readyState !== WebSocket.OPEN) {
+                this.pendingOutbound.unshift(...pending.slice(index));
+                return;
+            }
+            this.sendNow(socket, pending[index]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- stop sending remote-display websocket payloads before the socket is open
- queue outbound control and binary messages until the active socket reaches `OPEN`
- add a regression test covering queued sends and metric updates

## Testing
- bun test runtime/test/web/remote-display-socket.test.ts
- bun run typecheck