### PR TITLE
fix(entrypoint): ensure /workspace/logs exists and is writable by agent

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -419,6 +419,11 @@ if [ -d "/workspace" ] && [ ! -f "/workspace/notes/memory/README.md" ]; then
     fi
 fi
 
+if [ -d "/workspace" ] && [ ! -d "/workspace/logs" ]; then
+    mkdir -p /workspace/logs
+    chown agent:agent /workspace/logs 2>/dev/null || true
+fi
+
 if [ -d "/workspace" ]; then
     sync_workspace_supervisor_defaults \
         "$SUPERVISOR_DEFAULTS_DIR" \


### PR DESCRIPTION

Fixes #455 by creating `/workspace/logs` and chowning it to the `agent` usr before supervisord starts, matching the existing pattern for other workspace subdirectories (`/workspace/notes`, `/workspace/.pi`, etc.).

```bash
if [ -d "/workspace" ] && [ ! -d "/workspace/logs" ]; then
    mkdir -p /workspace/logs
    chown agent:agent /workspace/logs 2>/dev/null || true
fi
```