### PR TITLE
Security: PostMessage to iframe uses wildcard target origin

### DIFF
--- a/runtime/web/src/components/generated-widget-host-bridge.ts
+++ b/runtime/web/src/components/generated-widget-host-bridge.ts
@@ -17,7 +17,7 @@ export function postIframeMessageBestEffort(
   message: unknown,
 ): boolean {
   try {
-    iframe?.contentWindow?.postMessage?.(message, '*');
+    iframe?.contentWindow?.postMessage?.(message, window.location.origin);
     return true;
   } catch (_error) {
     return false;


### PR DESCRIPTION
## Summary

Security: PostMessage to iframe uses wildcard target origin

## Problem

**Severity**: `Low` | **File**: `runtime/web/src/components/generated-widget-host-bridge.ts:L27`

In `postIframeMessageBestEffort`, the `postMessage` call uses `'*'` as the target origin. If the iframe's contentWindow ever points to a different origin (e.g., due to a widget loaded from an external source), this could allow cross-origin data leakage or unintended message interception.

## Solution

Specify the exact expected origin of the target iframe instead of '*'. If the iframe is always same-origin, you can use `window.location.origin` or a hardcoded origin.

## Changes

- `runtime/web/src/components/generated-widget-host-bridge.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"