### PR TITLE
test(agent): smoke pi backend path

### DIFF
--- a/runtime/test/agent-pool/pi-backend-smoke.test.ts
+++ b/runtime/test/agent-pool/pi-backend-smoke.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import "../helpers.js";
+
+import type { AgentSessionRuntime } from "@mariozechner/pi-coding-agent";
+
+import { AgentPool } from "../../src/agent-pool.js";
+import { closeDbQuietly } from "../helpers.js";
+import { initDatabase } from "../../src/db.js";
+
+let dbModule: typeof import("../../src/db.js") | null = null;
+
+beforeEach(async () => {
+  dbModule = await import("../../src/db.js");
+  initDatabase();
+});
+
+afterEach(() => {
+  closeDbQuietly(dbModule);
+  dbModule = null;
+});
+
+function createRuntime(session: any): AgentSessionRuntime {
+  return {
+    session,
+    cwd: "/workspace",
+    diagnostics: [],
+    services: {} as any,
+    modelFallbackMessage: undefined,
+    newSession: async () => ({ cancelled: false }),
+    switchSession: async () => ({ cancelled: false }),
+    fork: async () => ({ cancelled: false }),
+    importFromJsonl: async () => ({ cancelled: false }),
+    dispose: async () => session.dispose?.(),
+  } as any;
+}
+
+test("pi backend still routes through the native session prompt path", async () => {
+  const chatJid = "web:pi-backend-smoke";
+
+  class StubSession {
+    prompts: string[] = [];
+    private listeners: Array<(event: any) => void> = [];
+
+    subscribe(listener: (event: any) => void) {
+      this.listeners.push(listener);
+      return () => {
+        this.listeners = this.listeners.filter((candidate) => candidate !== listener);
+      };
+    }
+
+    async prompt(prompt: string) {
+      this.prompts.push(prompt);
+      for (const listener of this.listeners) {
+        listener({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "pi smoke ok" } });
+      }
+    }
+
+    async abort() {}
+    dispose() {}
+  }
+
+  const session = new StubSession();
+  const pool = new AgentPool({ createSession: async () => createRuntime(session) });
+  try {
+    const result = await pool.runAgent("test pi backend", chatJid);
+    expect(result).toMatchObject({ status: "success", result: "pi smoke ok" });
+    expect(session.prompts).toEqual(["test pi backend"]);
+  } finally {
+    await pool.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

Adds a focused smoke test for the existing Pi-backed agent run path.

## What changed

- Adds `runtime/test/agent-pool/pi-backend-smoke.test.ts`.
- Verifies `AgentPool.runAgent()` creates the native session runtime, calls `session.prompt()` with the user prompt, aggregates streamed assistant text, and shuts the session down.

## Why

This gives the current Pi backend a small regression guard before any alternate backend work is proposed. It should be useful on its own because it covers the default agent execution path without introducing new backend abstractions or UI changes.

## Test results

- `bun test runtime/test/agent-pool/pi-backend-smoke.test.ts`
- `bun test runtime/test/agent-pool/agent-pool.test.ts runtime/test/agent-pool/run-agent-orchestrator.test.ts`
- `bun run typecheck`

— Pix (GPT-5.5)

