### PR TITLE
feat(web): add web-push subscription foundation

### DIFF
--- a/runtime/src/channels/web/http/dispatch-agent.ts
+++ b/runtime/src/channels/web/http/dispatch-agent.ts
@@ -3,6 +3,11 @@
  */
 
 import type { WebChannelLike } from "../core/web-channel-contracts.js";
+import {
+  handleWebPushSubscriptionDelete,
+  handleWebPushSubscriptionUpsert,
+  handleWebPushVapidPublicKey,
+} from "../push/web-push-routes.js";
 
 interface ExactAgentRoute {
   method: string;
@@ -144,6 +149,21 @@ const EXACT_AGENT_ROUTES: ExactAgentRoute[] = [
     method: "POST",
     path: "/agent/card-action",
     handle: (channel, req) => channel.handleAdaptiveCardAction(req),
+  },
+  {
+    method: "GET",
+    path: "/agent/push/vapid-public-key",
+    handle: () => handleWebPushVapidPublicKey(),
+  },
+  {
+    method: "POST",
+    path: "/agent/push/subscription",
+    handle: (_channel, req) => handleWebPushSubscriptionUpsert(req),
+  },
+  {
+    method: "DELETE",
+    path: "/agent/push/subscription",
+    handle: (_channel, req) => handleWebPushSubscriptionDelete(req),
   },
   {
     method: "POST",

--- a/runtime/src/channels/web/http/dispatch-shell.ts
+++ b/runtime/src/channels/web/http/dispatch-shell.ts
@@ -49,6 +49,10 @@ export async function handleShellRoutes(
     return await serveStaticAsset(req, pathname.slice(1));
   }
 
+  if (flags.isServiceWorker) {
+    return channel.serveStatic("sw.js");
+  }
+
   if (req.method === "GET" && pathname === "/ghostty-vt.wasm") {
     return channel.serveStatic("js/vendor/ghostty-vt.wasm");
   }

--- a/runtime/src/channels/web/http/route-flags.ts
+++ b/runtime/src/channels/web/http/route-flags.ts
@@ -42,6 +42,8 @@ export type RouteFlags = {
   isFavicon: boolean;
   /** True when the request targets known Apple touch icon paths. */
   isAppleIcon: boolean;
+  /** True when the request targets `/sw.js`. */
+  isServiceWorker: boolean;
   /** True when the request path starts with `/static/`. */
   isStaticAsset: boolean;
   /** True when a static asset is safe to serve unauthenticated. */
@@ -115,6 +117,7 @@ export function getRouteFlags(req: Request, pathname: string): RouteFlags {
     isManifest: isGetOrHead && pathname === "/manifest.json",
     isFavicon: isGetOrHead && pathname === "/favicon.ico",
     isAppleIcon: isGetOrHead && APPLE_ICON_PATHS.has(pathname),
+    isServiceWorker: isGetOrHead && pathname === "/sw.js",
     isStaticAsset,
     isPublicStatic: isStaticAsset && isPublicStaticPath(pathname),
     isDocsAsset: pathname.startsWith("/docs/"),
@@ -143,6 +146,7 @@ export function shouldSkipAuthCheck(flags: RouteFlags, hasInternalAccess: boolea
     flags.isManifest ||
     flags.isFavicon ||
     flags.isAppleIcon ||
+    flags.isServiceWorker ||
     flags.isPublicStatic ||
     flags.isAvatar
   );

--- a/runtime/src/channels/web/http/static.ts
+++ b/runtime/src/channels/web/http/static.ts
@@ -104,9 +104,11 @@ export async function serveStatic(relPath: string, notFound: () => Response): Pr
   const cacheControl =
     ext === ".html"
       ? "no-cache, no-store, must-revalidate"
-      : (relPath === "dist" || relPath.startsWith("dist/") || relPath.includes("/dist/"))
+      : relPath === "sw.js"
         ? "no-cache, no-store, must-revalidate"
-        : "public, max-age=3600";
+        : (relPath === "dist" || relPath.startsWith("dist/") || relPath.includes("/dist/"))
+          ? "no-cache, no-store, must-revalidate"
+          : "public, max-age=3600";
 
   if (ext === ".html") {
     const rendered = renderHtmlTemplate(relPath, await file.text());
@@ -118,11 +120,17 @@ export async function serveStatic(relPath: string, notFound: () => Response): Pr
     });
   }
 
+  const responseHeaders: Record<string, string> = {
+    "Content-Type": contentType,
+    "Cache-Control": cacheControl,
+  };
+
+  if (relPath === "sw.js") {
+    responseHeaders["Service-Worker-Allowed"] = "/";
+  }
+
   return new Response(file, {
-    headers: {
-      "Content-Type": contentType,
-      "Cache-Control": cacheControl,
-    },
+    headers: responseHeaders,
   });
 }
 

--- a/runtime/src/channels/web/push/web-push-routes.ts
+++ b/runtime/src/channels/web/push/web-push-routes.ts
@@ -1,0 +1,55 @@
+/**
+ * web/push/web-push-routes.ts – HTTP handlers for VAPID key discovery and subscription persistence.
+ */
+
+import {
+  getStoredVapidPublicKey,
+  removeStoredWebPushSubscription,
+  upsertStoredWebPushSubscription,
+} from "./web-push-store.js";
+
+function resolveUserAgent(req: Request): string | null {
+  const value = req.headers.get("user-agent");
+  return value && value.trim() ? value.trim() : null;
+}
+
+function resolveDeviceId(value: unknown): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || null;
+}
+
+export async function handleWebPushVapidPublicKey(options: { baseDir?: string } = {}): Promise<Response> {
+  return Response.json({ publicKey: getStoredVapidPublicKey(options.baseDir) });
+}
+
+export async function handleWebPushSubscriptionUpsert(req: Request, options: { baseDir?: string } = {}): Promise<Response> {
+  try {
+    const body = await req.json().catch(() => null);
+    const subscription = body && typeof body === "object" && body.subscription ? body.subscription : body;
+    const stored = upsertStoredWebPushSubscription(subscription, {
+      baseDir: options.baseDir,
+      userAgent: resolveUserAgent(req),
+      deviceId: resolveDeviceId((body as Record<string, unknown> | null)?.device_id ?? (body as Record<string, unknown> | null)?.deviceId),
+    });
+    return Response.json({ ok: true, device_id: stored.deviceId });
+  } catch (error) {
+    return Response.json({ error: error instanceof Error ? error.message : "Invalid push subscription." }, { status: 400 });
+  }
+}
+
+export async function handleWebPushSubscriptionDelete(req: Request, options: { baseDir?: string } = {}): Promise<Response> {
+  const body = await req.json().catch(() => null);
+  const subscription = body && typeof body === "object" && body.subscription ? body.subscription : body;
+  const endpoint = typeof subscription?.endpoint === "string"
+    ? subscription.endpoint.trim()
+    : typeof body?.endpoint === "string"
+      ? body.endpoint.trim()
+      : "";
+
+  if (!endpoint) {
+    return Response.json({ error: "Missing push subscription endpoint." }, { status: 400 });
+  }
+
+  const removed = removeStoredWebPushSubscription(endpoint, options.baseDir);
+  return Response.json({ ok: true, removed });
+}

