### PR TITLE
[codex] fix(docker-compose): default published web port to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PICLAW_WEB_PORT: "${PICLAW_WEB_PORT:-8080}"
       PICLAW_AUTOSTART: "${PICLAW_AUTOSTART:-1}"
     ports:
-      - "${PICLAW_WEB_PORT:-8080}:8080"
+      - "${PICLAW_WEB_BIND_HOST:-127.0.0.1}:${PICLAW_WEB_PORT:-8080}:8080"
     restart: unless-stopped
     deploy:
       resources:

--- a/runtime/test/runtime/docker-compose.test.ts
+++ b/runtime/test/runtime/docker-compose.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const DOCKER_COMPOSE_PATH = resolve(import.meta.dir, "../../..", "docker-compose.yml");
+
+test("docker-compose publishes the web port on loopback by default", () => {
+  const compose = readFileSync(DOCKER_COMPOSE_PATH, "utf8");
+
+  expect(compose).toContain('- "${PICLAW_WEB_BIND_HOST:-127.0.0.1}:${PICLAW_WEB_PORT:-8080}:8080"');
+  expect(compose).not.toContain('- "${PICLAW_WEB_PORT:-8080}:8080"');
+});


### PR DESCRIPTION
## Summary
- default the published web port binding to `127.0.0.1` instead of all interfaces
- keep external exposure opt-in through `PICLAW_WEB_BIND_HOST`
- add a regression test that locks the default compose mapping to loopback

## Root Cause
The compose port mapping used `${PICLAW_WEB_PORT:-8080}:8080`, which binds on every interface by default.

## Testing
- cd runtime && bun test test/runtime/docker-compose.test.ts
