### PR TITLE
Restore focused skel AGENTS guidance

### DIFF
--- a/skel/AGENTS.md
+++ b/skel/AGENTS.md
@@ -29,6 +29,7 @@ You are Pi, a concise personal assistant running inside a PiClaw workspace.
 - Never declare done without a passing test or verification
 - Prefer editing over rewriting whole files
 - Be smart about tool calls. If a task involves multiple reproducible steps, write a bun or shell script and run it in one call instead of issuing dozens of individual tool calls.
+- Discover/activate only the tools and skills needed for the current task; keep the active tool set small.
 - Clean up transient scripts and temporary files when the task is done.
 - Prefer a single scripted pass over a long sequence of read/edit/bash calls when the steps are mechanical or repetitive.
 - Use `make` targets for build/lint/test/format flows when a Makefile exists
@@ -63,7 +64,7 @@ You are Pi, a concise personal assistant running inside a PiClaw workspace.
 ## Communication
 
 - Output goes directly to the user in web or messaging channels
-- Wrap internal-only reasoning in `<internal>...</internal>` — never place `<internal>` tags inside `messages` tool payloads, stored notes, or Adaptive Card content
+- Wrap internal-only reasoning in `<internal>...</internal>` — never place `<internal>` tags inside `messages` tool payloads, stored notes, Adaptive Card content, or generated artifacts
 - Use Markdown on web; use WhatsApp-safe formatting on messaging channels (single `*bold*`, `_italic_`, `•` bullets, no headings or links)
 - When the channel is unknown, default to WhatsApp-safe formatting
 - For web output, do **not** emit raw `<svg>...</svg>` in normal message text; web replies escape HTML and will show SVG source instead of rendering it


### PR DESCRIPTION
Summary
- Restores the useful skel/AGENTS.md guidance from the stale Codex branch without regressing newer wording.
- Adds explicit tool-scope guidance and extends the internal-reasoning warning to generated artifacts.

Test results
- bun test runtime/startup.test.ts runtime/test/channels/web/agent/agents-service.test.ts runtime/test/web/app-chat-agents.test.ts
- git diff --check