### PR TITLE
fix: make tool descriptions and hints platform-aware for native installs

### DIFF
--- a/docs/install-from-repo.md
+++ b/docs/install-from-repo.md
@@ -94,3 +94,15 @@ After install, the goal is that:
 - Build, pack, and install commands should be run from the repo root; `runtime/` is not a separate package.
 - If repo-install behavior differs slightly from the published package layout, those differences should stay small and documented.
 - Dream/AutoDream details, file sequence, and outputs are documented in [`runtime/docs/dream-memory.md`](../runtime/docs/dream-memory.md).
+
+## Post-install: update AGENTS.md
+
+The seeded `AGENTS.md` in your workspace describes a Debian Linux container
+environment. On native macOS or Windows installs, update it to reflect your
+actual platform, available tools, and process management. Key lines to change:
+
+- **OS and architecture** — replace the `OS: Debian Linux (container)` line with your actual OS (e.g. `macOS (Apple Silicon, arm64)`)
+- **Available CLI tools** — list the tools actually installed on your host
+- **Package manager** — use `brew install` instead of `sudo apt install` on macOS
+- **Restart behavior** — note that there is no Supervisor on native installs; `exit_process` will terminate piclaw and it must be restarted manually
+- **Workspace path** — replace `/workspace` with your actual `--workspace` directory

--- a/runtime/src/extensions/env-tools.ts
+++ b/runtime/src/extensions/env-tools.ts
@@ -50,7 +50,7 @@ const MANAGED_BLOCK_END = "# <<< piclaw env tool <<<";
 const ENV_TOOL_HINT = [
   "## Workspace environment tool",
   "Use env to manage persistent workspace-scoped environment variables for non-secret configuration.",
-  "env writes a managed block into /workspace/.env.sh, persists the source-of-truth under /workspace/.piclaw/env-tool.json, and updates process.env immediately so later tool calls in the same runtime see the change.",
+  `env writes a managed block into ${getWorkspaceRoot()}/.env.sh, persists the source-of-truth under ${getWorkspaceRoot()}/.piclaw/env-tool.json, and updates process.env immediately so later tool calls in the same runtime see the change.`,
   "Prefer keychain for secrets/tokens/passwords; use env for deliberate persistent config like PATH helpers, config dirs, feature flags, or non-secret API endpoints.",
   "For action=set, values like $NAME or ${NAME} copy the current process environment variable of that name.",
 ].join("\n");