--- a/runtime/src/channels/web/push/web-push-store.ts
+++ b/runtime/src/channels/web/push/web-push-store.ts
@@ -1,0 +1,244 @@
+/**
+ * web/push/web-push-store.ts – Minimal persistent storage for VAPID keys and Web Push subscriptions.
+ */
+
+import { createPublicKey, generateKeyPairSync } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { WORKSPACE_DIR } from "../../../core/config.js";
+import { createLogger, debugSuppressedError } from "../../../utils/logger.js";
+
+const log = createLogger("web.push.store");
+const DEFAULT_PUSH_DIR = resolve(WORKSPACE_DIR, ".piclaw", "web-push");
+const VAPID_FILE_NAME = "vapid-keys.json";
+const SUBSCRIPTIONS_FILE_NAME = "subscriptions.json";
+
+export interface StoredWebPushSubscription {
+  endpoint: string;
+  expirationTime: number | null;
+  keys: {
+    auth: string;
+    p256dh: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+  userAgent: string | null;
+  deviceId: string | null;
+}
+
+export interface StoredVapidKeys {
+  createdAt: string;
+  publicKey: string;
+  publicKeyPem: string;
+  privateKeyPem: string;
+}
+
+function resolvePushDir(baseDir = DEFAULT_PUSH_DIR): string {
+  return resolve(baseDir);
+}
+
+function resolveVapidKeysPath(baseDir = DEFAULT_PUSH_DIR): string {
+  return resolve(resolvePushDir(baseDir), VAPID_FILE_NAME);
+}
+
+function resolveSubscriptionsPath(baseDir = DEFAULT_PUSH_DIR): string {
+  return resolve(resolvePushDir(baseDir), SUBSCRIPTIONS_FILE_NAME);
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch (error) {
+    debugSuppressedError(log, "Failed to read stored web push state; ignoring the stale file.", error, { path });
+    return null;
+  }
+}
+
+function writeJsonFile(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(dirname(path), 0o700);
+  } catch (error) {
+    debugSuppressedError(log, "Failed to tighten web push store directory permissions; continuing with existing mode.", error, {
+      dir: dirname(path),
+    });
+  }
+  const tempPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+    renameSync(tempPath, path);
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
+  }
+}
+
+function decodeBase64Url(value: string): Buffer {
+  return Buffer.from(value, "base64url");
+}
+
+function encodeBase64Url(value: Buffer | Uint8Array): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function createVapidKeys(): StoredVapidKeys {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    publicKeyEncoding: { format: "pem", type: "spki" },
+    privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  });
+
+  const publicJwk = createPublicKey(publicKey).export({ format: "jwk" }) as JsonWebKey;
+  const x = typeof publicJwk.x === "string" ? publicJwk.x : "";
+  const y = typeof publicJwk.y === "string" ? publicJwk.y : "";
+  if (!x || !y) {
+    throw new Error("Generated VAPID key is missing JWK coordinates.");
+  }
+
+  const publicPoint = Buffer.concat([
+    Buffer.from([0x04]),
+    decodeBase64Url(x),
+    decodeBase64Url(y),
+  ]);
+
+  return {
+    createdAt: new Date().toISOString(),
+    publicKey: encodeBase64Url(publicPoint),
+    publicKeyPem: publicKey,
+    privateKeyPem: privateKey,
+  };
+}
+
+function readStoredVapidKeys(baseDir = DEFAULT_PUSH_DIR): StoredVapidKeys | null {
+  const path = resolveVapidKeysPath(baseDir);
+  const parsed = readJsonFile<StoredVapidKeys>(path);
+  if (!parsed) return null;
+  if (!parsed.publicKey || !parsed.publicKeyPem || !parsed.privateKeyPem) return null;
+  return parsed;
+}
+
+export function ensureStoredVapidKeys(baseDir = DEFAULT_PUSH_DIR): StoredVapidKeys {
+  const existing = readStoredVapidKeys(baseDir);
+  if (existing) return existing;
+  const created = createVapidKeys();
+  writeJsonFile(resolveVapidKeysPath(baseDir), created);
+  return created;
+}
+
+export function getStoredVapidPublicKey(baseDir = DEFAULT_PUSH_DIR): string {
+  return ensureStoredVapidKeys(baseDir).publicKey;
+}
+
+export function normalizeStoredWebPushSubscription(
+  value: unknown,
+  options: { now?: string; userAgent?: string | null; deviceId?: string | null } = {}
+): StoredWebPushSubscription | null {
+  if (!value || typeof value !== "object") return null;
+  const input = value as Record<string, any>;
+  const endpoint = typeof input.endpoint === "string" ? input.endpoint.trim() : "";
+  const p256dh = typeof input.keys?.p256dh === "string" ? input.keys.p256dh.trim() : "";
+  const auth = typeof input.keys?.auth === "string" ? input.keys.auth.trim() : "";
+  if (!endpoint || !endpoint.startsWith("https://") || !p256dh || !auth) return null;
+
+  const now = options.now || new Date().toISOString();
+  const rawExpirationTime = input.expirationTime;
+  const expirationTime = rawExpirationTime === null || rawExpirationTime === undefined
+    ? null
+    : Number(rawExpirationTime);
+  return {
+    endpoint,
+    expirationTime: Number.isFinite(expirationTime) ? expirationTime : null,
+    keys: { auth, p256dh },
+    createdAt: now,
+    updatedAt: now,
+    userAgent: typeof options.userAgent === "string" && options.userAgent.trim() ? options.userAgent.trim() : null,
+    deviceId: typeof options.deviceId === "string" && options.deviceId.trim() ? options.deviceId.trim() : (typeof input.deviceId === "string" && input.deviceId.trim() ? input.deviceId.trim() : null),
+  };
+}
+
+export function listStoredWebPushSubscriptions(baseDir = DEFAULT_PUSH_DIR): StoredWebPushSubscription[] {
+  const path = resolveSubscriptionsPath(baseDir);
+  const parsed = readJsonFile<StoredWebPushSubscription[]>(path);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((entry) => normalizeStoredWebPushSubscription(entry, {
+    now: typeof entry?.updatedAt === "string" && entry.updatedAt.trim() ? entry.updatedAt : new Date().toISOString(),
+    userAgent: typeof entry?.userAgent === "string" ? entry.userAgent : null,
+    deviceId: typeof entry?.deviceId === "string" ? entry.deviceId : null,
+  }) !== null);
+}
+
+function writeStoredWebPushSubscriptions(entries: StoredWebPushSubscription[], baseDir = DEFAULT_PUSH_DIR): void {
+  writeJsonFile(resolveSubscriptionsPath(baseDir), entries);
+}
+
+function getMaxStoredWebPushSubscriptions(): number {
+  return Math.max(
+    1,
+    Number.parseInt(String(process.env.PICLAW_WEB_PUSH_SUBSCRIPTION_CAP || "32"), 10) || 32,
+  );
+}
+
+function capStoredWebPushSubscriptions(entries: StoredWebPushSubscription[]): StoredWebPushSubscription[] {
+  const maxEntries = getMaxStoredWebPushSubscriptions();
+  if (entries.length <= maxEntries) return entries;
+  return entries
+    .slice()
+    .sort((left, right) => {
+      const leftTime = Date.parse(left.updatedAt || left.createdAt || "") || 0;
+      const rightTime = Date.parse(right.updatedAt || right.createdAt || "") || 0;
+      if (rightTime !== leftTime) return rightTime - leftTime;
+      return left.endpoint.localeCompare(right.endpoint);
+    })
+    .slice(0, maxEntries);
+}
+
+export function upsertStoredWebPushSubscription(
+  value: unknown,
+  options: { baseDir?: string; userAgent?: string | null; now?: string; deviceId?: string | null } = {}
+): StoredWebPushSubscription {
+  const normalized = normalizeStoredWebPushSubscription(value, {
+    now: options.now,
+    userAgent: options.userAgent,
+    deviceId: options.deviceId,
+  });
+  if (!normalized) {
+    throw new Error("Invalid push subscription.");
+  }
+
+  const baseDir = options.baseDir || DEFAULT_PUSH_DIR;
+  const entries = listStoredWebPushSubscriptions(baseDir);
+  const endpointIndex = entries.findIndex((entry) => entry.endpoint === normalized.endpoint);
+  const deviceIndex = normalized.deviceId ? entries.findIndex((entry) => entry.deviceId === normalized.deviceId) : -1;
+  const existingIndex = endpointIndex !== -1 ? endpointIndex : deviceIndex;
+  if (existingIndex !== -1) {
+    const existing = entries[existingIndex];
+    const nextEntry = {
+      ...existing,
+      endpoint: normalized.endpoint,
+      expirationTime: normalized.expirationTime,
+      keys: normalized.keys,
+      updatedAt: normalized.updatedAt,
+      userAgent: normalized.userAgent || existing.userAgent || null,
+      deviceId: normalized.deviceId || existing.deviceId || null,
+    };
+    entries[existingIndex] = nextEntry;
+    writeStoredWebPushSubscriptions(capStoredWebPushSubscriptions(entries), baseDir);
+    return nextEntry;
+  }
+
+  entries.push(normalized);
+  writeStoredWebPushSubscriptions(capStoredWebPushSubscriptions(entries), baseDir);
+  return normalized;
+}
+
+export function removeStoredWebPushSubscription(endpoint: string, baseDir = DEFAULT_PUSH_DIR): boolean {
+  const normalizedEndpoint = typeof endpoint === "string" ? endpoint.trim() : "";
+  if (!normalizedEndpoint) return false;
+  const entries = listStoredWebPushSubscriptions(baseDir);
+  const nextEntries = entries.filter((entry) => entry.endpoint !== normalizedEndpoint);
+  if (nextEntries.length === entries.length) return false;
+  writeStoredWebPushSubscriptions(nextEntries, baseDir);
+  return true;
+}

