### PR TITLE
[codex] fix(ipc): harden task parsing and shutdown handling

### DIFF
--- a/runtime/src/ipc.ts
+++ b/runtime/src/ipc.ts
@@ -67,6 +67,8 @@ export interface IpcDeps {
 /** Guard to prevent starting the watcher more than once. */
 let running = false;
 let pollTimer: ReturnType<typeof setTimeout> | null = null;
+let activePoll: Promise<void> | null = null;
+let activePollController: AbortController | null = null;
 
 type IpcScheduleType = "cron" | "interval" | "once";
 type JsonRecord = Record<string, unknown>;
@@ -83,7 +85,23 @@ function getStringField(data: JsonRecord, key: string): string | undefined {
 
 function getFiniteNumberField(data: JsonRecord, key: string): number | undefined {
   const value = data[key];
-  return Number.isFinite(value) ? Number(value) : undefined;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!normalized) return undefined;
+    const parsed = Number(normalized);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function getStringOrFiniteNumberField(data: JsonRecord, key: string): string | undefined {
+  const stringValue = getStringField(data, key);
+  if (typeof stringValue === "string") return stringValue;
+
+  const numericValue = getFiniteNumberField(data, key);
+  if (numericValue !== undefined) return String(numericValue);
+  return undefined;
 }
 
 function getBooleanField(data: JsonRecord, key: string): boolean | undefined {
@@ -186,11 +204,13 @@ async function processIpcDir(
   dirPath: string,
   ipcDir: string,
   kind: "message" | "task",
-  handler: (data: JsonRecord) => Promise<void>
+  handler: (data: JsonRecord) => Promise<void>,
+  signal?: AbortSignal
 ): Promise<void> {
   if (!existsSync(dirPath)) return;
 
   for (const file of readdirSync(dirPath).filter((f) => f.endsWith(".json"))) {
+    if (signal?.aborted) return;
     const fp = join(dirPath, file);
     try {
       const parsed = JSON.parse(readFileSync(fp, "utf-8"));
@@ -250,7 +270,7 @@ function computeScheduledNextRun(
  *
  * Called once by runtime.ts during application startup.
  */
-export function startIpcWatcher(deps: IpcDeps): () => void {
+export function startIpcWatcher(deps: IpcDeps): () => Promise<void> {
   if (running) return stopIpcWatcher;
   running = true;
 
@@ -261,9 +281,12 @@ export function startIpcWatcher(deps: IpcDeps): () => void {
   mkdirSync(messagesDir, { recursive: true });
 
   const poll = async () => {
+    activePollController = new AbortController();
+    const { signal } = activePollController;
+
     // --- Process outbound message files ---
     try {
-      await processIpcDir(messagesDir, ipcDir, "message", (data) => processMessageCommand(data, deps));
+      await processIpcDir(messagesDir, ipcDir, "message", (data) => processMessageCommand(data, deps), signal);
     } catch (e) {
       log.error("Failed to read IPC messages directory", {
         operation: "start_ipc_watcher.poll_messages",
@@ -273,7 +296,7 @@ export function startIpcWatcher(deps: IpcDeps): () => void {
 
     // --- Process task command files ---
     try {
-      await processIpcDir(tasksDir, ipcDir, "task", (data) => processTaskCommand(data, deps));
+      await processIpcDir(tasksDir, ipcDir, "task", (data) => processTaskCommand(data, deps), signal);
     } catch (e) {
       log.error("Failed to read IPC tasks directory", {
         operation: "start_ipc_watcher.poll_tasks",
@@ -282,21 +305,31 @@ export function startIpcWatcher(deps: IpcDeps): () => void {
     }
 
     if (!running) return;
-    pollTimer = setTimeout(poll, getRuntimeTimingConfig().ipcPollIntervalMs);
+    pollTimer = setTimeout(() => {
+      activePoll = poll().finally(() => {
+        activePoll = null;
+        activePollController = null;
+      });
+    }, getRuntimeTimingConfig().ipcPollIntervalMs);
   };
 
-  poll();
+  activePoll = poll().finally(() => {
+    activePoll = null;
+    activePollController = null;
+  });
   log.info("IPC watcher started", { operation: "start_ipc_watcher" });
   return stopIpcWatcher;
 }
 
 /** Stop the active IPC watcher and clear associated runtime state. */
-export function stopIpcWatcher(): void {
+export async function stopIpcWatcher(): Promise<void> {
   running = false;
   if (pollTimer) {
     clearTimeout(pollTimer);
     pollTimer = null;
   }
+  activePollController?.abort();
+  if (activePoll) await activePoll;
 }
 
 /**
@@ -307,7 +340,9 @@ export async function processMessageCommand(data: JsonRecord, deps: IpcDeps): Pr
   const chatJid = resolveIpcChatJid(data);
   const text = getStringField(data, "text") || "";
 
-  if (type !== "message") return;
+  if (type !== "message") {
+    throw new Error(`Unsupported IPC message type: ${type || "missing"}`);
+  }
 
   const media = getArrayField(data, "media") || [];
   const { mediaIds, contentBlocks, warnings } = await buildMediaPayloadFromIpcEntries(media);
@@ -341,7 +376,7 @@ export async function processTaskCommand(data: JsonRecord, deps: IpcDeps): Promi
     // --- Create a new scheduled task ---
     case "schedule_task": {
       const scheduleTypeValue = getStringField(data, "schedule_type");
-      const scheduleValue = getStringField(data, "schedule_value");
+      const scheduleValue = getStringOrFiniteNumberField(data, "schedule_value");
       const chatJid = resolveIpcChatJid(data);
       if (!scheduleTypeValue || !scheduleValue || !isScheduleType(scheduleTypeValue)) return;
 
@@ -467,10 +502,14 @@ export async function processTaskCommand(data: JsonRecord, deps: IpcDeps): Promi
 
       const scheduleType = getStringField(data, "schedule_type");
       if (typeof scheduleType === "string") {
+        if (!isScheduleType(scheduleType)) {
+          if (chatJid) await deps.sendMessage(chatJid, `Cannot update task: invalid schedule_type "${scheduleType}".`);
+          return;
+        }
         updates.schedule_type = scheduleType as ScheduledTask["schedule_type"];
       }
 
-      const scheduleValue = getStringField(data, "schedule_value");
+      const scheduleValue = getStringOrFiniteNumberField(data, "schedule_value");
       if (typeof scheduleValue === "string") updates.schedule_value = scheduleValue;
 
       const taskKind = getStringField(data, "task_kind");
@@ -561,7 +600,17 @@ export async function processTaskCommand(data: JsonRecord, deps: IpcDeps): Promi
       const result = db.prepare("DELETE FROM scheduled_tasks WHERE status = 'completed'").run();
       const countValue = (result as { changes?: unknown }).changes;
       const count = typeof countValue === "number" ? countValue : 0;
-      if (chatJid) await deps.sendMessage(chatJid, `Cleaned up ${count} completed task(s).`);
+      if (chatJid) {
+        try {
+          await deps.sendMessage(chatJid, `Cleaned up ${count} completed task(s).`);
+        } catch (error) {
+          debugSuppressedError(log, "Cleanup completed but IPC cleanup notification failed to send.", error, {
+            operation: "process_task_command.cleanup_tasks.send_message",
+            chatJid,
+            deletedCount: count,
+          });
+        }
+      }
       break;
     }
 
@@ -595,5 +644,8 @@ export async function processTaskCommand(data: JsonRecord, deps: IpcDeps): Promi
       }
       break;
     }
+
+    default:
+      throw new Error(`Unsupported IPC task type: ${commandType || "missing"}`);
   }
 }

--- a/runtime/src/runtime/bootstrap.ts
+++ b/runtime/src/runtime/bootstrap.ts
@@ -110,7 +110,7 @@ export interface RuntimeBootstrapDeps {
   queueStartupResumePendingIpc(): void;
   startRuntimeLoop(deps: StartRuntimeLoopDeps): Promise<void>;
   log(message: string): void;
-  stopIpcWatcher(): void;
+  stopIpcWatcher(): Promise<void>;
   stopSchedulerLoop(): void;
 }
 

--- a/runtime/src/runtime/shutdown.ts
+++ b/runtime/src/runtime/shutdown.ts
@@ -13,7 +13,7 @@ export type ShutdownDeps = {
   whatsapp: { disconnect: () => Promise<unknown> };
   web: { stop: () => Promise<unknown> };
   pushover?: { stop: () => Promise<unknown> } | null;
-  stopIpcWatcher: () => void;
+  stopIpcWatcher: () => Promise<void>;
   stopSchedulerLoop: () => void;
 };
 
@@ -56,7 +56,7 @@ export function createShutdownHandler(deps: ShutdownDeps): (signal: string) => P
       process.exit(0);
     }, 15000);
 
-    deps.stopIpcWatcher();
+    await withTimeout(deps.stopIpcWatcher(), 4000, "ipc watcher stop");
     deps.stopSchedulerLoop();
     await withTimeout(deps.queue.shutdown(5000), 7000, "queue shutdown");
     await withTimeout(deps.agentPool.shutdown(), 8000, "agent pool shutdown");

--- a/runtime/test/ipc/ipc.test.ts
+++ b/runtime/test/ipc/ipc.test.ts
@@ -90,8 +90,8 @@ beforeAll(async () => {
 });
 
 
-afterAll(() => {
-  ipc.stopIpcWatcher();
+afterAll(async () => {
+  await ipc.stopIpcWatcher();
   restoreEnv?.();
 });
 
@@ -118,6 +118,12 @@ test("IPC message falls back to PICLAW_CHAT_JID when chatJid is omitted", async 
   const msg = sentMessages[sentMessages.length - 1];
   expect(msg.jid).toBe("web:test-chat");
   expect(msg.text).toBe("hello env");
+});
+
+test("IPC message rejects unknown message types", async () => {
+  await expect(
+    ipc.processMessageCommand({ type: "messages", chatJid: "web:default", text: "hello" }, deps),
+  ).rejects.toThrow("Unsupported IPC message type");
 });
 
 test("IPC message with media attaches files and supports inline rendering hints", async () => {
@@ -387,6 +393,25 @@ test("IPC schedule_task creates a due shell task", async () => {
   expect(due?.command).toBe("echo hi");
 });
 
+test("IPC schedule_task accepts numeric schedule values and numeric-string timeouts", async () => {
+  await ipc.processTaskCommand({
+    type: "schedule_task",
+    chatJid: "web:default",
+    task_kind: "shell",
+    command: "echo hi",
+    timeout_sec: "45",
+    schedule_type: "interval",
+    schedule_value: 60000,
+  } as Record<string, unknown>, deps);
+
+  const created = db.getDb()
+    .prepare("SELECT schedule_value, timeout_sec FROM scheduled_tasks WHERE task_kind = 'shell' ORDER BY rowid DESC LIMIT 1")
+    .get() as { schedule_value: string; timeout_sec: number | null } | undefined;
+
+  expect(created?.schedule_value).toBe("60000");
+  expect(created?.timeout_sec).toBe(45);
+});
+
 test("IPC schedule_task rejects unsafe shell command", async () => {
   const start = sentMessages.length;
   await ipc.processTaskCommand({
@@ -406,6 +431,12 @@ test("IPC resume_pending triggers resumePending handler", async () => {
   await ipc.processTaskCommand({ type: "resume_pending", chatJid: "web:default" }, deps);
   await waitFor(() => resumePendingCalls.length > start, 10000);
   expect(resumePendingCalls[resumePendingCalls.length - 1]?.chatJid).toBe("web:default");
+});
+
+test("IPC task commands reject unknown task types", async () => {
+  await expect(
+    ipc.processTaskCommand({ type: "task_typo", chatJid: "web:default" }, deps),
+  ).rejects.toThrow("Unsupported IPC task type");
 });
 
 test("IPC renames malformed task files", async () => {
@@ -480,6 +511,31 @@ test("IPC update_task ignores invalid schedule values", async () => {
   expect(task?.next_run).toBe(originalNextRun);
 });
 
+test("IPC update_task accepts numeric schedule values", async () => {
+  const taskId = `task_schedule_numeric_${Date.now()}`;
+  db.createTask({
+    id: taskId,
+    chat_jid: "web:default",
+    prompt: "hello",
+    model: null,
+    schedule_type: "interval",
+    schedule_value: "60000",
+    next_run: new Date(Date.now() + 60_000).toISOString(),
+    status: "active",
+    created_at: new Date().toISOString(),
+  });
+
+  await ipc.processTaskCommand({
+    type: "update_task",
+    taskId,
+    schedule_type: "interval",
+    schedule_value: 120000,
+  } as Record<string, unknown>, deps);
+
+  const task = db.getTaskById(taskId);
+  expect(task?.schedule_value).toBe("120000");
+});
+
 test("IPC cleanup_tasks removes completed tasks and logs", async () => {
   const tasksDir = join(config.DATA_DIR, "ipc", "tasks");
   mkdirSync(tasksDir, { recursive: true });
@@ -525,6 +581,87 @@ test("IPC cleanup_tasks removes completed tasks and logs", async () => {
   expect(db.getTaskById(completedId)).toBeNull();
   expect(db.getTaskRunLogs(completedId).length).toBe(0);
   expect(db.getTaskById(activeId)).not.toBeNull();
+});
+
+test("IPC cleanup_tasks does not fail after deleting rows when notification sending throws", async () => {
+  const completedId = `task_cleanup_notify_${Date.now()}`;
+  db.createTask({
+    id: completedId,
+    chat_jid: "web:default",
+    prompt: "done",
+    model: null,
+    schedule_type: "once",
+    schedule_value: new Date().toISOString(),
+    next_run: null,
+    status: "completed",
+    created_at: new Date().toISOString(),
+  });
+  db.logTaskRun({
+    task_id: completedId,
+    run_at: new Date().toISOString(),
+    duration_ms: 10,
+    status: "success",
+    result: "ok",
+    error: null,
+  });
+
+  await expect(ipc.processTaskCommand(
+    { type: "cleanup_tasks", chatJid: "web:default" },
+    {
+      ...deps,
+      sendMessage: async () => {
+        throw new Error("notify failed");
+      },
+    },
+  )).resolves.toBeUndefined();
+
+  expect(db.getTaskById(completedId)).toBeNull();
+  expect(db.getTaskRunLogs(completedId).length).toBe(0);
+});
+
+test("IPC watcher stop waits for the active poll to finish", async () => {
+  await ipc.stopIpcWatcher();
+
+  const messagesDir = join(config.DATA_DIR, "ipc", "messages");
+  mkdirSync(messagesDir, { recursive: true });
+  const fileName = `slow_${Date.now()}.json`;
+  const filePath = join(messagesDir, fileName);
+  writeFileSync(filePath, JSON.stringify({ type: "message", chatJid: "web:default", text: "slow" }));
+
+  let releaseSend!: () => void;
+  const sendStarted = new Promise<void>((resolve) => {
+    releaseSend = resolve;
+  });
+
+  let unblockSend!: () => void;
+  const sendBlocked = new Promise<void>((resolve) => {
+    unblockSend = resolve;
+  });
+
+  ipc.startIpcWatcher({
+    ...deps,
+    sendMessage: async () => {
+      releaseSend();
+      await sendBlocked;
+    },
+  });
+
+  await sendStarted;
+
+  let stopped = false;
+  const stopPromise = ipc.stopIpcWatcher().then(() => {
+    stopped = true;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(stopped).toBe(false);
+
+  unblockSend();
+  await stopPromise;
+  expect(stopped).toBe(true);
+  expect(readdirSync(messagesDir)).not.toContain(fileName);
+
+  ipc.startIpcWatcher(deps);
 });
 
 test("IPC-related exported symbols keep JSDoc coverage", () => {


### PR DESCRIPTION
## Summary
- accept numeric strings in IPC numeric fields and normalize numeric `schedule_value` inputs before task creation or updates
- reject unsupported IPC message and task command types instead of silently consuming malformed payloads
- make IPC watcher shutdown await the active poll, and avoid post-commit cleanup notification failures marking task payloads as failed
- add focused regressions covering unknown types, numeric parsing, cleanup behavior, and watcher stop semantics

## Root Cause
Several IPC command paths silently dropped malformed input, accepted only strict JS numbers, or let shutdown race with active polling. That combination caused silent data loss, inconsistent task updates, and non-graceful IPC shutdown.

## Testing
- cd runtime && bun test test/ipc/ipc.test.ts
- bun run typecheck
