### PR TITLE
[codex] fix(docker): pin Homebrew bootstrap installer

### DIFF
--- a/runtime/test/runtime/install-agent-runtime.test.ts
+++ b/runtime/test/runtime/install-agent-runtime.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const INSTALL_SCRIPT_PATH = resolve(import.meta.dir, "../../../scripts/docker/install-agent-runtime.sh");
+
+test("install-agent-runtime pins and verifies the Homebrew bootstrap script", () => {
+  const script = readFileSync(INSTALL_SCRIPT_PATH, "utf8");
+
+  expect(script).toMatch(/HOMEBREW_INSTALL_COMMIT="[0-9a-f]{40}"/);
+  expect(script).toMatch(/HOMEBREW_INSTALL_SCRIPT_SHA256="[0-9a-f]{64}"/);
+  expect(script).toContain('https://raw.githubusercontent.com/Homebrew/install/${HOMEBREW_INSTALL_COMMIT}/install.sh');
+  expect(script).toContain('actual_brew_install_sha256=$(sha256sum "$BREW_INSTALL_SCRIPT" | awk \'{print $1}\')');
+  expect(script).toContain('if [ "$actual_brew_install_sha256" != "$HOMEBREW_INSTALL_SCRIPT_SHA256" ]; then');
+  expect(script).not.toContain("https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh");
+});

--- a/scripts/docker/install-agent-runtime.sh
+++ b/scripts/docker/install-agent-runtime.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 
 DEFAULT_BREW_REMOTE="https://github.com/Homebrew/brew.git"
 DEFAULT_CORE_REMOTE="https://github.com/Homebrew/homebrew-core.git"
+HOMEBREW_INSTALL_COMMIT="de0b0bddf1c78731dcd16d953b2f5d29d070e229"
+HOMEBREW_INSTALL_SCRIPT_SHA256="dfd5145fe2aa5956a600e35848765273f5798ce6def01bd08ecec088a1268d91"
 
 choose_remote() {
   local fallback="$1"
@@ -185,7 +187,14 @@ export HOMEBREW_CACHE="${HOMEBREW_CACHE:-/tmp/homebrew-cache}"
 mkdir -p "$HOMEBREW_CACHE"
 
 BREW_INSTALL_SCRIPT="$(mktemp)"
-curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o "$BREW_INSTALL_SCRIPT"
+curl -fsSL "https://raw.githubusercontent.com/Homebrew/install/${HOMEBREW_INSTALL_COMMIT}/install.sh" -o "$BREW_INSTALL_SCRIPT"
+actual_brew_install_sha256=$(sha256sum "$BREW_INSTALL_SCRIPT" | awk '{print $1}')
+if [ "$actual_brew_install_sha256" != "$HOMEBREW_INSTALL_SCRIPT_SHA256" ]; then
+  echo "Checksum mismatch for pinned Homebrew install script" >&2
+  echo "Expected: $HOMEBREW_INSTALL_SCRIPT_SHA256" >&2
+  echo "Actual:   $actual_brew_install_sha256" >&2
+  exit 1
+fi
 /bin/bash "$BREW_INSTALL_SCRIPT"
 rm -f "$BREW_INSTALL_SCRIPT"
 


### PR DESCRIPTION
## Summary
- pin the Homebrew bootstrap download to a specific `Homebrew/install` commit
- verify the downloaded installer with a SHA-256 checksum before executing it
- add a regression test that rejects the floating `HEAD` bootstrap URL

## Root Cause
The installer fetched `Homebrew/install/HEAD/install.sh`, so the build consumed whichever script happened to be current at install time.

## Testing
- bash -n scripts/docker/install-agent-runtime.sh
- cd runtime && bun test test/runtime/install-agent-runtime.test.ts