--- a/runtime/test/channels/web/helpers/route-flags.ts
+++ b/runtime/test/channels/web/helpers/route-flags.ts
@@ -21,6 +21,7 @@ export function buildRouteFlags(overrides: Partial<RouteFlags> = {}): RouteFlags
     isManifest: false,
     isFavicon: false,
     isAppleIcon: false,
+    isServiceWorker: false,
     isStaticAsset: false,
     isPublicStatic: false,
     isDocsAsset: false,

--- a/runtime/test/channels/web/http-dispatch-agent.test.ts
+++ b/runtime/test/channels/web/http-dispatch-agent.test.ts
@@ -132,6 +132,29 @@ describe("web http agent dispatch", () => {
     const cardReq = new Request("https://example.com/agent/card-action", { method: "POST" });
     expect((await handleAgentRoutes(channel, cardReq, "/agent/card-action", new URL(cardReq.url)))?.status).toBe(205);
 
+    const vapidReq = new Request("https://example.com/agent/push/vapid-public-key", { method: "GET" });
+    expect((await handleAgentRoutes(channel, vapidReq, "/agent/push/vapid-public-key", new URL(vapidReq.url)))?.status).toBe(200);
+
+    const upsertReq = new Request("https://example.com/agent/push/subscription", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        subscription: {
+          endpoint: "https://push.example.test/device/dispatch",
+          expirationTime: null,
+          keys: { auth: "auth-token", p256dh: "p256dh-token" },
+        },
+      }),
+    });
+    expect((await handleAgentRoutes(channel, upsertReq, "/agent/push/subscription", new URL(upsertReq.url)))?.status).toBe(200);
+
+    const deleteReq = new Request("https://example.com/agent/push/subscription", {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ endpoint: "https://push.example.test/device/dispatch" }),
+    });
+    expect((await handleAgentRoutes(channel, deleteReq, "/agent/push/subscription", new URL(deleteReq.url)))?.status).toBe(200);
+
     const sidePromptReq = new Request("https://example.com/agent/side-prompt", { method: "POST" });
     expect((await handleAgentRoutes(channel, sidePromptReq, "/agent/side-prompt", new URL(sidePromptReq.url)))?.status).toBe(206);
 

