### PR TITLE
[codex] fix(cdp): reject invalid protocol and transport responses

### DIFF
--- a/runtime/extensions/browser/cdp-browser/cdp.ts
+++ b/runtime/extensions/browser/cdp-browser/cdp.ts
@@ -254,6 +254,16 @@ export async function withConnectedTab<T>(
 }
 
 export function cdpSend(ws: WebSocket, method: string, params?: any, signal?: MaybeAbortSignal): Promise<any> {
+  return cdpSendWithTimeout(ws, method, params, signal, 15_000);
+}
+
+export function cdpSendWithTimeout(
+  ws: WebSocket,
+  method: string,
+  params?: any,
+  signal?: MaybeAbortSignal,
+  timeoutMs = 15_000,
+): Promise<any> {
   throwIfAborted(signal);
   const id = Math.floor(Math.random() * 100_000);
   ws.send(JSON.stringify({ id, method, params }));
@@ -265,8 +275,8 @@ export function cdpSend(ws: WebSocket, method: string, params?: any, signal?: Ma
     };
     const timer = setTimeout(() => {
       cleanup();
-      resolve(null);
-    }, 15_000);
+      reject(new Error(`CDP command timed out: ${method}`));
+    }, timeoutMs);
     const unbind = bindAbortSignal(signal, () => {
       cleanup();
       reject(createAbortError());
@@ -276,7 +286,14 @@ export function cdpSend(ws: WebSocket, method: string, params?: any, signal?: Ma
         const msg = JSON.parse(typeof event.data === "string" ? event.data : String(event.data));
         if (msg.id === id) {
           cleanup();
-          resolve(msg.result ?? msg.error ?? null);
+          if (msg.error) {
+            const message = String(msg.error?.message || msg.error?.code || "CDP command failed");
+            const error = new Error(`CDP command failed for ${method}: ${message}`);
+            (error as any).cdpError = msg.error;
+            reject(error);
+            return;
+          }
+          resolve(msg.result ?? null);
         }
       } catch {
         return;

--- a/runtime/extensions/browser/cdp-browser/cdp.ts
+++ b/runtime/extensions/browser/cdp-browser/cdp.ts
@@ -133,7 +133,7 @@ export async function httpGet(url: string, timeout = 3000, signal?: MaybeAbortSi
     try {
       return JSON.parse(text);
     } catch {
-      return text;
+      return null;
     }
   } finally {
     request.cleanup();
@@ -149,7 +149,7 @@ export async function httpPut(url: string, timeout = 5000, signal?: MaybeAbortSi
     try {
       return JSON.parse(text);
     } catch {
-      return text;
+      return null;
     }
   } finally {
     request.cleanup();
@@ -160,8 +160,10 @@ export async function findCdpPort(signal?: MaybeAbortSignal): Promise<number | n
   for (const port of CDP_PORTS) {
     throwIfAborted(signal);
     try {
-      await httpGet(`http://localhost:${port}/json/version`, 2000, signal);
-      return port;
+      const version = await httpGet(`http://localhost:${port}/json/version`, 2000, signal);
+      if (version && typeof version === "object" && !Array.isArray(version)) {
+        return port;
+      }
     } catch (error) {
       if ((error as Error)?.name === "AbortError") throw error;
     }
@@ -200,7 +202,8 @@ export async function ensureBrowser(signal?: MaybeAbortSignal): Promise<number |
 }
 
 export async function getTargets(port: number, signal?: MaybeAbortSignal): Promise<any[]> {
-  const targets: any[] = await httpGet(`http://localhost:${port}/json`, 3000, signal);
+  const targets = await httpGet(`http://localhost:${port}/json`, 3000, signal);
+  if (!Array.isArray(targets)) return [];
   return targets.filter((target) => target.type === "page");
 }
 

--- a/runtime/test/extensions/cdp-browser-transport.test.ts
+++ b/runtime/test/extensions/cdp-browser-transport.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+
+import { cdpSendWithTimeout } from "../../extensions/browser/cdp-browser/cdp.ts";
+
+class FakeWebSocket {
+  sent: string[] = [];
+  listeners = new Map<string, Array<(...args: any[]) => void>>();
+
+  addEventListener(type: string, listener: (...args: any[]) => void) {
+    const current = this.listeners.get(type) || [];
+    current.push(listener);
+    this.listeners.set(type, current);
+  }
+
+  removeEventListener(type: string, listener: (...args: any[]) => void) {
+    const current = this.listeners.get(type) || [];
+    this.listeners.set(type, current.filter((candidate) => candidate !== listener));
+  }
+
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+
+  emit(type: string, event: any) {
+    for (const listener of this.listeners.get(type) || []) {
+      listener(event);
+    }
+  }
+}
+
+test("cdpSendWithTimeout rejects timed out commands instead of resolving null", async () => {
+  const ws = new FakeWebSocket() as unknown as WebSocket;
+
+  await expect(cdpSendWithTimeout(ws, "Page.enable", undefined, undefined, 5)).rejects.toThrow(
+    "CDP command timed out: Page.enable",
+  );
+});
+
+test("cdpSendWithTimeout rejects protocol errors instead of resolving them", async () => {
+  const ws = new FakeWebSocket() as unknown as WebSocket;
+  const pending = cdpSendWithTimeout(ws, "Page.navigate", { url: "https://example.com" }, undefined, 50);
+  const [{ id }] = ws.sent.map((payload) => JSON.parse(payload));
+
+  (ws as any).emit("message", {
+    data: JSON.stringify({
+      id,
+      error: {
+        code: -32000,
+        message: "Navigation failed",
+      },
+    }),
+  });
+
+  await expect(pending).rejects.toThrow("CDP command failed for Page.navigate: Navigation failed");
+});
+
+test("cdpSendWithTimeout still resolves successful protocol results", async () => {
+  const ws = new FakeWebSocket() as unknown as WebSocket;
+  const pending = cdpSendWithTimeout(ws, "Runtime.evaluate", { expression: "2 + 2" }, undefined, 50);
+  const [{ id }] = ws.sent.map((payload) => JSON.parse(payload));
+
+  (ws as any).emit("message", {
+    data: JSON.stringify({
+      id,
+      result: {
+        result: { type: "number", value: 4 },
+      },
+    }),
+  });
+
+  await expect(pending).resolves.toEqual({
+    result: { type: "number", value: 4 },
+  });
+});

--- a/runtime/test/extensions/cdp-browser-transport.test.ts
+++ b/runtime/test/extensions/cdp-browser-transport.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { cdpSendWithTimeout } from "../../extensions/browser/cdp-browser/cdp.ts";
+import { cdpSendWithTimeout, findCdpPort, getTargets, httpGet, httpPut } from "../../extensions/browser/cdp-browser/cdp.ts";
 
 class FakeWebSocket {
   sent: string[] = [];
@@ -71,4 +71,52 @@ test("cdpSendWithTimeout still resolves successful protocol results", async () =
   await expect(pending).resolves.toEqual({
     result: { type: "number", value: 4 },
   });
+});
+
+test("httpGet and httpPut return null when the response is not valid JSON", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.method === "PUT") {
+      return new Response("<html>not json</html>", { status: 200 });
+    }
+    return new Response("plain text", { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    await expect(httpGet("http://localhost/json/version", 10)).resolves.toBeNull();
+    await expect(httpPut("http://localhost/json/new", 10)).resolves.toBeNull();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("findCdpPort skips non-JSON ports instead of accepting them as CDP", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes(":9224/")) {
+      return new Response("<html>nginx default page</html>", { status: 200 });
+    }
+    if (url.includes(":9225/")) {
+      return new Response(JSON.stringify({ Browser: "Chrome/1.0" }), { status: 200 });
+    }
+    throw new Error(`unexpected url ${url}`);
+  }) as typeof fetch;
+
+  try {
+    await expect(findCdpPort()).resolves.toBe(9225);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getTargets returns an empty list when the endpoint does not return a JSON array", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({ error: "not targets" }), { status: 200 })) as typeof fetch;
+
+  try {
+    await expect(getTargets(9224)).resolves.toEqual([]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });


### PR DESCRIPTION
## Summary
- reject CDP commands when their response times out instead of resolving `null`
- reject protocol responses that contain `error` payloads so callers cannot treat failures as success
- treat non-JSON CDP HTTP responses as invalid and validate discovery/target-list shapes before using them
- add transport-level regressions for timeout, protocol-error, non-JSON, and success cases

## Root cause
The transport layer already needed to stop treating timed-out or protocol-error websocket commands as success. The same module also parsed `/json` and `/json/version` responses optimistically: invalid HTML or plaintext fell back to raw strings, which let callers accept non-CDP ports or crash when they assumed an array of targets.

## Impact
CDP discovery and command execution now fail closed: bad websocket responses reject, non-JSON HTTP responses become invalid, and callers no longer mistake arbitrary localhost endpoints for a working CDP transport.

## Testing
- `bun test runtime/test/extensions/cdp-browser-transport.test.ts runtime/test/extensions/cdp-browser.test.ts runtime/test/extensions/cdp-browser-cleanup.test.ts`
- `bun run typecheck`
