### PR TITLE
[codex] fix(office-tools): support ZIP data-descriptor entries

### DIFF
--- a/runtime/extensions/integrations/office-tools/index.ts
+++ b/runtime/extensions/integrations/office-tools/index.ts
@@ -8,7 +8,6 @@ import { pathToFileURL } from "node:url";
 import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
 
 import { ensureBrowser, findBrowser, findCdpPort, printToPdf, type MaybeAbortSignal } from "../../browser/cdp-browser/cdp.ts";
-import { decodeZipEntryText } from "./zip-entry-text.ts";
 
 const EXT_DIR = typeof import.meta.dir === "string" ? import.meta.dir : dirname(new URL(import.meta.url).pathname);
 const OFFICE_TOOLS_STATUS_ICON_SVG = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 3h10l4 4v14H4z"></path><path d="M14 3v5h4"></path><path d="M7 13h10"></path><path d="M7 17h10"></path></svg>`;
@@ -58,18 +57,9 @@ function resolveWorkspacePath(baseDir: string, requestedPath: string): string {
 
 function readZipEntries(buf: Buffer): Map<string, string> {
   const entries = new Map<string, string>();
-  let i = 0;
-  while (i + 30 <= buf.length) {
-    if (buf.readUInt32LE(i) !== 0x04034b50) break;
-    const method = buf.readUInt16LE(i + 8);
-    const cSize = buf.readUInt32LE(i + 18);
-    const nameLen = buf.readUInt16LE(i + 26);
-    const extraLen = buf.readUInt16LE(i + 28);
-    const name = buf.toString("utf-8", i + 30, i + 30 + nameLen);
-    const dataStart = i + 30 + nameLen + extraLen;
-    const text = decodeZipEntryText(name, method, buf.subarray(dataStart, dataStart + cSize));
-    if (text !== null) entries.set(name, text);
-    i = dataStart + cSize;
+  const archive = unzipSync(new Uint8Array(buf));
+  for (const [name, data] of Object.entries(archive)) {
+    entries.set(name, Buffer.from(data).toString("utf-8"));
   }
   return entries;
 }

--- a/runtime/test/extensions/extensions-office-tools.test.ts
+++ b/runtime/test/extensions/extensions-office-tools.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import "../helpers.js";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { WORKSPACE_DIR } from "../../src/core/config.js";
@@ -15,6 +15,77 @@ function makeTempDir(): { prefix: string; base: string } {
   mkdirSync(base, { recursive: true });
   cleanupPaths.push(base);
   return { prefix, base };
+}
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buf) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      const mask = -(crc & 1);
+      crc = (crc >>> 1) ^ (0xedb88320 & mask);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createStoredDataDescriptorZip(name: string, text: string): Buffer {
+  const nameBuf = Buffer.from(name, "utf-8");
+  const dataBuf = Buffer.from(text, "utf-8");
+  const checksum = crc32(dataBuf);
+
+  const localHeader = Buffer.alloc(30);
+  localHeader.writeUInt32LE(0x04034b50, 0);
+  localHeader.writeUInt16LE(20, 4);
+  localHeader.writeUInt16LE(0x0008, 6);
+  localHeader.writeUInt16LE(0, 8);
+  localHeader.writeUInt16LE(0, 10);
+  localHeader.writeUInt16LE(0, 12);
+  localHeader.writeUInt32LE(0, 14);
+  localHeader.writeUInt32LE(0, 18);
+  localHeader.writeUInt32LE(0, 22);
+  localHeader.writeUInt16LE(nameBuf.length, 26);
+  localHeader.writeUInt16LE(0, 28);
+
+  const descriptor = Buffer.alloc(16);
+  descriptor.writeUInt32LE(0x08074b50, 0);
+  descriptor.writeUInt32LE(checksum, 4);
+  descriptor.writeUInt32LE(dataBuf.length, 8);
+  descriptor.writeUInt32LE(dataBuf.length, 12);
+
+  const centralHeader = Buffer.alloc(46);
+  centralHeader.writeUInt32LE(0x02014b50, 0);
+  centralHeader.writeUInt16LE(20, 4);
+  centralHeader.writeUInt16LE(20, 6);
+  centralHeader.writeUInt16LE(0x0008, 8);
+  centralHeader.writeUInt16LE(0, 10);
+  centralHeader.writeUInt16LE(0, 12);
+  centralHeader.writeUInt16LE(0, 14);
+  centralHeader.writeUInt32LE(checksum, 16);
+  centralHeader.writeUInt32LE(dataBuf.length, 20);
+  centralHeader.writeUInt32LE(dataBuf.length, 24);
+  centralHeader.writeUInt16LE(nameBuf.length, 28);
+  centralHeader.writeUInt16LE(0, 30);
+  centralHeader.writeUInt16LE(0, 32);
+  centralHeader.writeUInt16LE(0, 34);
+  centralHeader.writeUInt16LE(0, 36);
+  centralHeader.writeUInt32LE(0, 38);
+  centralHeader.writeUInt32LE(0, 42);
+
+  const localRecord = Buffer.concat([localHeader, nameBuf, dataBuf, descriptor]);
+  const centralRecord = Buffer.concat([centralHeader, nameBuf]);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(centralRecord.length, 12);
+  eocd.writeUInt32LE(localRecord.length, 16);
+  eocd.writeUInt16LE(0, 20);
+
+  return Buffer.concat([localRecord, centralRecord, eocd]);
 }
 
 afterEach(() => {
@@ -139,5 +210,23 @@ describe("office-tools extension", () => {
     expect(text).toContain("## Slide 2: KPIs");
     expect(text).toContain("| Metric | Value |");
     expect(text).toContain("| Users | 120 |");
+  });
+
+  test("office_read handles DOCX archives that use ZIP data descriptors", async () => {
+    const fake = createFakeExtensionApi();
+    officeToolsExtension(fake.api);
+    const reader = fake.tools.get("office_read");
+    if (!reader) throw new Error("office_read not registered");
+
+    const { prefix, base } = makeTempDir();
+    const relPath = `${prefix}/descriptor.docx`;
+    const xml = '<w:document><w:body><w:p><w:r><w:t>Descriptor-backed DOCX</w:t></w:r></w:p></w:body></w:document>';
+    writeFileSync(join(base, "descriptor.docx"), createStoredDataDescriptorZip("word/document.xml", xml));
+
+    const readResult = await reader.execute("docx-read", { path: relPath }, undefined, undefined, { cwd: WORKSPACE_DIR });
+    const text = readResult.content[0].text;
+
+    expect(readResult.details.ok).toBe(true);
+    expect(text).toContain("Descriptor-backed DOCX");
   });
 });


### PR DESCRIPTION
## Summary
- switch Office archive reads to `unzipSync` so ZIP central-directory metadata is honored
- stop relying on local-header compressed sizes, which are zero for data-descriptor archives
- add a crafted DOCX regression that stores its payload behind a ZIP data descriptor

## Testing
- bun test runtime/test/extensions/extensions-office-tools.test.ts runtime/test/extensions/office-tools-zip-entry-text.test.ts
- bun run typecheck