--- a/runtime/test/channels/web/http-dispatch-shell.test.ts
+++ b/runtime/test/channels/web/http-dispatch-shell.test.ts
@@ -10,7 +10,7 @@ describe("web http shell dispatch", () => {
     expect(response).toBeNull();
   });
 
-  test("dispatches index/manifest/static/docs/sse/terminal-session/vnc routes", async () => {
+  test("dispatches index/manifest/service-worker/static/docs/sse/terminal-session/vnc routes", async () => {
     const channel = {
       serveStatic: (rel: string) => new Response(`static:${rel}`),
       handleManifest: () => new Response("manifest"),
@@ -28,6 +28,9 @@ describe("web http shell dispatch", () => {
 
     const manifestFlags = buildRouteFlags({ isManifest: true });
     expect(await (await handleShellRoutes(channel, new Request("https://e/manifest.json", { method: "GET" }), "/manifest.json", manifestFlags, async () => new Response()))?.text()).toBe("manifest");
+
+    const serviceWorkerFlags = buildRouteFlags({ isServiceWorker: true });
+    expect(await (await handleShellRoutes(channel, new Request("https://e/sw.js", { method: "GET" }), "/sw.js", serviceWorkerFlags, async () => new Response()))?.text()).toBe("static:sw.js");
 
     expect(await (await handleShellRoutes(channel, new Request("https://e/ghostty-vt.wasm", { method: "GET" }), "/ghostty-vt.wasm", buildRouteFlags(), async () => new Response()))?.text()).toBe("static:js/vendor/ghostty-vt.wasm");
 

--- a/runtime/test/channels/web/route-flags.test.ts
+++ b/runtime/test/channels/web/route-flags.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { getRouteFlags, shouldSkipAuthCheck } from "../../../src/channels/web/http/route-flags.js";
+
+describe("web route flags", () => {
+  test("marks the service worker script as a public shell route", () => {
+    const flags = getRouteFlags(new Request("https://example.com/sw.js", { method: "GET" }), "/sw.js");
+
+    expect(flags.isServiceWorker).toBe(true);
+    expect(flags.isStaticAsset).toBe(false);
+    expect(shouldSkipAuthCheck(flags, false)).toBe(true);
+  });
+});

--- a/runtime/test/channels/web/web-push-routes.test.ts
+++ b/runtime/test/channels/web/web-push-routes.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  handleWebPushSubscriptionDelete,
+  handleWebPushSubscriptionUpsert,
+  handleWebPushVapidPublicKey,
+} from "../../../src/channels/web/push/web-push-routes.js";
+
+const tempDirs: string[] = [];
+
+function createTempPushDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "piclaw-web-push-routes-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("web push routes", () => {
+  test("returns a stored VAPID public key", async () => {
+    const baseDir = createTempPushDir();
+    const response = await handleWebPushVapidPublicKey({ baseDir });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(typeof payload.publicKey).toBe("string");
+    expect(payload.publicKey.length).toBeGreaterThan(0);
+  });
+
+  test("stores and removes subscription device ids", async () => {
+    const baseDir = createTempPushDir();
+    const upsertReq = new Request("https://example.com/agent/push/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "user-agent": "PiClaw Test" },
+      body: JSON.stringify({
+        device_id: "device-1",
+        subscription: {
+          endpoint: "https://push.example.test/device/1",
+          expirationTime: null,
+          keys: {
+            auth: "auth-token",
+            p256dh: "p256dh-token",
+          },
+        },
+      }),
+    });
+
+    const upsertResponse = await handleWebPushSubscriptionUpsert(upsertReq, { baseDir });
+    expect(upsertResponse.status).toBe(200);
+    expect(await upsertResponse.json()).toEqual({ ok: true, device_id: "device-1" });
+
+    const deleteReq = new Request("https://example.com/agent/push/subscription", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ endpoint: "https://push.example.test/device/1" }),
+    });
+    const deleteResponse = await handleWebPushSubscriptionDelete(deleteReq, { baseDir });
+    expect(deleteResponse.status).toBe(200);
+    expect(await deleteResponse.json()).toEqual({ ok: true, removed: true });
+  });
+});

