### PR TITLE
feat(web): visual stop button during active agent turns

### DIFF
--- a/runtime/web/src/components/compose-box.ts
+++ b/runtime/web/src/components/compose-box.ts
@@ -2232,15 +2232,29 @@ export function ComposeBox({
                                 </span>
                             `}
                             ${!searchMode && html`
-                                <button 
-                                    class="icon-btn send-btn" 
-                                    type="button"
-                                    onClick=${() => { void handleSubmit(); }}
-                                    disabled=${!canSend}
-                                    title="Send (Enter)"
-                                >
-                                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>
-                                </button>
+                                ${isAgentActive ? html`
+                                    <button 
+                                        class="icon-btn send-btn abort-mode" 
+                                        type="button"
+                                        style="color: #e05252"
+                                        onClick=${() => { void handleSubmit('/abort', 'steer'); }}
+                                        title="Stop response"
+                                        aria-label="Stop response"
+                                    >
+                                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>
+                                    </button>
+                                ` : html`
+                                    <button 
+                                        class="icon-btn send-btn" 
+                                        type="button"
+                                        onClick=${() => { void handleSubmit(); }}
+                                        disabled=${!canSend}
+                                        title="Send (Enter)"
+                                        aria-label="Send message"
+                                    >
+                                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>
+                                    </button>
+                                `}
                             `}
                         </div>
                     `}

--- a/runtime/web/static/css/chat.css
+++ b/runtime/web/static/css/chat.css
@@ -1348,6 +1348,13 @@
     color: var(--text-secondary);
 }
 
+.send-btn.abort-mode {
+    color: #e05252 !important;
+}
+.send-btn.abort-mode:hover {
+    color: #ff6b6b !important;
+}
+
 .media-files-preview {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary

The send button transforms into a **red stop square** (■) when the agent is actively processing a turn. Clicking it dispatches `/abort` immediately — same as the slash command but discoverable and one-click.

## Problem

Currently, aborting an active agent response requires typing `/abort` in the compose box. This is:

- **Not discoverable** — new users don't know `/abort` exists
- **Awkward** — typing in the compose box during streaming feels ambiguous (interrupting? queuing?)
- **Below industry standard** — ChatGPT, Claude, and Gemini all show a visible stop button

## Implementation

**Path:** Transform send button (industry-standard UX pattern used by ChatGPT, Claude, Gemini).

```
Idle state:    [ ➤ ]  blue send arrow   → onClick=handleSubmit()
Active state:  [ ■ ]  red stop square   → onClick=handleSubmit('/abort', 'steer')
```

### Key details:

- **Signal:** Uses existing `isAgentActive` prop (already computed as `isAgentTurnActive || agentStatus !== null`)
- **Submit mode:** Uses `'steer'` to bypass the queue — abort executes immediately even during active turns, not queued behind the current response
- **Styling:** Inline `color: #e05252` for the stop button; CSS `.abort-mode` class for hover state (`#ff6b6b`)
- **Accessibility:** `aria-label` switches between "Send message" and "Stop response"
- **State lifecycle:**
  1. Agent starts → `isAgentActive` becomes true → button transforms to red ■
  2. User clicks ■ → `/abort` dispatched with `steer` mode → backend processes abort
  3. Backend confirms abort → `isAgentActive` becomes false → button reverts to blue ➤

### Files changed:

| File | Change |
|------|--------|
| `runtime/web/src/components/compose-box.ts` | Conditional render: stop button when `isAgentActive`, send button otherwise |
| `runtime/web/static/css/chat.css` | `.send-btn.abort-mode` red color + hover state |

## Testing

- [x] Idle: blue send arrow, disabled when empty
- [x] Active turn: red stop square appears
- [x] Click stop: agent aborts immediately (not queued)
- [x] After abort confirmed: button reverts to blue send arrow
- [x] Normal completion: button reverts when turn ends
- [x] Accessibility: aria-label changes with state

## Notes

- `/abort` slash command is preserved for power users and TUI
- No confirmation dialog — stop is instant (same as ChatGPT/Claude behavior)
- Button reflects true agent state — stays as ■ until backend confirms abort (1-2s delay is the backend winding down)