### PR TITLE
[codex] fix(m365): escape sync pattern text before glob regex conversion

### DIFF
--- a/runtime/extensions/experimental/m365/index.ts
+++ b/runtime/extensions/experimental/m365/index.ts
@@ -48,6 +48,14 @@ import {
 const log = createLogger("extensions.experimental.m365.index");
 const M365_STATUS_ICON_SVG = `<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><rect x="3" y="3" width="8" height="8" rx="1.2"></rect><rect x="13" y="3" width="8" height="8" rx="1.2"></rect><rect x="3" y="13" width="8" height="8" rx="1.2"></rect><rect x="13" y="13" width="8" height="8" rx="1.2"></rect></svg>`;
 
+export function compileM365SyncPattern(pattern: string): RegExp {
+	const escaped = String(pattern)
+		.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&")
+		.replace(/\\\*/g, ".*")
+		.replace(/\\\?/g, ".");
+	return new RegExp(`^${escaped}$`, "i");
+}
+
 function readTrimmedString(...values: unknown[]): string | null {
 	for (const value of values) {
 		if (typeof value === "string" && value.trim()) return value.trim();
@@ -1502,7 +1510,7 @@ export default function (pi: ExtensionAPI) {
 
 			const direction = (params.direction ?? "upload").toLowerCase();
 			const dryRun = getDryRun(params);
-			const pattern = params.pattern ? new RegExp(params.pattern.replace(/\*/g, ".*").replace(/\?/g, "."), "i") : null;
+			const pattern = params.pattern ? compileM365SyncPattern(params.pattern) : null;
 
 			let driveId = params.driveId;
 			let folderId = params.folderId;

--- a/runtime/test/extensions/m365-sync-pattern.test.ts
+++ b/runtime/test/extensions/m365-sync-pattern.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import "../helpers.js";
+
+import { compileM365SyncPattern } from "../../extensions/experimental/m365/index.ts";
+
+test("compileM365SyncPattern anchors exact matches instead of regex substrings", () => {
+	const pattern = compileM365SyncPattern("foo.md");
+
+	expect(pattern.test("foo.md")).toBe(true);
+	expect(pattern.test("fooXmd")).toBe(false);
+	expect(pattern.test("prefix-foo.md")).toBe(false);
+});
+
+test("compileM365SyncPattern escapes regex metacharacters before glob expansion", () => {
+	const bracketPattern = compileM365SyncPattern("[.git]");
+	const parenPattern = compileM365SyncPattern("report(1).md");
+	const wildcardPattern = compileM365SyncPattern("*.md");
+
+	expect(bracketPattern.test("[.git]")).toBe(true);
+	expect(bracketPattern.test("x.git")).toBe(false);
+	expect(parenPattern.test("report(1).md")).toBe(true);
+	expect(parenPattern.test("report11md")).toBe(false);
+	expect(wildcardPattern.test("notes.md")).toBe(true);
+	expect(wildcardPattern.test("notes.txt")).toBe(false);
+});


### PR DESCRIPTION
## Summary
- escape regex metacharacters before expanding `*` and `?` in M365 sync patterns
- anchor sync pattern matching so literal patterns match exact filenames instead of regex substrings
- add regressions covering literal dots, bracket text, parentheses, and wildcard filtering

## Testing
- bun test runtime/test/extensions/m365-sync-pattern.test.ts runtime/test/channels/web/tool-status-hints.test.ts
- bun run typecheck