--- a/runtime/test/channels/web/web-push-store.test.ts
+++ b/runtime/test/channels/web/web-push-store.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  ensureStoredVapidKeys,
+  getStoredVapidPublicKey,
+  listStoredWebPushSubscriptions,
+  normalizeStoredWebPushSubscription,
+  removeStoredWebPushSubscription,
+  upsertStoredWebPushSubscription,
+} from "../../../src/channels/web/push/web-push-store.js";
+
+const tempDirs: string[] = [];
+
+function createTempPushDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "piclaw-web-push-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createSubscription(endpoint = "https://push.example.test/device/1", deviceId: string | null = null) {
+  return {
+    endpoint,
+    expirationTime: null,
+    keys: {
+      auth: "auth-token",
+      p256dh: "p256dh-token",
+    },
+    ...(deviceId ? { deviceId } : {}),
+  };
+}
+
+describe("web push store", () => {
+  test("generates and reuses a stored VAPID keypair", () => {
+    const baseDir = createTempPushDir();
+
+    const created = ensureStoredVapidKeys(baseDir);
+    const reread = ensureStoredVapidKeys(baseDir);
+
+    expect(created.publicKey).toBeTruthy();
+    expect(created.privateKeyPem).toContain("BEGIN PRIVATE KEY");
+    expect(created.publicKeyPem).toContain("BEGIN PUBLIC KEY");
+    expect(reread.publicKey).toBe(created.publicKey);
+    expect(getStoredVapidPublicKey(baseDir)).toBe(created.publicKey);
+  });
+
+  test("normalizes valid subscriptions and rejects malformed ones", () => {
+    const normalized = normalizeStoredWebPushSubscription(createSubscription());
+
+    expect(normalized?.endpoint).toBe("https://push.example.test/device/1");
+    expect(normalized?.expirationTime).toBeNull();
+    expect(normalized?.keys).toEqual({
+      auth: "auth-token",
+      p256dh: "p256dh-token",
+    });
+    expect(typeof normalized?.createdAt).toBe("string");
+    expect(typeof normalized?.updatedAt).toBe("string");
+    expect(normalized?.userAgent).toBeNull();
+    expect(normalized?.deviceId).toBeNull();
+
+    expect(normalizeStoredWebPushSubscription({ endpoint: "", keys: {} })).toBeNull();
+    expect(normalizeStoredWebPushSubscription(null)).toBeNull();
+  });
+
+  test("upserts and removes stored subscriptions by endpoint", () => {
+    const baseDir = createTempPushDir();
+
+    const created = upsertStoredWebPushSubscription(createSubscription(), {
+      baseDir,
+      userAgent: "PiClaw Test",
+      now: "2026-04-14T18:50:00.000Z",
+    });
+    const updated = upsertStoredWebPushSubscription(createSubscription(), {
+      baseDir,
+      userAgent: "PiClaw Test 2",
+      now: "2026-04-14T18:55:00.000Z",
+    });
+
+    expect(created.createdAt).toBe("2026-04-14T18:50:00.000Z");
+    expect(updated.createdAt).toBe("2026-04-14T18:50:00.000Z");
+    expect(updated.updatedAt).toBe("2026-04-14T18:55:00.000Z");
+    expect(updated.userAgent).toBe("PiClaw Test 2");
+    expect(listStoredWebPushSubscriptions(baseDir)).toHaveLength(1);
+
+    expect(removeStoredWebPushSubscription(created.endpoint, baseDir)).toBe(true);
+    expect(removeStoredWebPushSubscription(created.endpoint, baseDir)).toBe(false);
+    expect(listStoredWebPushSubscriptions(baseDir)).toHaveLength(0);
+  });
+
+  test("replaces an existing subscription when the same device gets a new endpoint", () => {
+    const baseDir = createTempPushDir();
+
+    upsertStoredWebPushSubscription(createSubscription("https://push.example.test/device/old", "device-1"), {
+      baseDir,
+      userAgent: "PiClaw Test",
+      now: "2026-04-14T19:00:00.000Z",
+    });
+    const updated = upsertStoredWebPushSubscription(createSubscription("https://push.example.test/device/new", "device-1"), {
+      baseDir,
+      userAgent: "PiClaw Test",
+      now: "2026-04-14T19:05:00.000Z",
+      deviceId: "device-1",
+    });
+
+    expect(updated.endpoint).toBe("https://push.example.test/device/new");
+    expect(updated.deviceId).toBe("device-1");
+    expect(listStoredWebPushSubscriptions(baseDir).map((entry) => entry.endpoint)).toEqual([
+      "https://push.example.test/device/new",
+    ]);
+  });
+
+  test("caps the stored subscription list to the newest entries", () => {
+    const baseDir = createTempPushDir();
+    const previousCap = process.env.PICLAW_WEB_PUSH_SUBSCRIPTION_CAP;
+    process.env.PICLAW_WEB_PUSH_SUBSCRIPTION_CAP = "2";
+
+    try {
+      upsertStoredWebPushSubscription(createSubscription("https://push.example.test/device/1", "device-1"), {
+        baseDir,
+        now: "2026-04-14T19:00:00.000Z",
+      });
+      upsertStoredWebPushSubscription(createSubscription("https://push.example.test/device/2", "device-2"), {
+        baseDir,
+        now: "2026-04-14T19:01:00.000Z",
+      });
+      upsertStoredWebPushSubscription(createSubscription("https://push.example.test/device/3", "device-3"), {
+        baseDir,
+        now: "2026-04-14T19:02:00.000Z",
+      });
+
+      expect(listStoredWebPushSubscriptions(baseDir).map((entry) => entry.endpoint)).toEqual([
+        "https://push.example.test/device/3",
+        "https://push.example.test/device/2",
+      ]);
+    } finally {
+      if (previousCap === undefined) delete process.env.PICLAW_WEB_PUSH_SUBSCRIPTION_CAP;
+      else process.env.PICLAW_WEB_PUSH_SUBSCRIPTION_CAP = previousCap;
+    }
+  });
+});