@@ -196,8 +196,8 @@ export const envTools: ExtensionFactory = (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "env",
     label: "env",
-    description: "Get, set, or clear persistent workspace-scoped environment variables. Writes a managed block into /workspace/.env.sh, persists state under /workspace/.piclaw/env-tool.json, updates process.env immediately for later tool calls, and supports copying existing vars via $NAME on set. Prefer keychain for secrets.",
-    promptSnippet: "env: get/set/clear persistent workspace-scoped environment variables in /workspace/.env.sh (use $NAME to copy an existing env var; prefer keychain for secrets).",
+    description: `Get, set, or clear persistent workspace-scoped environment variables. Writes a managed block into ${getWorkspaceRoot()}/.env.sh, persists state under ${getWorkspaceRoot()}/.piclaw/env-tool.json, updates process.env immediately for later tool calls, and supports copying existing vars via $NAME on set. Prefer keychain for secrets.`,
+    promptSnippet: `env: get/set/clear persistent workspace-scoped environment variables in ${getWorkspaceRoot()}/.env.sh (use $NAME to copy an existing env var; prefer keychain for secrets).`,
     parameters: ENV_TOOL_SCHEMA,
     async execute(_toolCallId, params: EnvToolParams): Promise<AgentToolResult<EnvToolDetails>> {
       const current = loadManagedEnv();

--- a/runtime/src/extensions/exit-process.ts
+++ b/runtime/src/extensions/exit-process.ts
@@ -22,6 +22,11 @@ import { getActiveSessionCount } from "./session-status.js";
 
 const log = createLogger("extensions.exit-process");
 
+const IS_SUPERVISED = Boolean(process.env.SUPERVISOR_ENABLED);
+const RESTART_HINT = IS_SUPERVISED
+  ? "Supervisor will restart it automatically."
+  : "The process will exit; restart it manually or via your service manager.";
+
 const ExitProcessSchema = Type.Object({
   reason: Type.Optional(Type.String({ description: "Human-readable reason for the exit (logged, not required)." })),
 });
@@ -33,7 +38,7 @@ type ExitProcessParams = {
 const HINT = [
   "## Process exit",
   "Use exit_process to gracefully terminate the running piclaw process after your current turn completes.",
-  "Supervisor will restart it automatically. Call this as the LAST tool in a turn after deploying new code.",
+  `${RESTART_HINT} Call this as the LAST tool in a turn after deploying new code.`,
   "Do NOT call exit_process in the middle of a multi-step turn — only when you are done and ready to restart.",
 ].join("\n");
 
@@ -45,8 +50,8 @@ export const exitProcess: ExtensionFactory = (pi: ExtensionAPI) => {
   pi.registerTool({
     name: "exit_process",
     label: "exit_process",
-    description: "Gracefully terminate piclaw (drain queue, persist sessions, stop services) so Supervisor restarts it. Call as the LAST tool in a turn after deploying new code.",
-    promptSnippet: "exit_process: gracefully terminate piclaw so supervisor restarts it with new code. Call LAST in a turn.",
+    description: `Gracefully terminate piclaw (drain queue, persist sessions, stop services). ${RESTART_HINT} Call as the LAST tool in a turn after deploying new code.`,
+    promptSnippet: `exit_process: gracefully terminate piclaw. ${RESTART_HINT} Call LAST in a turn.`,
     parameters: ExitProcessSchema,
     async execute(_toolCallId, params: ExitProcessParams) {
       const reason = params.reason?.trim() || "Agent-initiated restart";
@@ -66,7 +71,7 @@ export const exitProcess: ExtensionFactory = (pi: ExtensionAPI) => {
       markPendingShutdown(reason);
 
       return {
-        content: [{ type: "text", text: `Graceful shutdown scheduled.${activeWarning} ${killed} subprocess${killed === 1 ? "" : 'es'} killed. Supervisor will restart piclaw. Reason: ${reason}` }],
+        content: [{ type: "text", text: `Graceful shutdown scheduled.${activeWarning} ${killed} subprocess${killed === 1 ? "" : 'es'} killed. ${RESTART_HINT} Reason: ${reason}` }],
         details: {
           tool: "exit_process",
           scheduled: true,

--- a/runtime/src/extensions/file-attachments.ts
+++ b/runtime/src/extensions/file-attachments.ts
@@ -310,7 +310,7 @@ const ATTACHMENT_HINT = [
   "to look for the download card below your message.",
   "Use attachment:<id> when you want to reference an uploaded attachment by id.",
   "Use read_attachment to load an attachment by id (auto/text/image/base64 modes).",
-  "Use export_attachment to save an attachment into /workspace/tmp for shell tools.",
+  `Use export_attachment to save an attachment into ${WORKSPACE_DIR}/tmp for shell tools.`,
 ].join("\n");
 
 // ── Factory ───────────────────────────────────────────────
@@ -449,8 +449,8 @@ export function createFileAttachmentsExtension(registry: AttachmentRegistry = ge
     pi.registerTool({
       name: "export_attachment",
       label: "export_attachment",
-      description: "Export an attachment by id to /workspace/tmp for shell tools.",
-      promptSnippet: "export_attachment: write attachment content to /workspace/tmp and return the file path.",
+      description: `Export an attachment by id to ${WORKSPACE_DIR}/tmp for shell tools.`,
+      promptSnippet: `export_attachment: write attachment content to ${WORKSPACE_DIR}/tmp and return the file path.`,
       parameters: ExportAttachmentSchema,
       execute: executeExportAttachment,
     });

--- a/runtime/src/extensions/internal-tools.ts
+++ b/runtime/src/extensions/internal-tools.ts
@@ -515,7 +515,7 @@ const HINT = [
   "- Prefer editing over rewriting whole files.",
   "- Keep output direct, concise, and specific. Lead with findings.",
   "- Attach generated files to the chat with attach_file instead of only naming paths.",
-  "- Prefer Bun scripts over Python/uv. Use `brew install` for system tools, `sudo apt install` for system-level dependencies.",
+  `- Prefer Bun scripts over Python/uv. ${process.platform === "linux" ? "Use \\`brew install\\` for system tools, \\`sudo apt install\\` for system-level dependencies." : "Use \\`brew install\\` for system tools."}`,
   "- Keychain entries are auto-injected as $ENV_VARS into bash (names with `/`, `-`, `.` become `_` and uppercase). Never fetch secrets and inline them.",
 ].join("\n");
 

--- a/supervisor/conf.d/piclaw.conf
+++ b/supervisor/conf.d/piclaw.conf
@@ -17,4 +17,4 @@ stopasgroup=true
 killasgroup=true
 stdout_logfile=/var/log/piclaw/piclaw.stdout.log
 stderr_logfile=/var/log/piclaw/piclaw.stderr.log
-environment=HOME="/home/agent",BUN_INSTALL="/usr/local/lib/bun",PATH="/usr/local/lib/bun/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",PICLAW_WEB_TERMINAL_ENABLED="1"
+environment=HOME="/home/agent",BUN_INSTALL="/usr/local/lib/bun",PATH="/usr/local/lib/bun/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",PICLAW_WEB_TERMINAL_ENABLED="1",SUPERVISOR_ENABLED="1"


### PR DESCRIPTION
## Problem

Tool descriptions, system prompt hints, and result text hardcode Linux/container assumptions that mislead the agent on native (non-Docker) installs:

- `exit_process` tells the agent "Supervisor will restart it" — on native installs there is no supervisor, so the agent doesn't warn the user to restart manually
- `env` and `export_attachment` tool descriptions reference `/workspace/` paths — on native installs the workspace is wherever `--workspace` points
- `internal-tools` baseline hint says `sudo apt install` — which doesn't exist on macOS
- `docs/install-from-repo.md` doesn't mention updating `AGENTS.md` for the host platform

## Changes

| File | Change |
|---|---|
| `runtime/src/extensions/exit-process.ts` | Conditional on `SUPERVISOR_ENABLED` env var — says "restart manually" when absent |
| `runtime/src/extensions/env-tools.ts` | Use `getWorkspaceRoot()` in hint/description/promptSnippet instead of hardcoded `/workspace/` |
| `runtime/src/extensions/file-attachments.ts` | Use `WORKSPACE_DIR` (already imported) in hint/description/promptSnippet |
| `runtime/src/extensions/internal-tools.ts` | Platform-conditional: omit `apt install` on non-Linux |
| `supervisor/conf.d/piclaw.conf` | Set `SUPERVISOR_ENABLED=1` so container deployments keep the auto-restart message |
| `docs/install-from-repo.md` | Add "Post-install: update AGENTS.md" section |

**6 files, +29 −12 lines. No new files. No runtime behavior changes — only agent-facing text.**

## Why this matters

On native macOS installs the agent:
1. Calls `exit_process` thinking supervisor auto-restarts — doesn't tell the user to restart manually
2. References `/workspace/.env.sh` in responses when the actual path is e.g. `~/piclaw/workspace/.env.sh`
3. May suggest `sudo apt install` for missing tools instead of `brew install`

## Design choice

`exit_process` uses `SUPERVISOR_ENABLED` env var (not `process.platform`) because platform doesn't determine process management — someone could run supervisor on macOS or skip it on Linux. The supervisor conf sets `SUPERVISOR_ENABLED=1` so existing Docker deployments are unaffected.

## Testing

- `bun run typecheck` — passes
- All 32 extension tests pass (`env-tools`, `internal-tools`, `attachments`)
- 18 pre-existing test failures in `session-manager.test.ts` (unrelated — they fail on clean main because `mkdir '/workspace'` is not possible on macOS)