### PR TITLE
[codex] fix(web): bound refresh-state growth

### DIFF
--- a/runtime/test/web/app-refresh-coordination.test.ts
+++ b/runtime/test/web/app-refresh-coordination.test.ts
@@ -4,6 +4,7 @@ import { getAppPerfTracing, startAppPerfTrace } from '../../web/src/ui/app-perf-
 import {
   isAppChatActivationRecent,
   noteAppChatActivation,
+  pruneAppRefreshCoordination,
   resetAppRefreshCoordination,
   runCoalescedAppRefresh,
 } from '../../web/src/ui/app-refresh-coordination.js';
@@ -127,4 +128,41 @@ test('runCoalescedAppRefresh suppresses immediate duplicate refreshes after chat
   expect(first).toEqual({ run: 1 });
   expect(second).toEqual({ run: 1 });
   expect(callCount).toBe(1);
+});
+
+test('pruneAppRefreshCoordination drops stale cached refresh results for long-lived sessions', async () => {
+  let callCount = 0;
+
+  noteAppChatActivation({ chatJid: 'web:branch', nowMs: 100 });
+
+  const first = await runCoalescedAppRefresh({
+    kind: 'model-state',
+    chatJid: 'web:branch',
+    cooldownMs: Number.MAX_SAFE_INTEGER,
+    activationWindowMs: 1_500,
+    run: async () => {
+      callCount += 1;
+      return { run: callCount };
+    },
+    nowMs: 110,
+  });
+
+  pruneAppRefreshCoordination(Number.MAX_SAFE_INTEGER);
+  noteAppChatActivation({ chatJid: 'web:branch', nowMs: 120 });
+
+  const second = await runCoalescedAppRefresh({
+    kind: 'model-state',
+    chatJid: 'web:branch',
+    cooldownMs: Number.MAX_SAFE_INTEGER,
+    activationWindowMs: 1_500,
+    run: async () => {
+      callCount += 1;
+      return { run: callCount };
+    },
+    nowMs: 130,
+  });
+
+  expect(first).toEqual({ run: 1 });
+  expect(second).toEqual({ run: 2 });
+  expect(callCount).toBe(2);
 });

--- a/runtime/web/src/ui/app-refresh-coordination.ts
+++ b/runtime/web/src/ui/app-refresh-coordination.ts
@@ -45,11 +45,25 @@ function pruneOldChatActivations(nowMs: number): void {
   }
 }
 
+function pruneStaleRefreshStates(nowMs: number): void {
+  for (const [key, state] of refreshStates.entries()) {
+    if (state.inFlight) continue;
+    if (!Number.isFinite(state.lastCompletedAt) || nowMs - state.lastCompletedAt > ACTIVATION_RETENTION_MS) {
+      refreshStates.delete(key);
+    }
+  }
+}
+
+export function pruneAppRefreshCoordination(nowMs = now()): void {
+  pruneOldChatActivations(nowMs);
+  pruneStaleRefreshStates(nowMs);
+}
+
 export function noteAppChatActivation(options: NoteAppChatActivationOptions): void {
   const { chatJid, nowMs = now() } = options;
   if (!chatJid) return;
   recentChatActivationAt.set(chatJid, nowMs);
-  pruneOldChatActivations(nowMs);
+  pruneAppRefreshCoordination(nowMs);
 }
 
 export function isAppChatActivationRecent(chatJid: string, withinMs = DEFAULT_ACTIVATION_WINDOW_MS, nowMs = now()): boolean {
@@ -68,6 +82,8 @@ export async function runCoalescedAppRefresh<T>(options: RunCoalescedAppRefreshO
     activationWindowMs = DEFAULT_ACTIVATION_WINDOW_MS,
     nowMs = now(),
   } = options;
+
+  pruneAppRefreshCoordination(nowMs);
 
   const key = buildRefreshKey(kind, chatJid);
   const state = refreshStates.get(key) || {


### PR DESCRIPTION
## Summary
- prune stale app refresh coordination entries alongside old chat activations
- remove cached refresh results that outlive the activation retention window
- add a regression covering stale refresh-state eviction in long-lived sessions

## Testing
- bun test runtime/test/web/app-refresh-coordination.test.ts
- bun run typecheck