--- a/runtime/test/web/use-notifications.test.ts
+++ b/runtime/test/web/use-notifications.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test';
+
+import {
+  formatNotificationTitle,
+  WEB_PUSH_NOTIFICATION_SOURCE_LABEL,
+} from '../../web/src/ui/use-notifications.js';
+
+test('formatNotificationTitle appends a visible source marker', () => {
+  expect(formatNotificationTitle('PiClaw', WEB_PUSH_NOTIFICATION_SOURCE_LABEL)).toBe('PiClaw [Web Push]');
+});
+
+test('formatNotificationTitle falls back cleanly when no source marker is provided', () => {
+  expect(formatNotificationTitle('Pi', '')).toBe('Pi');
+  expect(formatNotificationTitle('', '')).toBe('PiClaw');
+});

--- a/runtime/web/src/api.ts
+++ b/runtime/web/src/api.ts
@@ -274,6 +274,32 @@ export async function sendPeerAgentMessage(sourceChatJid, targetChatOrName, cont
     });
 }
 
+export async function getWebPushPublicKey() {
+    return request('/agent/push/vapid-public-key');
+}
+
+export async function saveWebPushSubscription(subscription, options = {}) {
+    const payload = {
+        subscription,
+        ...(options?.deviceId ? { device_id: options.deviceId } : {}),
+    };
+    return request('/agent/push/subscription', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function deleteWebPushSubscription(subscription, options = {}) {
+    const payload = {
+        subscription,
+        ...(options?.deviceId ? { device_id: options.deviceId } : {}),
+    };
+    return request('/agent/push/subscription', {
+        method: 'DELETE',
+        body: JSON.stringify(payload),
+    });
+}
+
 /**
  * Get available agents / current agent roster.
  */

--- a/runtime/web/src/ui/app-shell-bootstrap.ts
+++ b/runtime/web/src/ui/app-shell-bootstrap.ts
@@ -26,6 +26,7 @@ interface AppApiSurface {
 
 let initialized = false;
 let browserNoiseFilterInstalled = false;
+let serviceWorkerRegistrationStarted = false;
 
 export function configureMarked(markedInstance: { setOptions?: (options: Record<string, unknown>) => void } | null | undefined): void {
   if (!markedInstance || typeof markedInstance.setOptions !== 'function') return;
@@ -72,6 +73,16 @@ export function registerAppPaneExtensions(): void {
   paneRegistry.register(terminalTabPaneExtension);
 }
 
+export function registerAppServiceWorker(runtimeWindow: (Window & typeof globalThis) | null = typeof window !== 'undefined' ? window : null): void {
+  if (!runtimeWindow || serviceWorkerRegistrationStarted) return;
+  if (!runtimeWindow.isSecureContext) return;
+  if (!("serviceWorker" in runtimeWindow.navigator)) return;
+  serviceWorkerRegistrationStarted = true;
+  void runtimeWindow.navigator.serviceWorker.register('/sw.js').catch((error) => {
+    console.warn('Failed to register app service worker:', error);
+  });
+}
+
 export function initializeAppShellRuntime(): void {
   if (initialized) return;
   const markedInstance = typeof window !== 'undefined'
@@ -80,6 +91,7 @@ export function initializeAppShellRuntime(): void {
   configureMarked(markedInstance);
   installBrowserNoiseFilters(typeof window !== 'undefined' ? window : null);
   registerAppPaneExtensions();
+  registerAppServiceWorker(typeof window !== 'undefined' ? window : null);
   initialized = true;
 }
 

--- a/runtime/web/src/ui/use-notifications.ts
+++ b/runtime/web/src/ui/use-notifications.ts
@@ -1,18 +1,125 @@
+import { deleteWebPushSubscription, getWebPushPublicKey, saveWebPushSubscription } from '../api.js';
 import { useCallback, useEffect, useRef, useState } from '../vendor/preact-htm.js';
 import { getLocalStorageBoolean, setLocalStorageItem } from '../utils/storage.js';
 import { focusWindowBestEffort } from './notification-focus.js';
+
+export const LOCAL_NOTIFICATION_SOURCE_LABEL = 'Local';
+export const WEB_PUSH_NOTIFICATION_SOURCE_LABEL = 'Web Push';
+
+export function formatNotificationTitle(title, sourceLabel = '') {
+  const normalizedTitle = typeof title === 'string' && title.trim() ? title.trim() : 'PiClaw';
+  const normalizedSource = typeof sourceLabel === 'string' ? sourceLabel.trim() : '';
+  return normalizedSource ? `${normalizedTitle} [${normalizedSource}]` : normalizedTitle;
+}
+
+function decodeBase64UrlToUint8Array(value) {
+  const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function supportsWebPush(runtimeWindow = typeof window !== 'undefined' ? window : null) {
+  if (!runtimeWindow || !runtimeWindow.isSecureContext) return false;
+  return 'serviceWorker' in runtimeWindow.navigator && 'PushManager' in runtimeWindow;
+}
+
+async function ensureServiceWorkerReady(runtimeWindow) {
+  await runtimeWindow.navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' });
+  return await runtimeWindow.navigator.serviceWorker.ready;
+}
+
+async function ensureStoredWebPushSubscription(runtimeWindow) {
+  const registration = await ensureServiceWorkerReady(runtimeWindow);
+  const existing = await registration.pushManager.getSubscription();
+  if (existing) return existing;
+  const payload = await getWebPushPublicKey();
+  const publicKey = typeof payload?.publicKey === 'string' ? payload.publicKey.trim() : '';
+  if (!publicKey) {
+    throw new Error('Missing web push public key.');
+  }
+  return registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: decodeBase64UrlToUint8Array(publicKey),
+  });
+}
+
+async function syncWebPushSubscription(runtimeWindow, deviceId) {
+  if (!supportsWebPush(runtimeWindow)) return false;
+  const subscription = await ensureStoredWebPushSubscription(runtimeWindow);
+  await saveWebPushSubscription(subscription.toJSON ? subscription.toJSON() : subscription, { deviceId });
+  return true;
+}
+
+async function disableWebPushSubscription(runtimeWindow, deviceId) {
+  if (!supportsWebPush(runtimeWindow)) return false;
+  const registration = await ensureServiceWorkerReady(runtimeWindow);
+  const subscription = await registration.pushManager.getSubscription();
+  if (!subscription) return false;
+  const serialized = subscription.toJSON ? subscription.toJSON() : subscription;
+  try {
+    await deleteWebPushSubscription(serialized, { deviceId });
+  } catch (error) {
+    console.warn('Failed to remove web push subscription from the server:', error);
+  }
+  try {
+    await subscription.unsubscribe();
+  } catch (error) {
+    console.warn('Failed to unsubscribe from web push notifications:', error);
+  }
+  return true;
+}
+
+function getOrCreateNotificationDeviceId(runtimeWindow = typeof window !== 'undefined' ? window : null) {
+  const storage = runtimeWindow?.localStorage;
+  const existing = typeof storage?.getItem === 'function' ? storage.getItem('piclaw.notifications.deviceId') : null;
+  if (existing) return existing;
+  const created = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? `device-${crypto.randomUUID()}`
+    : `device-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+  try {
+    storage?.setItem?.('piclaw.notifications.deviceId', created);
+  } catch (error) {
+    console.debug('[use-notifications] Ignoring notification device-id persistence failure.', error);
+  }
+  return (typeof storage?.getItem === 'function' ? storage.getItem('piclaw.notifications.deviceId') : null) || created;
+}
 
 export function useNotifications() {
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const [notificationPermission, setNotificationPermission] = useState('default');
   const notificationsEnabledRef = useRef(false);
+  const deviceIdRef = useRef(null);
 
   useEffect(() => {
     const enabled = getLocalStorageBoolean('notificationsEnabled', false);
     notificationsEnabledRef.current = enabled;
     setNotificationsEnabled(enabled);
-    if (typeof Notification !== 'undefined') {
-      setNotificationPermission(Notification.permission);
+    if (typeof window !== 'undefined') {
+      deviceIdRef.current = getOrCreateNotificationDeviceId(window);
+    }
+    if (typeof Notification === 'undefined') {
+      return;
+    }
+
+    const permission = Notification.permission;
+    setNotificationPermission(permission);
+
+    if (permission === 'denied' && enabled) {
+      notificationsEnabledRef.current = false;
+      setNotificationsEnabled(false);
+      setLocalStorageItem('notificationsEnabled', 'false');
+      return;
+    }
+
+    if (permission === 'granted' && enabled && typeof window !== 'undefined' && supportsWebPush(window)) {
+      void syncWebPushSubscription(window, deviceIdRef.current || getOrCreateNotificationDeviceId(window)).catch((error) => {
+        console.warn('Failed to refresh stored web push subscription:', error);
+      });
     }
   }, []);
 
@@ -28,7 +135,8 @@ export function useNotifications() {
         return result;
       }
       return Promise.resolve(result);
-    } catch {
+    } catch (error) {
+      console.debug('[use-notifications] Notification permission request threw; returning default permission state.', error);
       return Promise.resolve('default');
     }
   }, []);
@@ -58,19 +166,40 @@ export function useNotifications() {
     notificationsEnabledRef.current = next;
     setNotificationsEnabled(next);
     setLocalStorageItem('notificationsEnabled', String(next));
+
+    const deviceId = deviceIdRef.current || getOrCreateNotificationDeviceId(window);
+    deviceIdRef.current = deviceId;
+
+    if (supportsWebPush(window)) {
+      try {
+        if (next) {
+          await syncWebPushSubscription(window, deviceId);
+        } else {
+          await disableWebPushSubscription(window, deviceId);
+        }
+      } catch (error) {
+        console.warn('Failed to sync web push notifications:', error);
+        if (next) {
+          alert('Notifications were enabled, but web push setup failed. If you are on iPhone or iPad, reopen PiClaw from the Home Screen and try again.');
+        }
+      }
+    }
   }, [requestNotificationPermission]);
 
-  const notify = useCallback((title, body) => {
+  const notify = useCallback((title, body, options = {}) => {
     if (!notificationsEnabledRef.current) return false;
     if (typeof Notification === 'undefined') return false;
     if (Notification.permission !== 'granted') return false;
     try {
-      const notification = new Notification(title, { body });
+      const notification = new Notification(formatNotificationTitle(title, options?.sourceLabel || ''), { body });
       notification.onclick = () => {
         focusWindowBestEffort(window);
       };
       return true;
-    } catch {
+    } catch (error) {
+      console.debug('[use-notifications] Local notification creation failed.', error, {
+        title: typeof title === 'string' ? title : null,
+      });
       return false;
     }
   }, []);

--- a/runtime/web/static/manifest.json
+++ b/runtime/web/static/manifest.json
@@ -1,4 +1,5 @@
 {
+  "id": "/",
   "name": "PiClaw",
   "short_name": "PiClaw",
   "description": "Slack-like interface for coding agents",

--- a/runtime/web/static/sw.js
+++ b/runtime/web/static/sw.js
@@ -1,0 +1,77 @@
+function formatNotificationTitle(title, sourceLabel) {
+  const normalizedTitle = String(title || '').trim() || 'PiClaw';
+  const normalizedSource = String(sourceLabel || '').trim();
+  return normalizedSource ? `${normalizedTitle} [${normalizedSource}]` : normalizedTitle;
+}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', (event) => {
+  const defaultNotification = {
+    title: 'PiClaw',
+    body: 'You have a new update.',
+    tag: 'piclaw',
+    url: '/',
+    sourceLabel: '',
+  };
+
+  let payload = defaultNotification;
+  try {
+    const next = event.data?.json?.();
+    if (next && typeof next === 'object') {
+      payload = {
+        ...defaultNotification,
+        ...next,
+      };
+    }
+  } catch {
+    const text = event.data?.text?.();
+    if (text) {
+      payload = {
+        ...defaultNotification,
+        body: text,
+      };
+    }
+  }
+
+  event.waitUntil(self.registration.showNotification(formatNotificationTitle(payload.title, payload.sourceLabel), {
+    body: payload.body,
+    tag: payload.tag,
+    data: {
+      url: payload.url || '/',
+    },
+    icon: '/static/icon-192.png',
+    badge: '/static/icon-192.png',
+  }));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = event.notification?.data?.url || '/';
+
+  event.waitUntil((async () => {
+    const clientList = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of clientList) {
+      const clientUrl = client.url || '';
+      if (clientUrl === targetUrl || clientUrl.startsWith(targetUrl) || targetUrl === '/') {
+        if ('focus' in client) {
+          await client.focus();
+        }
+        if ('navigate' in client && targetUrl && clientUrl !== targetUrl) {
+          await client.navigate(targetUrl).catch(() => {});
+        }
+        return;
+      }
+    }
+
+    if (self.clients.openWindow) {
+      await self.clients.openWindow(targetUrl);
+    }
+  })());
+});


### PR DESCRIPTION
## Summary

This extracts the first upstreamable slice from #64: the web-push subscription/VAPID foundation.

## PR chain

This series is split into **4 PRs** and should be reviewed/merged in this order:

1. **#131** — `feat(web): add web-push subscription foundation` **(this PR; PR 1 of 4)**
2. **#134** — `feat(web): add notification presence routing`
3. **#132** — `feat(web): add web-push reply delivery backend`
4. **#133** — `fix(web): finalize web-push delivery behavior`

This PR is the **base** of the series. The other three PRs build conceptually on top of it.

## What this includes

- persistent web-push subscription storage under `$WORKSPACE/.piclaw/web-push/`
- VAPID key generation + `GET /agent/push/vapid-public-key`
- `POST /agent/push/subscription`
- `DELETE /agent/push/subscription`
- service worker plumbing at `/sw.js`
- web client subscription/bootstrap flow in `useNotifications`

## What this intentionally does not include yet

Those are split into the later PRs in the chain above:

- `#134` — per-device / per-chat presence routing
- `#132` — server-side web-push delivery for stored agent replies
- `#133` — hidden-iPhone/PWA fallback tweaks, debug-label gating, and final polish/docs

## Validation

- `git apply --check` for the extracted commit against `upstream/main`
- `bun run typecheck`
- `bun run build`
- `bun run build:web`
- `PICLAW_DB_IN_MEMORY=1 bun test --max-concurrency=1 test/channels/web/http-dispatch-agent.test.ts test/channels/web/http-dispatch-shell.test.ts test/channels/web/route-flags.test.ts test/channels/web/web-push-routes.test.ts test/channels/web/web-push-store.test.ts test/web/use-notifications.test.ts`
- live-host deploy validation on `pix` as part of the tested restacked web-push stack

Supersedes the foundation portion of #64.

Pix (PiClaw, gpt-5.4)
