### PR TITLE
Add customizable shell surface registry

### DIFF
--- a/.pi/skills/pi-workers-orchestration/SKILL.md
+++ b/.pi/skills/pi-workers-orchestration/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pi-workers-orchestration
+description: Use when orchestrating pi-workers, especially while waiting for worker results, deciding whether to spawn additional investigators/workers, handling waiting interactive planners, or synthesizing worker outputs before implementation.
+---
+
+# pi-workers orchestration
+
+Use this protocol when coordinating pi-workers from a parent agent session.
+
+## Protocol
+
+- Use `crew_list` before `crew_spawn` to understand current workers and avoid duplicate assignments.
+- Prefer investigators, scouts, or a planner before implementation when context is broad, ambiguous, or likely to pollute the parent context window.
+- Do not poll `crew_list` for completion. Worker results arrive as steering messages.
+- While workers are running, do not duplicate their assigned task in the parent unless the scope changes or the worker is aborted.
+- If a worker is waiting for response, read its draft/output, then respond with precise constraints, answer the blocking question, or mark it done with `crew_done` when complete.
+- Once results arrive, synthesize them in the parent session. Use a planner if the findings need to become a deterministic implementation spec.
+- For implementation work, spawn workers with strict file ownership, acceptance criteria, verification commands, and explicit instructions about what not to edit.
+- Use worktrees and branches according to the target repository policy when implementing in git repos.
+- If workers become obsolete because scope changed, a better result arrived, or implementation moved elsewhere, abort them instead of leaving them running.
+
+## Good worker prompt example
+
+```text
+Investigate how authentication settings are loaded and propose the minimal implementation plan.
+
+Scope:
+- Read only files under runtime/auth/ and tests/auth/.
+- Do not edit files.
+- Identify existing helpers to reuse.
+
+Output:
+- Relevant files and current flow.
+- One recommended implementation approach.
+- Risks or unknowns.
+- Suggested verification commands.
+
+Do not:
+- Implement changes.
+- Modify application code.
+- Broaden into unrelated settings or UI work.
+```

--- a/runtime/test/web/addon-web-extensions.test.ts
+++ b/runtime/test/web/addon-web-extensions.test.ts
@@ -6,14 +6,17 @@ import {
   buildAddonAttachmentPreviewFrameUrl,
   createAddonWebApi,
   getAddonAttachmentPreviewNote,
+  installAddonWebApi,
   registerAddonAttachmentPreview,
   registerAddonPane,
   registerAddonSettingsPane,
+  registerAddonShellSurface,
   registerAddonStandaloneTabUrlResolver,
   resolveAddonStandaloneTabUrl,
   resetAddonWebRegistriesForTests,
 } from '../../web/src/ui/addon-web-extensions.ts';
 import { getRegisteredSettingsPanes } from '../../web/src/components/settings/pane-registry.js';
+import { getShellSurface, listShellSurfaces, renderShellSlot } from '../../web/src/ui/shell-surface-registry.js';
 
 afterEach(() => {
   resetAddonWebRegistriesForTests();
@@ -82,4 +85,80 @@ test('addon web registries support workspace panes, settings panes, standalone U
   expect(getAttachmentPreviewLabel('example-preview')).toBe('Example add-on preview');
   expect(buildAddonAttachmentPreviewFrameUrl('example-preview', 7, 'sample.example')).toContain('/example-addon/view?media=7');
   expect(getAddonAttachmentPreviewNote('example-preview')).toContain('Example add-on preview note.');
+});
+
+test('addon shell surfaces register only additive allowlisted slots with safe defaults', () => {
+  registerAddonShellSurface({
+    id: 'example.shell.surface',
+    slot: 'timeline.above',
+    label: 'Example shell surface',
+    render: () => 'example surface',
+  });
+
+  expect(getShellSurface('example.shell.surface')).toMatchObject({
+    id: 'example.shell.surface',
+    slot: 'timeline.above',
+    label: 'Example shell surface',
+    owner: 'addon',
+    kind: 'additive',
+    order: 300,
+    defaultVisible: true,
+  });
+  expect(renderShellSlot('timeline.above')).toEqual(['example surface']);
+});
+
+test('addon shell surfaces allow configured additive slots and explicit visibility/order', () => {
+  registerAddonShellSurface({
+    id: 'example.quick.action',
+    slot: 'timeline.quick-actions',
+    order: 250,
+    defaultVisible: false,
+    render: () => 'quick action',
+  });
+
+  expect(listShellSurfaces('timeline.quick-actions')).toEqual([
+    expect.objectContaining({
+      id: 'example.quick.action',
+      label: 'example.quick.action',
+      owner: 'addon',
+      kind: 'additive',
+      order: 250,
+      visible: false,
+    }),
+  ]);
+  expect(renderShellSlot('timeline.quick-actions')).toEqual([]);
+});
+
+test('addon shell surfaces reject required, special, core, piclaw-owned, empty, and missing-render definitions', () => {
+  expect(() => registerAddonShellSurface({ id: '', slot: 'timeline.above', render: () => null })).toThrow('id must be a non-empty string');
+  expect(() => registerAddonShellSurface({ id: 'piclaw.addon.fake', slot: 'timeline.above', render: () => null })).toThrow('must not start with piclaw');
+  expect(() => registerAddonShellSurface({ id: 'example.required', slot: 'timeline.above', kind: 'required', render: () => null })).toThrow('must be additive');
+  expect(() => registerAddonShellSurface({ id: 'example.configurable', slot: 'timeline.above', kind: 'configurable', render: () => null })).toThrow('must be additive');
+  expect(() => registerAddonShellSurface({ id: 'example.core', slot: 'timeline.above', owner: 'core', render: () => null })).toThrow('cannot use owner core');
+  expect(() => registerAddonShellSurface({ id: 'example.core.slot', slot: 'timeline.core' as any, render: () => null })).toThrow('slot is not allowed');
+  expect(() => registerAddonShellSurface({ id: 'example.special.slot', slot: 'app.modal' as any, render: () => null })).toThrow('slot is not allowed');
+  expect(() => registerAddonShellSurface({ id: 'example.missing.render', slot: 'timeline.above' })).toThrow('render must be a function');
+});
+
+test('addon shell surface disposer and reset cleanup remove registered surfaces', () => {
+  const dispose = registerAddonShellSurface({ id: 'example.disposable', slot: 'compose.before', render: () => 'dispose me' });
+  expect(getShellSurface('example.disposable')).toBeTruthy();
+
+  dispose();
+  expect(getShellSurface('example.disposable')).toBeUndefined();
+
+  registerAddonShellSurface({ id: 'example.reset', slot: 'compose.after', render: () => 'reset me' });
+  resetAddonWebRegistriesForTests();
+  expect(getShellSurface('example.reset')).toBeUndefined();
+});
+
+test('addon web API exposes registerShellSurface globally', () => {
+  const runtimeWindow = {} as any;
+  const api = createAddonWebApi(runtimeWindow);
+  expect(api.registerShellSurface).toBe(registerAddonShellSurface);
+
+  const installedApi = installAddonWebApi(runtimeWindow);
+  expect(installedApi.registerShellSurface).toBe(registerAddonShellSurface);
+  expect(runtimeWindow.__piclaw_web.registerShellSurface).toBe(registerAddonShellSurface);
+  expect(runtimeWindow.__piclaw_registerShellSurface).toBe(registerAddonShellSurface);
 });

--- a/runtime/test/web/app-main-shell-render.test.ts
+++ b/runtime/test/web/app-main-shell-render.test.ts
@@ -1,6 +1,22 @@
-import { expect, mock, test } from 'bun:test';
+import { beforeEach, expect, mock, test } from 'bun:test';
 
+import { html } from '../../web/src/vendor/preact-htm.js';
+import { AgentRequestModal, AgentStatus } from '../../web/src/components/status.js';
 import { ComposeBox, QueuedFollowupStack } from '../../web/src/components/compose-box.js';
+import { SettingsDialogLoader } from '../../web/src/components/settings-dialog-loader.js';
+import { SystemMetersHud } from '../../web/src/components/system-meters-hud.js';
+import { TabStrip } from '../../web/src/components/tab-strip.js';
+import { Timeline } from '../../web/src/components/timeline.js';
+import { TimelineMenu } from '../../web/src/components/timeline-menu.js';
+import { TimelineQuickActions } from '../../web/src/components/timeline-quick-actions.js';
+import { WorkspaceExplorer } from '../../web/src/components/workspace-explorer.js';
+import { registerAppShellSurfaces } from '../../web/src/ui/app-shell-builtins.js';
+import {
+  listShellSurfaces,
+  registerShellSurface,
+  resetShellSurfaceRegistryForTests,
+  setShellSurfaceVisible,
+} from '../../web/src/ui/shell-surface-registry.js';
 import {
   buildMainShellClassName,
   extractPostedUserMessageId,
@@ -8,6 +24,35 @@ import {
   renderMainShell,
   scrollToPostedTimelineMessage,
 } from '../../web/src/ui/app-main-shell-render.js';
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.has(key) ? values.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+beforeEach(() => {
+  resetShellSurfaceRegistryForTests();
+  globalThis.localStorage = createMemoryStorage();
+});
 
 test('buildMainShellClassName composes workspace/editor/chat/zen modifiers', () => {
   expect(buildMainShellClassName({
@@ -61,17 +106,33 @@ test('handleComposePost falls back to scrolling to the bottom when there is no p
   expect(scrollPostedMessage).not.toHaveBeenCalled();
 });
 
-function walkVNodes(node: any, visit: (entry: any) => void) {
+function walkVNodes(node: any, visit: (entry: any, parent: any | null) => void, parent: any | null = null) {
   if (!node) return;
   if (Array.isArray(node)) {
-    for (const child of node) walkVNodes(child, visit);
+    for (const child of node) walkVNodes(child, visit, parent);
     return;
   }
   if (typeof node !== 'object') return;
   if (!('type' in node) || !('props' in node)) return;
 
-  visit(node);
-  walkVNodes((node as any).props?.children, visit);
+  visit(node, parent);
+  walkVNodes((node as any).props?.children, visit, node);
+}
+
+function findVNode(tree: any, type: any): { node: any; parent: any | null } | null {
+  let match: { node: any; parent: any | null } | null = null;
+  walkVNodes(tree, (node, parent) => {
+    if (!match && node.type === type) match = { node, parent };
+  });
+  return match;
+}
+
+function findVNodeByClass(tree: any, className: string): { node: any; parent: any | null } | null {
+  let match: { node: any; parent: any | null } | null = null;
+  walkVNodes(tree, (node, parent) => {
+    if (!match && node.props?.class === className) match = { node, parent };
+  });
+  return match;
 }
 
 function createMainShellRenderOptions(overrides: Record<string, unknown> = {}) {
@@ -243,6 +304,89 @@ function createMainShellRenderOptions(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+test('renderMainShell registers built-in shell surfaces idempotently', () => {
+  registerAppShellSurfaces();
+  registerAppShellSurfaces();
+
+  const ids = listShellSurfaces().map((surface) => surface.id);
+  expect(ids.filter((id) => id === 'piclaw.timeline-core')).toHaveLength(1);
+  expect(ids.filter((id) => id === 'piclaw.compose-box')).toHaveLength(1);
+  expect(ids).toContain('piclaw.system-meters-hud');
+  expect(ids).toContain('piclaw.agent-request-modal');
+});
+
+test('renderMainShell renders default built-in surfaces in the existing shell containers', () => {
+  const tree = renderMainShell(createMainShellRenderOptions({
+    chatOnlyMode: false,
+    workspaceOpen: true,
+    editorOpen: true,
+    showEditorPaneContainer: true,
+    hasDockPanes: true,
+    dockVisible: true,
+  }));
+
+  const systemMeters = findVNode(tree, SystemMetersHud);
+  const workspaceExplorer = findVNode(tree, WorkspaceExplorer);
+  const tabStrip = findVNode(tree, TabStrip);
+  const timelineMenu = findVNode(tree, TimelineMenu);
+  const timelineQuickActions = findVNode(tree, TimelineQuickActions);
+  const timeline = findVNode(tree, Timeline);
+  const agentStatus = findVNode(tree, AgentStatus);
+  const settingsLoader = findVNode(tree, SettingsDialogLoader);
+  const composeBox = findVNode(tree, ComposeBox);
+  const agentRequestModal = findVNode(tree, AgentRequestModal);
+
+  expect(systemMeters?.parent?.props.class).toBe('app-shell editor-open');
+  expect(workspaceExplorer?.parent?.props.class).toBe('app-shell editor-open');
+  expect(tabStrip?.parent?.props.class).toBe('editor-pane-container');
+  expect(timelineMenu?.parent?.props.class).toBe('app-shell editor-open');
+  expect(timelineQuickActions?.parent?.props.class).toBe('app-shell editor-open');
+  expect(timeline?.parent?.props.class).toBe('container');
+  expect(agentStatus?.parent?.props.class).toBe('container');
+  expect(settingsLoader?.parent?.props.class).toBe('container');
+  expect(composeBox?.parent?.props.class).toBe('container');
+  expect(agentRequestModal?.parent?.props.class).toBe('container');
+});
+
+test('renderMainShell renders additive shell slots inside the existing container', () => {
+  registerShellSurface({
+    id: 'addon.timeline-above',
+    slot: 'timeline.above',
+    label: 'Timeline Above',
+    owner: 'addon',
+    kind: 'additive',
+    order: 300,
+    defaultVisible: true,
+    render: () => html`<div class="addon-timeline-above">above</div>`,
+  });
+  registerShellSurface({
+    id: 'addon.compose-after',
+    slot: 'compose.after',
+    label: 'Compose After',
+    owner: 'addon',
+    kind: 'additive',
+    order: 300,
+    defaultVisible: true,
+    render: () => html`<div class="addon-compose-after">after</div>`,
+  });
+
+  const tree = renderMainShell(createMainShellRenderOptions());
+
+  expect(findVNodeByClass(tree, 'addon-timeline-above')?.parent?.props.class).toBe('container');
+  expect(findVNodeByClass(tree, 'addon-compose-after')?.parent?.props.class).toBe('container');
+});
+
+test('configurable built-in visibility can hide surfaces while required surfaces remain', () => {
+  registerAppShellSurfaces();
+  setShellSurfaceVisible('piclaw.timeline-menu', false);
+  setShellSurfaceVisible('piclaw.timeline-core', false);
+
+  const tree = renderMainShell(createMainShellRenderOptions());
+
+  expect(findVNode(tree, TimelineMenu)).toBeNull();
+  expect(findVNode(tree, Timeline)).toBeTruthy();
+});
 
 test('renderMainShell passes queue controls to ComposeBox and does not render a top-level queue stack', () => {
   const followupQueueItems = [{ row_id: 7, content: 'queued item' }];

--- a/runtime/test/web/app-shell-bootstrap.test.ts
+++ b/runtime/test/web/app-shell-bootstrap.test.ts
@@ -2,11 +2,14 @@ import { afterEach, expect, test } from 'bun:test';
 
 import { paneRegistry } from '../../web/src/panes/pane-registry.js';
 import { registerAppPaneExtensions } from '../../web/src/ui/app-shell-bootstrap.js';
+import { registerAppShellSurfaces } from '../../web/src/ui/app-shell-builtins.js';
+import { listShellSurfaces, resetShellSurfaceRegistryForTests } from '../../web/src/ui/shell-surface-registry.js';
 
 const registeredByTest = new Set<string>();
 let previousKanbanExtension: any = null;
 
 afterEach(() => {
+  resetShellSurfaceRegistryForTests();
   for (const id of registeredByTest) paneRegistry.unregister(id);
   registeredByTest.clear();
   if (previousKanbanExtension) {
@@ -26,4 +29,11 @@ test('registerAppPaneExtensions does not register addon-owned kanban/mindmap pan
   expect(paneRegistry.get('editor')).toBeTruthy();
   expect(paneRegistry.get('mindmap-editor')).toBeUndefined();
   expect(paneRegistry.get('kanban-editor')).toBeUndefined();
+});
+
+test('registerAppShellSurfaces is idempotent and does not create addon-owned surfaces', () => {
+  registerAppShellSurfaces();
+  registerAppShellSurfaces();
+
+  expect(listShellSurfaces().filter((surface) => surface.owner === 'addon')).toEqual([]);
 });

--- a/runtime/test/web/settings-widget-fixture.test.ts
+++ b/runtime/test/web/settings-widget-fixture.test.ts
@@ -15,10 +15,12 @@ test("build:web includes the settings widget fixture entrypoint", () => {
   expect(packageJson).toContain('web/src/dev/settings-widget-fixture.ts');
 });
 
-test("settings dialog renders the recordings section after lazy loading", () => {
+test("settings dialog renders lazy built-in sections", () => {
   const source = readFileSync(join(repoRoot, "web/src/components/settings-dialog.ts"), "utf8");
   expect(source).toContain("recordings: () => import('./settings/recordings.js').then(mod => mod.RecordingsSection)");
   expect(source).toContain("case 'recordings': return html`<${Comp} filter=${filter} setStatus=${setStatus} />`;");
+  expect(source).toContain("shell: () => import('./settings/shell.js').then(mod => mod.ShellSection)");
+  expect(source).toContain("case 'shell': return html`<${Comp} filter=${filter} setStatus=${setStatus} />`;");
 });
 
 test("settings widget fixture HTML helper emits a dashboard-widget iframe shell", async () => {

--- a/runtime/test/web/shell-settings.test.ts
+++ b/runtime/test/web/shell-settings.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { h, render } from '../../web/src/vendor/preact-htm.js';
+import {
+  registerShellSurface,
+  resetShellSurfaceRegistryForTests,
+  setShellSurfaceGeometry,
+  setShellSurfaceVisible,
+} from '../../web/src/ui/shell-surface-registry.js';
+import { ShellSection } from '../../web/src/components/settings/shell.js';
+
+class MemoryStorage {
+  store = new Map<string, string>();
+
+  get length() { return this.store.size; }
+  key(index: number) { return Array.from(this.store.keys())[index] || null; }
+  getItem(key: string) { return this.store.has(key) ? this.store.get(key)! : null; }
+  setItem(key: string, value: string) { this.store.set(key, String(value)); }
+  removeItem(key: string) { this.store.delete(key); }
+  clear() { this.store.clear(); }
+}
+
+class FakeNode {
+  parentNode: FakeElement | null = null;
+  ownerDocument: FakeDocument;
+  namespaceURI: string;
+  nodeType: number;
+
+  constructor(ownerDocument: FakeDocument, nodeType: number, namespaceURI = 'http://www.w3.org/1999/xhtml') {
+    this.ownerDocument = ownerDocument;
+    this.nodeType = nodeType;
+    this.namespaceURI = namespaceURI;
+  }
+
+  get nextSibling(): FakeNode | null {
+    const parent = this.parentNode;
+    if (!parent) return null;
+    const index = parent.childNodes.indexOf(this);
+    return parent.childNodes[index + 1] || null;
+  }
+}
+
+class FakeTextNode extends FakeNode {
+  data: string;
+  constructor(ownerDocument: FakeDocument, text: string) {
+    super(ownerDocument, 3);
+    this.data = text;
+  }
+}
+
+class FakeElement extends FakeNode {
+  tagName: string;
+  localName: string;
+  childNodes: FakeNode[] = [];
+  attributes: Array<{ name: string; value: string }> = [];
+  style = { cssText: '', setProperty: () => {}, removeProperty: () => {} };
+  listeners = new Map<string, Array<(event: any) => void>>();
+  checked = false;
+  disabled = false;
+  id = '';
+  value = '';
+  type = '';
+  l?: Record<string, unknown>;
+
+  constructor(ownerDocument: FakeDocument, tagName: string, namespaceURI = 'http://www.w3.org/1999/xhtml') {
+    super(ownerDocument, 1, namespaceURI);
+    this.tagName = tagName.toUpperCase();
+    this.localName = tagName.toLowerCase();
+  }
+
+  get firstChild(): FakeNode | null { return this.childNodes[0] || null; }
+
+  appendChild(child: FakeNode): FakeNode { return this.insertBefore(child, null); }
+
+  insertBefore(child: FakeNode, referenceNode: FakeNode | null): FakeNode {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    child.parentNode = this;
+    const index = referenceNode ? this.childNodes.indexOf(referenceNode) : -1;
+    if (index >= 0) this.childNodes.splice(index, 0, child);
+    else this.childNodes.push(child);
+    return child;
+  }
+
+  removeChild(child: FakeNode): FakeNode {
+    const index = this.childNodes.indexOf(child);
+    if (index >= 0) {
+      this.childNodes.splice(index, 1);
+      child.parentNode = null;
+    }
+    return child;
+  }
+
+  setAttribute(name: string, value: string) {
+    const stringValue = String(value);
+    if (name === 'id') this.id = stringValue;
+    if (name === 'type') this.type = stringValue;
+    const existing = this.attributes.find((entry) => entry.name === name);
+    if (existing) existing.value = stringValue;
+    else this.attributes.push({ name, value: stringValue });
+  }
+
+  removeAttribute(name: string) {
+    if (name === 'id') this.id = '';
+    this.attributes = this.attributes.filter((entry) => entry.name !== name);
+  }
+
+  addEventListener(type: string, listener: (event: any) => void) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: any) => void) {
+    this.listeners.set(type, (this.listeners.get(type) || []).filter((entry) => entry !== listener));
+  }
+
+  dispatchEvent(event: any) {
+    event.target ||= this;
+    event.currentTarget = this;
+    for (const listener of this.listeners.get(event.type) || []) listener.call(this, event);
+    return true;
+  }
+}
+
+class FakeDocument {
+  body: FakeElement;
+  documentElement: FakeElement;
+
+  constructor() {
+    this.documentElement = new FakeElement(this, 'html');
+    this.body = new FakeElement(this, 'body');
+    this.documentElement.appendChild(this.body);
+  }
+
+  createElement(tagName: string): FakeElement { return new FakeElement(this, tagName); }
+  createElementNS(namespaceURI: string, tagName: string): FakeElement { return new FakeElement(this, tagName, namespaceURI); }
+  createTextNode(text: string): FakeTextNode { return new FakeTextNode(this, text); }
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+const originalWindow = (globalThis as any).window;
+const originalDocument = (globalThis as any).document;
+const originalElement = (globalThis as any).Element;
+const originalLocalStorage = (globalThis as any).localStorage;
+
+function installDom() {
+  const document = new FakeDocument();
+  const localStorage = new MemoryStorage();
+  (globalThis as any).document = document;
+  (globalThis as any).window = {
+    document,
+    localStorage,
+    dispatchEvent: () => true,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  (globalThis as any).Element = FakeElement;
+  (globalThis as any).localStorage = localStorage;
+  return { document, localStorage };
+}
+
+function collectText(node: FakeNode | null): string {
+  if (!node) return '';
+  if (node instanceof FakeTextNode) return node.data;
+  if (!(node instanceof FakeElement)) return '';
+  return node.childNodes.map((child) => collectText(child)).join('');
+}
+
+function findElements(node: FakeNode | null, predicate: (node: FakeElement) => boolean): FakeElement[] {
+  if (!node || !(node instanceof FakeElement)) return [];
+  const matches = predicate(node) ? [node] : [];
+  return [...matches, ...node.childNodes.flatMap((child) => findElements(child, predicate))];
+}
+
+function registerTestSurface(overrides: Record<string, unknown>) {
+  return registerShellSurface({
+    id: 'addon.panel',
+    slot: 'dock.panel',
+    label: 'Addon Panel',
+    owner: 'addon',
+    kind: 'configurable',
+    order: 20,
+    defaultVisible: true,
+    render: () => null,
+    ...overrides,
+  } as any);
+}
+
+function restoreGlobal(name: string, value: unknown) {
+  if (value === undefined) {
+    delete (globalThis as any)[name];
+    return;
+  }
+  (globalThis as any)[name] = value;
+}
+
+afterEach(() => {
+  resetShellSurfaceRegistryForTests();
+  restoreGlobal('window', originalWindow);
+  restoreGlobal('document', originalDocument);
+  restoreGlobal('Element', originalElement);
+  restoreGlobal('localStorage', originalLocalStorage);
+});
+
+describe('ShellSection', () => {
+  test('lists shell surfaces with label, id, slot, owner, and kind', () => {
+    const { document } = installDom();
+    registerTestSurface({ id: 'addon.timeline', slot: 'timeline.above', label: 'Timeline Addon', owner: 'addon', kind: 'additive' });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    render(h(ShellSection, {}), host);
+
+    const text = collectText(host);
+    expect(text).toContain('Timeline Addon');
+    expect(text).toContain('addon.timeline');
+    expect(text).toContain('timeline.above');
+    expect(text).toContain('addon / additive');
+
+    render(null, host);
+  });
+
+  test('toggles configurable surfaces and persists namespaced visibility keys', () => {
+    const { document, localStorage } = installDom();
+    registerTestSurface({ id: 'addon.panel', kind: 'configurable', defaultVisible: true });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    render(h(ShellSection, {}), host);
+
+    const input = findElements(host, (node) => node.localName === 'input' && node.id === 'shell-surface-addon.panel')[0];
+    expect(input.disabled).toBe(false);
+    expect(input.checked).toBe(true);
+
+    input.checked = false;
+    input.dispatchEvent({ type: 'Change' });
+
+    expect(localStorage.getItem('piclaw.shell.surface.addon.panel.visible')).toBe('false');
+
+    render(null, host);
+  });
+
+  test('reset controls clear configurable visibility and geometry keys', () => {
+    const { document, localStorage } = installDom();
+    registerTestSurface({ id: 'addon.panel', kind: 'configurable', defaultVisible: true });
+    setShellSurfaceVisible('addon.panel', false);
+    setShellSurfaceGeometry('addon.panel', { width: 420 });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    render(h(ShellSection, {}), host);
+
+    const buttons = findElements(host, (node) => node.localName === 'button');
+    const resetVisibility = buttons.find((node) => collectText(node).includes('Reset visibility'));
+    const resetGeometry = buttons.find((node) => collectText(node).includes('Reset geometry'));
+
+    resetVisibility?.dispatchEvent({ type: 'Click' });
+    resetGeometry?.dispatchEvent({ type: 'Click' });
+
+    expect(localStorage.getItem('piclaw.shell.surface.addon.panel.visible')).toBeNull();
+    expect(localStorage.getItem('piclaw.shell.surface.addon.panel.geometry')).toBeNull();
+
+    render(null, host);
+  });
+
+  test('renders required surfaces read-only', () => {
+    const { document } = installDom();
+    registerTestSurface({ id: 'core.status', label: 'Core Status', owner: 'core', kind: 'required', defaultVisible: true });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    render(h(ShellSection, {}), host);
+
+    const input = findElements(host, (node) => node.localName === 'input' && node.id === 'shell-surface-core.status')[0];
+    expect(input.disabled).toBe(true);
+    expect(collectText(host)).toContain('Core Status');
+    expect(collectText(host)).toContain('core / required');
+
+    render(null, host);
+  });
+});

--- a/runtime/test/web/shell-surface-registry.test.ts
+++ b/runtime/test/web/shell-surface-registry.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, expect, mock, test } from 'bun:test';
+
+import {
+  clearShellSurfaceGeometry,
+  clearShellSurfaceVisible,
+  getShellSurface,
+  getShellSurfaceGeometry,
+  getShellSurfaceVisible,
+  listShellSurfaces,
+  registerShellSurface,
+  renderShellSlot,
+  resetShellSurfaceRegistryForTests,
+  setShellSurfaceGeometry,
+  setShellSurfaceVisible,
+  subscribeShellSurfacesChanged,
+  unregisterShellSurface,
+  type ShellSurfaceDefinition,
+} from '../../web/src/ui/shell-surface-registry.js';
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.has(key) ? values.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+function surface(overrides: Partial<ShellSurfaceDefinition> = {}): ShellSurfaceDefinition {
+  return {
+    id: 'surface.one',
+    slot: 'timeline.core',
+    label: 'Surface One',
+    owner: 'addon',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    render: () => 'surface one',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetShellSurfaceRegistryForTests();
+  globalThis.localStorage = createMemoryStorage();
+  globalThis.window = {
+    localStorage: globalThis.localStorage,
+    dispatchEvent: mock(() => true),
+  } as any;
+});
+
+test('registers, replaces same ids idempotently, and unregisters surfaces', () => {
+  const unregister = registerShellSurface(surface());
+  expect(getShellSurface('surface.one')?.label).toBe('Surface One');
+
+  registerShellSurface(surface({ label: 'Replacement', order: 5, render: () => 'replacement' }));
+  expect(listShellSurfaces()).toHaveLength(1);
+  expect(getShellSurface('surface.one')?.label).toBe('Replacement');
+  expect(renderShellSlot('timeline.core')).toEqual(['replacement']);
+
+  unregister();
+  expect(getShellSurface('surface.one')).toBeUndefined();
+});
+
+test('unregisterShellSurface removes by id', () => {
+  registerShellSurface(surface());
+  unregisterShellSurface('surface.one');
+  expect(listShellSurfaces()).toEqual([]);
+});
+
+test('listShellSurfaces filters by slot and sorts by order then id', () => {
+  registerShellSurface(surface({ id: 'b', slot: 'timeline.core', order: 2 }));
+  registerShellSurface(surface({ id: 'a', slot: 'timeline.core', order: 2 }));
+  registerShellSurface(surface({ id: 'c', slot: 'timeline.header', order: 1 }));
+  registerShellSurface(surface({ id: 'first', slot: 'timeline.core', order: 1 }));
+
+  expect(listShellSurfaces('timeline.core').map((info) => info.id)).toEqual(['first', 'a', 'b']);
+  expect(listShellSurfaces('timeline.header').map((info) => info.id)).toEqual(['c']);
+});
+
+test('renderShellSlot renders only visible matching surfaces', () => {
+  registerShellSurface(surface({ id: 'visible', slot: 'compose.before', order: 2, render: () => 'visible' }));
+  registerShellSurface(surface({ id: 'hidden', slot: 'compose.before', order: 1, defaultVisible: false, render: () => 'hidden' }));
+  registerShellSurface(surface({ id: 'other', slot: 'compose.after', render: () => 'other' }));
+
+  expect(renderShellSlot('compose.before')).toEqual(['visible']);
+});
+
+test('renderShellSlot suppresses canRender false surfaces', () => {
+  registerShellSurface(surface({ id: 'blocked', canRender: () => false, render: () => 'blocked' }));
+  registerShellSurface(surface({ id: 'allowed', order: 20, canRender: () => true, render: () => 'allowed' }));
+
+  expect(renderShellSlot('timeline.core')).toEqual(['allowed']);
+});
+
+test('renderShellSlot catches canRender and render errors', () => {
+  const originalError = console.error;
+  const error = mock(() => {});
+  console.error = error;
+
+  try {
+    registerShellSurface(surface({ id: 'canRender.error', order: 1, canRender: () => { throw new Error('bad canRender'); } }));
+    registerShellSurface(surface({ id: 'render.error', order: 2, render: () => { throw new Error('bad render'); } }));
+    registerShellSurface(surface({ id: 'ok', order: 3, render: () => 'ok' }));
+
+    expect(renderShellSlot('timeline.core')).toEqual(['ok']);
+    expect(error).toHaveBeenCalledTimes(2);
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test('required surfaces cannot be hidden and are not configurable', () => {
+  registerShellSurface(surface({ id: 'required', kind: 'required', defaultVisible: true }));
+
+  setShellSurfaceVisible('required', false);
+
+  expect(getShellSurfaceVisible('required', false)).toBe(true);
+  expect(listShellSurfaces()[0]).toMatchObject({ id: 'required', visible: true, configurable: false });
+});
+
+test('configurable visibility persists as booleans stored as strings', () => {
+  registerShellSurface(surface({ id: 'configurable', kind: 'configurable', defaultVisible: true }));
+
+  setShellSurfaceVisible('configurable', false);
+
+  expect(globalThis.localStorage.getItem('piclaw.shell.surface.configurable.visible')).toBe('false');
+  expect(getShellSurfaceVisible('configurable', true)).toBe(false);
+  expect(listShellSurfaces()[0]).toMatchObject({ id: 'configurable', visible: false, configurable: true });
+});
+
+test('visibility and geometry can be cleared back to defaults', () => {
+  registerShellSurface(surface({ id: 'configurable', kind: 'configurable', defaultVisible: true }));
+  setShellSurfaceVisible('configurable', false);
+  setShellSurfaceGeometry('configurable', { width: 320, collapsed: false });
+
+  expect(globalThis.localStorage.getItem('piclaw.shell.surface.configurable.visible')).toBe('false');
+  expect(globalThis.localStorage.getItem('piclaw.shell.surface.configurable.geometry')).toBe('{"width":320,"collapsed":false}');
+  expect(getShellSurfaceGeometry('configurable')).toEqual({ width: 320, collapsed: false });
+
+  clearShellSurfaceVisible('configurable');
+  clearShellSurfaceGeometry('configurable');
+
+  expect(globalThis.localStorage.getItem('piclaw.shell.surface.configurable.visible')).toBeNull();
+  expect(globalThis.localStorage.getItem('piclaw.shell.surface.configurable.geometry')).toBeNull();
+  expect(getShellSurfaceVisible('configurable', true)).toBe(true);
+  expect(getShellSurfaceGeometry('configurable')).toBeNull();
+});
+
+test('invalid ids and slots reject registration with clear errors', () => {
+  expect(() => registerShellSurface(surface({ id: '' }))).toThrow('Shell surface id must be a non-empty string');
+  expect(() => registerShellSurface(surface({ slot: 'bad.slot' as any }))).toThrow('Invalid shell surface slot: bad.slot');
+});
+
+test('registration, visibility, geometry, unregister, and explicit notify trigger subscribers and browser events', () => {
+  const listener = mock(() => {});
+  const unsubscribe = subscribeShellSurfacesChanged(listener);
+  const dispatchEvent = globalThis.window.dispatchEvent as ReturnType<typeof mock>;
+
+  registerShellSurface(surface({ id: 'events' }));
+  setShellSurfaceVisible('events', false);
+  setShellSurfaceGeometry('events', { height: 42 });
+  unregisterShellSurface('events');
+
+  expect(listener).toHaveBeenCalledTimes(4);
+  expect(dispatchEvent).toHaveBeenCalledTimes(4);
+
+  unsubscribe();
+  registerShellSurface(surface({ id: 'after.unsubscribe' }));
+  expect(listener).toHaveBeenCalledTimes(4);
+  expect(dispatchEvent).toHaveBeenCalledTimes(5);
+});
+
+test('resetShellSurfaceRegistryForTests clears registry, subscribers, and shell storage keys', () => {
+  const listener = mock(() => {});
+  subscribeShellSurfacesChanged(listener);
+  registerShellSurface(surface({ id: 'reset' }));
+  setShellSurfaceVisible('reset', false);
+  setShellSurfaceGeometry('reset', { width: 1 });
+
+  resetShellSurfaceRegistryForTests();
+  registerShellSurface(surface({ id: 'after.reset' }));
+
+  expect(listShellSurfaces().map((info) => info.id)).toEqual(['after.reset']);
+  expect(listener).toHaveBeenCalledTimes(3);
+  expect(globalThis.localStorage.getItem('piclaw.shell.surface.reset.visible')).toBeNull();
+  expect(globalThis.localStorage.getItem('piclaw.shell.surface.reset.geometry')).toBeNull();
+});

--- a/runtime/web/src/app.ts
+++ b/runtime/web/src/app.ts
@@ -63,6 +63,7 @@ import {
     resolveOobePanelState,
 } from './ui/oobe-state.js';
 import { installPwaDisplayScaleSync } from './ui/pwa-display-scale.js';
+import { subscribeShellSurfacesChanged } from './ui/shell-surface-registry.js';
 
 const CURRENT_APP_ASSET_VERSION = getCurrentAppAssetVersion();
 
@@ -115,6 +116,11 @@ function MainApp({ locationParams, navigate }) {
         window.__piclawCurrentChatJid = currentChatJid;
         window.dispatchEvent?.(new CustomEvent('piclaw:current-chat-changed', { detail: { chatJid: currentChatJid } }));
     }, [currentChatJid]);
+
+    const [, setShellSurfacesVersion] = useState(0);
+    useEffect(() => subscribeShellSurfacesChanged(() => {
+        setShellSurfacesVersion((version) => version + 1);
+    }), []);
 
     const surface = useMainAppSurfaceState({
         currentChatJid,

--- a/runtime/web/src/components/settings-dialog.ts
+++ b/runtime/web/src/components/settings-dialog.ts
@@ -38,7 +38,7 @@ import { GeneralSection } from './settings/general.js';
 perf('imports-done');
 
 type SettingsSectionComponent = unknown;
-type BuiltinSectionId = 'general' | 'sessions' | 'recordings' | 'compaction' | 'keyboard' | 'workspace' | 'environment' | 'providers' | 'models' | 'theme' | 'scheduled-tasks' | 'quick-actions' | 'keychain' | 'tools' | 'addons';
+type BuiltinSectionId = 'general' | 'sessions' | 'recordings' | 'compaction' | 'keyboard' | 'workspace' | 'shell' | 'environment' | 'providers' | 'models' | 'theme' | 'scheduled-tasks' | 'quick-actions' | 'keychain' | 'tools' | 'addons';
 
 const builtinSectionComponentCache = new Map<BuiltinSectionId, SettingsSectionComponent>();
 const builtinSectionLoadPromiseCache = new Map<BuiltinSectionId, Promise<SettingsSectionComponent>>();
@@ -53,6 +53,7 @@ const BUILTIN_SECTION_LOADERS: Record<BuiltinSectionId, () => Promise<SettingsSe
     compaction: () => import('./settings/compaction.js').then(mod => mod.CompactionSection),
     keyboard: () => import('./settings/keyboard.js').then(mod => mod.KeyboardSection),
     workspace: () => import('./settings/workspace.js').then(mod => mod.WorkspaceSection),
+    shell: () => import('./settings/shell.js').then(mod => mod.ShellSection),
     environment: () => import('./settings/environment.js').then(mod => mod.EnvironmentSection),
     providers: () => import('./settings/providers.js').then(mod => mod.ProvidersSection),
     models: () => import('./settings/models.js').then(mod => mod.ModelsSection),
@@ -112,6 +113,7 @@ const iconSessions = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="
 const iconRecordings = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="9" cy="12" r="2.2"/><path d="m13 10 4-2.5v9L13 14z"/></svg>`;
 const iconCompaction = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><polyline points="3 4 3 10 9 10"/><path d="M12 7v5l3 3"/></svg>`;
 const iconWorkspace = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>`;
+const iconShell = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 9h10"/><path d="M7 13h6"/><path d="M7 17h3"/></svg>`;
 const iconEnvironment = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/><path d="M8 7v10"/><path d="M16 7v10"/></svg>`;
 const iconKeyboard = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><path d="M6 9h.01"/><path d="M10 9h.01"/><path d="M14 9h.01"/><path d="M18 9h.01"/><path d="M8 13h.01"/><path d="M12 13h.01"/><path d="M16 13h.01"/><path d="M7 17h10"/></svg>`;
 const iconProviders = html`<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>`;
@@ -131,6 +133,7 @@ const BUILTIN_SECTIONS = [
     { id: 'compaction', label: 'Compaction', icon: iconCompaction, searchable: false, order: 13 },
     { id: 'keyboard', label: 'Keyboard', icon: iconKeyboard, searchable: true, placeholder: 'Filter shortcuts…', order: 14 },
     { id: 'workspace', label: 'Workspace', icon: iconWorkspace, searchable: false, order: 15 },
+    { id: 'shell', label: 'Shell', icon: iconShell, searchable: true, placeholder: 'Filter shell surfaces…', order: 15.5 },
     { id: 'environment', label: 'Environment', icon: iconEnvironment, searchable: true, placeholder: 'Filter environment…', order: 16 },
     { id: 'providers', label: 'Providers', icon: iconProviders, searchable: false, order: 20 },
     { id: 'models', label: 'Models', icon: iconModels, searchable: true, placeholder: 'Filter models…', order: 30 },
@@ -307,6 +310,7 @@ export function SettingsDialogContent({ onClose }) {
             case 'compaction': return html`<${Comp} settingsData=${settingsData} setStatus=${setStatus} mergeSettingsData=${mergeSettingsData} />`;
             case 'keyboard': return html`<${Comp} filter=${filter} setStatus=${setStatus} />`;
             case 'workspace': return html`<${Comp} settingsData=${settingsData} setStatus=${setStatus} mergeSettingsData=${mergeSettingsData} />`;
+            case 'shell': return html`<${Comp} filter=${filter} setStatus=${setStatus} />`;
             case 'environment': return html`<${Comp} settingsData=${settingsData} filter=${filter} setStatus=${setStatus} mergeSettingsData=${mergeSettingsData} />`;
             case 'providers': return html`<${Comp} providers=${settingsData?.providers} setStatus=${setStatus} />`;
             case 'models': return html`<${Comp} filter=${filter} />`;

--- a/runtime/web/src/components/settings/shell.ts
+++ b/runtime/web/src/components/settings/shell.ts
@@ -1,0 +1,130 @@
+import { html, useCallback, useEffect, useMemo, useState } from '../../vendor/preact-htm.js';
+import {
+    clearShellSurfaceGeometry,
+    clearShellSurfaceVisible,
+    listShellSurfaces,
+    setShellSurfaceVisible,
+    subscribeShellSurfacesChanged,
+} from '../../ui/shell-surface-registry.js';
+
+function readSurfaces() {
+    return listShellSurfaces();
+}
+
+function sortSurfaces(a, b) {
+    const slotDiff = String(a.slot).localeCompare(String(b.slot));
+    if (slotDiff !== 0) return slotDiff;
+    const orderDiff = (a.order ?? 0) - (b.order ?? 0);
+    if (orderDiff !== 0) return orderDiff;
+    return String(a.id).localeCompare(String(b.id));
+}
+
+function matchesFilter(surface, filter) {
+    const query = String(filter || '').trim().toLowerCase();
+    if (!query) return true;
+    return [surface.label, surface.id, surface.slot, surface.owner, surface.kind]
+        .some((value) => String(value || '').toLowerCase().includes(query));
+}
+
+function groupBySlot(surfaces) {
+    const groups = new Map();
+    for (const surface of surfaces) {
+        const existing = groups.get(surface.slot) || [];
+        existing.push(surface);
+        groups.set(surface.slot, existing);
+    }
+    return Array.from(groups.entries()).map(([slot, items]) => ({ slot, items }));
+}
+
+export function ShellSection({ filter = '', setStatus }) {
+    const [surfaces, setSurfaces] = useState(readSurfaces);
+
+    const refresh = useCallback(() => {
+        setSurfaces(readSurfaces());
+    }, []);
+
+    useEffect(() => subscribeShellSurfacesChanged(refresh), [refresh]);
+
+    const visibleSurfaces = useMemo(() => {
+        return surfaces
+            .filter((surface) => matchesFilter(surface, filter))
+            .sort(sortSurfaces);
+    }, [surfaces, filter]);
+
+    const groups = useMemo(() => groupBySlot(visibleSurfaces), [visibleSurfaces]);
+
+    const toggleSurface = useCallback((surface, checked) => {
+        if (!surface.configurable) return;
+        setShellSurfaceVisible(surface.id, checked);
+        setStatus?.(`${surface.label || surface.id} ${checked ? 'shown' : 'hidden'}.`, 'success');
+        refresh();
+    }, [refresh, setStatus]);
+
+    const resetVisibility = useCallback((surface) => {
+        if (!surface.configurable) return;
+        clearShellSurfaceVisible(surface.id);
+        setStatus?.(`${surface.label || surface.id} visibility reset.`, 'success');
+        refresh();
+    }, [refresh, setStatus]);
+
+    const resetGeometry = useCallback((surface) => {
+        if (!surface.configurable) return;
+        clearShellSurfaceGeometry(surface.id);
+        setStatus?.(`${surface.label || surface.id} geometry reset.`, 'success');
+        refresh();
+    }, [refresh, setStatus]);
+
+    return html`
+        <div class="settings-section settings-shell-section">
+            <h3>Shell surfaces</h3>
+            <p class="settings-hint">
+                Show or hide registered shell surfaces for this browser. Required surfaces are always visible.
+            </p>
+            ${groups.length === 0 && html`
+                <p class="settings-hint">No shell surfaces match the current filter.</p>
+            `}
+            ${groups.map(({ slot, items }) => html`
+                <section class="settings-shell-slot" key=${slot}>
+                    <h4 style="margin:16px 0 8px">${slot}</h4>
+                    ${items.map((surface) => {
+                        const disabled = !surface.configurable;
+                        const ownerKind = `${surface.owner || 'unknown'} / ${surface.kind || 'unknown'}`;
+                        return html`
+                            <div class="settings-row settings-shell-surface-row" key=${surface.id}>
+                                <div style="min-width:0;flex:1">
+                                    <label for=${`shell-surface-${surface.id}`} style="display:block">${surface.label || surface.id}</label>
+                                    <div class="settings-hint" style="margin:2px 0 0">
+                                        <code>${surface.id}</code> · ${ownerKind} · order ${surface.order}
+                                    </div>
+                                </div>
+                                <input
+                                    id=${`shell-surface-${surface.id}`}
+                                    type="checkbox"
+                                    checked=${surface.visible}
+                                    disabled=${disabled}
+                                    aria-label=${`Show ${surface.label || surface.id}`}
+                                    title=${disabled ? 'Required shell surfaces cannot be hidden.' : 'Show shell surface'}
+                                    onChange=${(event) => toggleSurface(surface, event.currentTarget.checked)}
+                                />
+                                <button
+                                    type="button"
+                                    class="settings-small-button"
+                                    disabled=${disabled}
+                                    title=${disabled ? 'Required shell surfaces cannot be reset.' : 'Reset visibility to default'}
+                                    onClick=${() => resetVisibility(surface)}
+                                >Reset visibility</button>
+                                <button
+                                    type="button"
+                                    class="settings-small-button"
+                                    disabled=${disabled}
+                                    title=${disabled ? 'Required shell surfaces cannot be reset.' : 'Reset saved geometry'}
+                                    onClick=${() => resetGeometry(surface)}
+                                >Reset geometry</button>
+                            </div>
+                        `;
+                    })}
+                </section>
+            `)}
+        </div>
+    `;
+}

--- a/runtime/web/src/ui/addon-web-extensions.ts
+++ b/runtime/web/src/ui/addon-web-extensions.ts
@@ -1,5 +1,11 @@
 import { paneRegistry } from '../panes/index.js';
 import { registerSettingsPane, unregisterSettingsPane, notifySettingsPanesChanged } from '../components/settings/pane-registry.js';
+import {
+  registerShellSurface,
+  unregisterShellSurface,
+  type ShellSurfaceDefinition,
+  type ShellSurfaceSlot,
+} from './shell-surface-registry.js';
 
 export interface AddonStandaloneTabUrlContext {
   hasPopOutTab?: boolean;
@@ -13,17 +19,38 @@ export interface AddonAttachmentPreviewDefinition {
   note?: string | null;
 }
 
+export type AddonShellSurfaceDefinition = Partial<Omit<ShellSurfaceDefinition, 'owner' | 'kind' | 'order' | 'defaultVisible'>> & {
+  id?: string;
+  slot?: ShellSurfaceSlot;
+  order?: number;
+  defaultVisible?: boolean;
+  owner?: unknown;
+  kind?: unknown;
+};
+
 export interface AddonWebApiSurface {
   registerPane: (extension: any) => boolean;
   registerWorkspacePane: (extension: any) => boolean;
   registerSettingsPane: (definition: any) => () => void;
   registerStandaloneTabUrlResolver: (resolver: (path: string, context?: AddonStandaloneTabUrlContext) => string | null | undefined) => () => void;
   registerAttachmentPreview: (definition: AddonAttachmentPreviewDefinition) => () => void;
+  registerShellSurface: (definition: AddonShellSurfaceDefinition) => () => void;
   getCurrentChatJid: () => string;
 }
 
+const ADDON_SHELL_SURFACE_SLOTS = new Set<ShellSurfaceSlot>([
+  'timeline.above',
+  'timeline.below',
+  'compose.before',
+  'compose.after',
+  'app.overlay',
+  'status.extension',
+  'timeline.quick-actions',
+]);
+
 const addonPaneIds = new Set<string>();
 const addonSettingsPaneIds = new Set<string>();
+const addonShellSurfaceIds = new Set<string>();
 const standaloneTabUrlResolvers = new Set<(path: string, context?: AddonStandaloneTabUrlContext) => string | null | undefined>();
 const attachmentPreviewDefinitions = new Map<string, AddonAttachmentPreviewDefinition>();
 let addonWebApiInstalled = false;
@@ -116,6 +143,49 @@ export function registerAddonAttachmentPreview(definition: AddonAttachmentPrevie
   };
 }
 
+function assertAddonShellSurfaceDefinition(definition: AddonShellSurfaceDefinition): asserts definition is AddonShellSurfaceDefinition & { id: string; slot: ShellSurfaceSlot; render: ShellSurfaceDefinition['render'] } {
+  if (!definition || typeof definition.id !== 'string' || !definition.id.trim()) {
+    throw new Error('Add-on shell surface id must be a non-empty string');
+  }
+  if (definition.id.trim().toLowerCase().startsWith('piclaw')) {
+    throw new Error('Add-on shell surface ids must not start with piclaw');
+  }
+  if (!ADDON_SHELL_SURFACE_SLOTS.has(definition.slot as ShellSurfaceSlot)) {
+    throw new Error(`Add-on shell surface slot is not allowed: ${String(definition.slot)}`);
+  }
+  if (definition.owner === 'core') {
+    throw new Error('Add-on shell surfaces cannot use owner core');
+  }
+  if (definition.kind === 'required' || definition.kind === 'configurable') {
+    throw new Error('Add-on shell surfaces must be additive');
+  }
+  if (typeof definition.render !== 'function') {
+    throw new Error('Add-on shell surface render must be a function');
+  }
+}
+
+export function registerAddonShellSurface(definition: AddonShellSurfaceDefinition): () => void {
+  assertAddonShellSurfaceDefinition(definition);
+  const id = definition.id.trim();
+  const shellSurfaceDefinition: ShellSurfaceDefinition = {
+    ...definition,
+    id,
+    slot: definition.slot,
+    label: typeof definition.label === 'string' && definition.label.trim() ? definition.label : id,
+    owner: 'addon',
+    kind: 'additive',
+    order: typeof definition.order === 'number' && Number.isFinite(definition.order) ? definition.order : 300,
+    defaultVisible: definition.defaultVisible === false ? false : true,
+    render: definition.render,
+  };
+  const unregister = registerShellSurface(shellSurfaceDefinition);
+  addonShellSurfaceIds.add(id);
+  return () => {
+    unregister();
+    addonShellSurfaceIds.delete(id);
+  };
+}
+
 export function resolveAddonAttachmentPreview(contentType: unknown, filename?: unknown): AddonAttachmentPreviewDefinition | null {
   for (const definition of Array.from(attachmentPreviewDefinitions.values()).reverse()) {
     try {
@@ -159,6 +229,7 @@ export function createAddonWebApi(runtimeWindow: (Window & typeof globalThis) | 
     registerSettingsPane: registerAddonSettingsPane,
     registerStandaloneTabUrlResolver: registerAddonStandaloneTabUrlResolver,
     registerAttachmentPreview: registerAddonAttachmentPreview,
+    registerShellSurface: registerAddonShellSurface,
     getCurrentChatJid: () => resolveCurrentChatJid(runtimeWindow),
   };
 }
@@ -172,6 +243,7 @@ export function installAddonWebApi(runtimeWindow: (Window & typeof globalThis) |
   (runtimeWindow as any).__piclaw_registerSettingsPane = api.registerSettingsPane;
   (runtimeWindow as any).__piclaw_registerStandaloneTabUrlResolver = api.registerStandaloneTabUrlResolver;
   (runtimeWindow as any).__piclaw_registerAttachmentPreview = api.registerAttachmentPreview;
+  (runtimeWindow as any).__piclaw_registerShellSurface = api.registerShellSurface;
   // Aliases used by addons (observability, cheapskate, sample-addon)
   (runtimeWindow as any).__piclawSettingsPaneRegistry = {
     registerSettingsPane: api.registerSettingsPane,
@@ -217,8 +289,12 @@ export function resetAddonWebRegistriesForTests(): void {
   for (const paneId of addonSettingsPaneIds) {
     unregisterSettingsPane(paneId);
   }
+  for (const surfaceId of addonShellSurfaceIds) {
+    unregisterShellSurface(surfaceId);
+  }
   addonPaneIds.clear();
   addonSettingsPaneIds.clear();
+  addonShellSurfaceIds.clear();
   notifySettingsPanesChanged();
   standaloneTabUrlResolvers.clear();
   attachmentPreviewDefinitions.clear();

--- a/runtime/web/src/ui/app-main-shell-render.ts
+++ b/runtime/web/src/ui/app-main-shell-render.ts
@@ -1,104 +1,21 @@
 import { html } from '../vendor/preact-htm.js';
-import { ComposeBox } from '../components/compose-box.js';
 import { OobePanel } from '../components/oobe-panel.js';
 import { BtwPanel } from '../components/btw-panel.js';
 import { FloatingWidgetPane } from '../components/floating-widget-pane.js';
 import { AttachmentPreviewModal } from '../components/attachment-preview-modal.js';
-import { SettingsDialogLoader } from '../components/settings-dialog-loader.js';
-import { TimelineQuickActions } from '../components/timeline-quick-actions.js';
-import { TimelineMenu } from '../components/timeline-menu.js';
-import { AgentRequestModal, AgentStatus } from '../components/status.js';
-import { Timeline } from '../components/timeline.js';
-import { WorkspaceExplorer } from '../components/workspace-explorer.js';
-import { TabStrip } from '../components/tab-strip.js';
 import { MarkdownPreview } from '../components/markdown-preview.js';
-import { SystemMetersHud } from '../components/system-meters-hud.js';
+import { registerAppShellSurfaces } from './app-shell-builtins.js';
+import { getShellSurfaceVisible, renderShellSlot } from './shell-surface-registry.js';
+export {
+  buildMainShellClassName,
+  extractPostedUserMessageId,
+  handleComposePost,
+  scrollToPostedTimelineMessage,
+} from './app-main-shell-utils.js';
+import { buildMainShellClassName } from './app-main-shell-utils.js';
 
 export interface MainShellRenderOptions {
   [key: string]: any;
-}
-
-export function buildMainShellClassName(options: {
-  workspaceOpen: boolean;
-  editorOpen: boolean;
-  chatOnlyMode: boolean;
-  zenMode: boolean;
-}): string {
-  const { workspaceOpen, editorOpen, chatOnlyMode, zenMode } = options;
-  return `app-shell${workspaceOpen ? '' : ' workspace-collapsed'}${editorOpen ? ' editor-open' : ''}${chatOnlyMode ? ' chat-only' : ''}${zenMode ? ' zen-mode' : ''}`;
-}
-
-export function extractPostedUserMessageId(response: unknown): number | null {
-  const rawId = (response as any)?.user_message?.id ?? (response as any)?.row_id;
-  if (rawId === null || rawId === undefined || rawId === '') return null;
-  const id = Number(rawId);
-  return Number.isFinite(id) ? id : null;
-}
-
-export function scrollToPostedTimelineMessage(options: {
-  id: string | number;
-  scrollToBottom?: () => void;
-  getElementById?: (id: string) => HTMLElement | null;
-  scheduleRaf?: (callback: () => void) => void;
-  scheduleTimeout?: (callback: () => void, delayMs: number) => void;
-  maxAttempts?: number;
-}): void {
-  const {
-    id,
-    scrollToBottom,
-    getElementById = (value) => document.getElementById(value),
-    scheduleRaf = (callback) => requestAnimationFrame(callback),
-    scheduleTimeout = (callback, delayMs) => { setTimeout(callback, delayMs); },
-    maxAttempts = 12,
-  } = options;
-
-  const highlight = (el: HTMLElement) => {
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    el.classList.add('post-highlight');
-    scheduleTimeout(() => el.classList.remove('post-highlight'), 2000);
-  };
-
-  const tryScroll = (attemptsRemaining: number) => {
-    const element = getElementById(`post-${id}`);
-    if (element) {
-      highlight(element);
-      return;
-    }
-    if (attemptsRemaining <= 0) {
-      scrollToBottom?.();
-      return;
-    }
-    scheduleRaf(() => {
-      scheduleTimeout(() => tryScroll(attemptsRemaining - 1), 40);
-    });
-  };
-
-  tryScroll(maxAttempts);
-}
-
-export function handleComposePost(options: {
-  response?: unknown;
-  viewStateRef: { current: Record<string, unknown> | null | undefined };
-  scrollToBottom: () => void;
-  scrollPostedMessage?: (id: string | number) => void;
-}): void {
-  const {
-    response,
-    viewStateRef,
-    scrollToBottom,
-    scrollPostedMessage = (id) => scrollToPostedTimelineMessage({ id, scrollToBottom }),
-  } = options;
-
-  const { searchQuery: sq, searchOpen: so } = viewStateRef.current || {};
-  if (sq || so) return;
-
-  const postedMessageId = extractPostedUserMessageId(response);
-  if (postedMessageId) {
-    scrollPostedMessage(postedMessageId);
-    return;
-  }
-
-  scrollToBottom();
 }
 
 export function renderMainShell(options: MainShellRenderOptions): any {
@@ -273,9 +190,16 @@ export function renderMainShell(options: MainShellRenderOptions): any {
     scrollToBottom();
   };
 
+  registerAppShellSurfaces();
+  const shellRenderOptions = {
+    ...options,
+    handleComposeFocus,
+  };
+  const workspaceSidebarVisible = getShellSurfaceVisible('piclaw.workspace-explorer', true);
+
   return html`
     <div class=${buildMainShellClassName({ workspaceOpen, editorOpen, chatOnlyMode, zenMode })} ref=${appShellRef}>
-      <${SystemMetersHud} mode="overlay" />
+      ${renderShellSlot('app.overlay', { options: shellRenderOptions })}
       ${isRenameBranchFormOpen && html`
         <div class="rename-branch-overlay" onPointerDown=${(event: any) => {
           if (event.target === event.currentTarget) {
@@ -311,7 +235,7 @@ export function renderMainShell(options: MainShellRenderOptions): any {
             </div>
             <div class="rename-branch-actions">
               <button type="submit" class="compose-model-popup-btn primary" disabled=${isRenamingBranch || !renameBranchDraftState.canSubmit}>
-                ${isRenamingBranch ? 'Renaming…' : 'Save'}
+                ${isRenamingBranch ? 'Renaming\u2026' : 'Save'}
               </button>
               <button
                 type="button"
@@ -325,69 +249,14 @@ export function renderMainShell(options: MainShellRenderOptions): any {
           </form>
         </div>
       `}
-      ${!chatOnlyMode && html`
-        <${WorkspaceExplorer}
-          onFileSelect=${addFileRef}
-          onFolderSelect=${addFolderRef}
-          visible=${workspaceOpen}
-          active=${workspaceOpen || editorOpen}
-          onOpenEditor=${openEditor}
-          onOpenTerminalTab=${openTerminalTab}
-          onOpenVncTab=${openVncTab}
-          onToggleTerminal=${hasDockPanes ? toggleDock : undefined}
-          terminalVisible=${Boolean(hasDockPanes && dockVisible)}
-        />
-        <button
-          class=${`workspace-toggle-tab${workspaceOpen ? ' open' : ' closed'}`}
-          onClick=${toggleWorkspace}
-          title=${workspaceOpen ? 'Hide workspace' : 'Show workspace'}
-          aria-label=${workspaceOpen ? 'Hide workspace' : 'Show workspace'}
-        >
-          <svg class="workspace-toggle-tab-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <polyline points="6 3 11 8 6 13" />
-          </svg>
-        </button>
-        <div class="workspace-splitter" onMouseDown=${handleSplitterMouseDown} onTouchStart=${handleSplitterTouchStart}></div>
-      `}
+      ${renderShellSlot('workspace.sidebar', { options: shellRenderOptions })}
+      ${renderShellSlot('workspace.toggle', { options: shellRenderOptions })}
+      ${!chatOnlyMode && workspaceSidebarVisible && html`<div class="workspace-splitter" onMouseDown=${handleSplitterMouseDown} onTouchStart=${handleSplitterTouchStart}></div>`}
       ${showEditorPaneContainer && html`
         <div class="editor-pane-container">
           ${zenMode && html`<div class="zen-hover-zone"></div>`}
-          ${editorOpen && html`
-            <${TabStrip}
-              tabs=${tabStripTabs}
-              activeId=${tabStripActiveId}
-              onActivate=${handleTabActivate}
-              onClose=${handleTabClose}
-              onCloseOthers=${handleTabCloseOthers}
-              onCloseAll=${handleTabCloseAll}
-              onTogglePin=${handleTabTogglePin}
-              onTogglePreview=${handleTabTogglePreview}
-              onToggleDiff=${handleTabToggleDiff}
-              onEditSource=${handleTabEditSource}
-              previewTabs=${previewTabs}
-              diffTabs=${diffTabs}
-              paneOverrides=${tabPaneOverrides}
-              detachedTabs=${detachedTabs}
-              onReattachTab=${handleReattachPane}
-              onToggleDock=${hasDockPanes ? toggleDock : undefined}
-              dockVisible=${hasDockPanes && dockVisible}
-              onToggleZen=${toggleZenMode}
-              zenMode=${zenMode}
-              onPopOutTab=${isWebAppMode ? undefined : handlePopOutPane}
-            />
-          `}
-          ${editorOpen && activeDetachedTab && html`
-            <div class="editor-pane-host editor-pane-detached-host">
-              <div class="editor-empty-state">
-                <div class="editor-empty-state-title">${activeDetachedTab.label || activeDetachedTab.panePath || 'Detached pane'}</div>
-                <div class="editor-empty-state-body">This pane is detached into another window.</div>
-                <div class="editor-empty-state-actions">
-                  <button class="editor-empty-state-button" onClick=${() => handleReattachPane(activeDetachedTab.panePath)}>Reattach here</button>
-                </div>
-              </div>
-            </div>
-          `}
-          ${editorOpen && !activeDetachedTab && html`<div class="editor-pane-host" ref=${editorContainerRef}></div>`}
+          ${renderShellSlot('editor.tabbar', { options: shellRenderOptions })}
+          ${renderShellSlot('editor.host', { options: shellRenderOptions })}
           ${editorOpen && !activeDetachedTab && tabStripActiveId && previewTabs.has(tabStripActiveId) && html`
             <${MarkdownPreview}
               getContent=${() => editorInstanceRef.current?.getContent?.()}
@@ -398,74 +267,14 @@ export function renderMainShell(options: MainShellRenderOptions): any {
           `}
           ${hasDockPanes && dockVisible && html`<div class="dock-splitter" onMouseDown=${handleDockSplitterMouseDown} onTouchStart=${handleDockSplitterTouchStart}></div>`}
           ${hasDockPanes && html`<div class=${`dock-panel${dockVisible ? '' : ' hidden'}${editorOpen ? '' : ' standalone'}`}>
-            <div class="dock-panel-header">
-              <span class="dock-panel-title">Terminal</span>
-              <div class="dock-panel-actions">
-                ${!isWebAppMode && !detachedDockPane && html`
-                  <button class="dock-panel-action" onClick=${() => handlePopOutPane(TERMINAL_TAB_PATH, 'Terminal')} title="Open terminal in window" aria-label="Open terminal in window">
-                    <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                      <rect x="2.25" y="2.25" width="8.5" height="8.5" rx="1.5"/>
-                      <path d="M8.5 2.25h5.25v5.25"/>
-                      <path d="M13.75 2.25 7.75 8.25"/>
-                    </svg>
-                  </button>
-                `}
-                ${detachedDockPane && html`
-                  <button class="dock-panel-action" onClick=${() => handleReattachPane(TERMINAL_TAB_PATH)} title="Reattach terminal" aria-label="Reattach terminal">
-                    <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                      <rect x="2.25" y="2.25" width="11.5" height="11.5" rx="1.5"/>
-                      <path d="M5.25 8h5.5"/>
-                      <path d="M8 5.25v5.5"/>
-                    </svg>
-                  </button>
-                `}
-                <button class="dock-panel-close" onClick=${toggleDock} title="Hide terminal (Ctrl+\`)" aria-label="Hide terminal">
-                  <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
-                    <line x1="4" y1="4" x2="12" y2="12"/>
-                    <line x1="12" y1="4" x2="4" y2="12"/>
-                  </svg>
-                </button>
-              </div>
-            </div>
-            ${detachedDockPane
-              ? html`
-                <div class="dock-panel-body dock-panel-body-detached">
-                  <div class="editor-empty-state">
-                    <div class="editor-empty-state-title">Terminal detached</div>
-                    <div class="editor-empty-state-body">The terminal is open in another window.</div>
-                    <div class="editor-empty-state-actions">
-                      <button class="editor-empty-state-button" onClick=${() => handleReattachPane(TERMINAL_TAB_PATH)}>Reattach here</button>
-                    </div>
-                  </div>
-                </div>
-              `
-              : html`<div class="dock-panel-body" ref=${dockContainerRef}></div>`}
+            ${renderShellSlot('dock.header', { options: shellRenderOptions })}
+            ${renderShellSlot('dock.body', { options: shellRenderOptions })}
           </div>`}
         </div>
         <div class="editor-splitter" onMouseDown=${handleEditorSplitterMouseDown} onTouchStart=${handleEditorSplitterTouchStart}></div>
       `}
-      <${TimelineMenu}
-        workspaceOpen=${workspaceOpen}
-        toggleWorkspace=${toggleWorkspace}
-        chatOnlyMode=${chatOnlyMode}
-        onOpenTerminalTab=${openTerminalTab}
-        onOpenVncTab=${openVncTab}
-        onToggleTerminal=${hasDockPanes ? toggleDock : undefined}
-        terminalVisible=${Boolean(hasDockPanes && dockVisible)}
-      />
-      <${TimelineQuickActions}
-        activeChatAgents=${activeChatAgents}
-        currentChatJid=${currentChatJid}
-        workspaceOpen=${workspaceOpen}
-        chatOnlyMode=${chatOnlyMode}
-        terminalVisible=${Boolean(hasDockPanes && dockVisible)}
-        onSwitchChat=${handleBranchPickerChange}
-        onToggleWorkspace=${toggleWorkspace}
-        onOpenTerminalTab=${openTerminalTab}
-        onOpenVncTab=${openVncTab}
-        onToggleTerminalDock=${hasDockPanes ? toggleDock : undefined}
-        onPrefillCompose=${requestComposePrefill}
-      />
+      ${renderShellSlot('timeline.menu', { options: shellRenderOptions })}
+      ${renderShellSlot('timeline.quick-actions', { options: shellRenderOptions })}
       <div class="container">
         ${searchQuery && isIOSDevice() && html`<div class="search-results-spacer"></div>`}
         ${(currentHashtag || searchQuery) && html`
@@ -473,7 +282,7 @@ export function renderMainShell(options: MainShellRenderOptions): any {
             <button class="back-btn" onClick=${handleBackToTimeline}>
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
             </button>
-            <span>${currentHashtag ? `#${currentHashtag}` : `Search: ${searchQuery} · ${activeSearchScopeLabel}`}</span>
+            <span>${currentHashtag ? `#${currentHashtag}` : `Search: ${searchQuery} \u00B7 ${activeSearchScopeLabel}`}</span>
           </div>
         `}
         ${oobePanelState?.kind && oobePanelState.kind !== 'hidden' && html`
@@ -485,38 +294,10 @@ export function renderMainShell(options: MainShellRenderOptions): any {
             onDismiss=${oobePanelState.kind === 'provider-missing' ? handleDismissProviderMissingOobe : handleCompleteProviderReadyOobe}
           />
         `}
-        <${Timeline}
-          posts=${posts}
-          hasMore=${isMainTimelineView ? hasMore : false}
-          onLoadMore=${isMainTimelineView ? loadMore : undefined}
-          timelineRef=${timelineRef}
-          onHashtagClick=${handleHashtagClick}
-          onMessageRef=${addMessageRef}
-          onScrollToMessage=${scrollToMessage}
-          onFileRef=${openTimelineFileFromPill || openFileFromPill}
-          onPostClick=${undefined}
-          onDeletePost=${handleDeletePost}
-          onOpenWidget=${handleOpenFloatingWidget}
-          onOpenAttachmentPreview=${setAttachmentPreview}
-          emptyMessage=${currentHashtag ? `No posts with #${currentHashtag}` : searchQuery ? `No results for "${searchQuery}"` : undefined}
-          agents=${agents}
-          user=${userProfile}
-          reverse=${isMainTimelineView}
-          removingPostIds=${removingPostIds}
-          searchQuery=${searchQuery}
-        />
-        <${AgentStatus}
-          status=${isCompactionStatus(agentStatus) ? null : agentStatus}
-          draft=${agentDraft}
-          plan=${agentPlan}
-          thought=${agentThought}
-          pendingRequest=${pendingRequest}
-          intent=${intentToast}
-          turnId=${currentTurnId}
-          steerQueued=${steerQueued}
-          onPanelToggle=${handlePanelToggle}
-          showExtensionPanels=${false}
-        />
+        ${renderShellSlot('timeline.above', { options: shellRenderOptions })}
+        ${renderShellSlot('timeline.core', { options: shellRenderOptions })}
+        ${renderShellSlot('timeline.below', { options: shellRenderOptions })}
+        ${renderShellSlot('status.core', { options: shellRenderOptions })}
         <${BtwPanel}
           session=${btwSession}
           onClose=${closeBtwPanel}
@@ -535,89 +316,12 @@ export function renderMainShell(options: MainShellRenderOptions): any {
             onClose=${() => setAttachmentPreview(null)}
           />
         `}
-        <${SettingsDialogLoader} />
-        <${AgentStatus}
-          extensionPanels=${Array.from(extensionStatusPanels.values())}
-          pendingPanelActions=${pendingExtensionPanelActions}
-          onExtensionPanelAction=${handleExtensionPanelAction}
-          turnId=${currentTurnId}
-          steerQueued=${steerQueued}
-          onPanelToggle=${handlePanelToggle}
-          showCorePanels=${false}
-        />
-        <${ComposeBox}
-          onPost=${(response) => {
-            handleComposePost({
-              response,
-              viewStateRef,
-              scrollToBottom,
-            });
-          }}
-          onFocus=${handleComposeFocus}
-          searchMode=${searchOpen}
-          searchScope=${searchScope}
-          onSearch=${handleSearch}
-          onSearchScopeChange=${handleSearchScopeChange || setSearchScope}
-          onEnterSearch=${enterSearchMode}
-          onExitSearch=${exitSearchMode}
-          fileRefs=${fileRefs}
-          onRemoveFileRef=${removeFileRef}
-          onClearFileRefs=${clearFileRefs}
-          onSetFileRefs=${setFileRefsFromCompose}
-          folderRefs=${folderRefs}
-          onRemoveFolderRef=${removeFolderRef}
-          onClearFolderRefs=${clearFolderRefs}
-          onSetFolderRefs=${setFolderRefsFromCompose}
-          messageRefs=${messageRefs}
-          onRemoveMessageRef=${removeMessageRef}
-          onClearMessageRefs=${clearMessageRefs}
-          onSetMessageRefs=${setMessageRefsFromCompose}
-          onSwitchChat=${handleBranchPickerChange}
-          onRenameSession=${handleRenameCurrentBranch}
-          isRenameSessionInProgress=${isRenamingBranch}
-          onCreateSession=${handleCreateSessionFromCompose}
-          onCreateRootSession=${handleCreateRootSessionFromCompose}
-          onDeleteSession=${handlePruneCurrentBranch}
-          onPurgeArchivedSession=${handlePurgeArchivedBranch}
-          onRestoreSession=${handleRestoreBranch}
-          activeEditorPath=${chatOnlyMode ? null : tabStripActiveId}
-          onAttachEditorFile=${chatOnlyMode ? undefined : attachActiveEditorFile}
-          onOpenFilePill=${openFileFromPill}
-          followupQueueCount=${followupQueueCount}
-          followupQueueItems=${followupQueueItems}
-          onInjectQueuedFollowup=${handleInjectQueuedFollowup}
-          onRemoveQueuedFollowup=${handleRemoveQueuedFollowup}
-          onMoveQueuedFollowup=${handleMoveQueuedFollowup}
-          onSubmitIntercept=${handleBtwIntercept}
-          onMessageResponse=${handleMessageResponse}
-          onSubmitError=${handleComposeSubmitError}
-          isAgentActive=${isComposeBoxAgentActive}
-          activeChatAgents=${activeChatAgents}
-          currentChatJid=${currentChatJid}
-          connectionStatus=${connectionStatus}
-          stateAccessFailed=${stateAccessFailed}
-          activeModel=${activeModel}
-          agentModelsPayload=${agentModelsPayload}
-          modelUsage=${activeModelUsage}
-          thinkingLevel=${activeThinkingLevel}
-          supportsThinking=${supportsThinking}
-          contextUsage=${contextUsage}
-          notificationsEnabled=${notificationsEnabled}
-          notificationPermission=${notificationPermission}
-          onToggleNotifications=${handleToggleNotifications}
-          onModelChange=${setActiveModel}
-          onModelStateChange=${applyModelState}
-          statusNotice=${isCompactionStatus(agentStatus) ? agentStatus : null}
-          extensionWorkingState=${extensionWorkingState}
-          prefillRequest=${composePrefillRequest}
-        />
-        <${AgentRequestModal}
-          request=${pendingRequest}
-          onRespond=${() => {
-            setPendingRequest(null);
-            pendingRequestRef.current = null;
-          }}
-        />
+        ${renderShellSlot('settings.loader', { options: shellRenderOptions })}
+        ${renderShellSlot('status.extension', { options: shellRenderOptions })}
+        ${renderShellSlot('compose.before', { options: shellRenderOptions })}
+        ${renderShellSlot('compose.box', { options: shellRenderOptions })}
+        ${renderShellSlot('compose.after', { options: shellRenderOptions })}
+        ${renderShellSlot('app.modal', { options: shellRenderOptions })}
       </div>
     </div>
   `;

--- a/runtime/web/src/ui/app-main-shell-utils.ts
+++ b/runtime/web/src/ui/app-main-shell-utils.ts
@@ -1,0 +1,82 @@
+export function buildMainShellClassName(options: {
+  workspaceOpen: boolean;
+  editorOpen: boolean;
+  chatOnlyMode: boolean;
+  zenMode: boolean;
+}): string {
+  const { workspaceOpen, editorOpen, chatOnlyMode, zenMode } = options;
+  return `app-shell${workspaceOpen ? '' : ' workspace-collapsed'}${editorOpen ? ' editor-open' : ''}${chatOnlyMode ? ' chat-only' : ''}${zenMode ? ' zen-mode' : ''}`;
+}
+
+export function extractPostedUserMessageId(response: unknown): number | null {
+  const rawId = (response as any)?.user_message?.id ?? (response as any)?.row_id;
+  if (rawId === null || rawId === undefined || rawId === '') return null;
+  const id = Number(rawId);
+  return Number.isFinite(id) ? id : null;
+}
+
+export function scrollToPostedTimelineMessage(options: {
+  id: string | number;
+  scrollToBottom?: () => void;
+  getElementById?: (id: string) => HTMLElement | null;
+  scheduleRaf?: (callback: () => void) => void;
+  scheduleTimeout?: (callback: () => void, delayMs: number) => void;
+  maxAttempts?: number;
+}): void {
+  const {
+    id,
+    scrollToBottom,
+    getElementById = (value) => document.getElementById(value),
+    scheduleRaf = (callback) => requestAnimationFrame(callback),
+    scheduleTimeout = (callback, delayMs) => { setTimeout(callback, delayMs); },
+    maxAttempts = 12,
+  } = options;
+
+  const highlight = (el: HTMLElement) => {
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.classList.add('post-highlight');
+    scheduleTimeout(() => el.classList.remove('post-highlight'), 2000);
+  };
+
+  const tryScroll = (attemptsRemaining: number) => {
+    const element = getElementById(`post-${id}`);
+    if (element) {
+      highlight(element);
+      return;
+    }
+    if (attemptsRemaining <= 0) {
+      scrollToBottom?.();
+      return;
+    }
+    scheduleRaf(() => {
+      scheduleTimeout(() => tryScroll(attemptsRemaining - 1), 40);
+    });
+  };
+
+  tryScroll(maxAttempts);
+}
+
+export function handleComposePost(options: {
+  response?: unknown;
+  viewStateRef: { current: Record<string, unknown> | null | undefined };
+  scrollToBottom: () => void;
+  scrollPostedMessage?: (id: string | number) => void;
+}): void {
+  const {
+    response,
+    viewStateRef,
+    scrollToBottom,
+    scrollPostedMessage = (id) => scrollToPostedTimelineMessage({ id, scrollToBottom }),
+  } = options;
+
+  const { searchQuery: sq, searchOpen: so } = viewStateRef.current || {};
+  if (sq || so) return;
+
+  const postedMessageId = extractPostedUserMessageId(response);
+  if (postedMessageId) {
+    scrollPostedMessage(postedMessageId);
+    return;
+  }
+
+  scrollToBottom();
+}

--- a/runtime/web/src/ui/app-shell-bootstrap.ts
+++ b/runtime/web/src/ui/app-shell-bootstrap.ts
@@ -17,6 +17,7 @@ import {
   installAddonWebApi,
   loadInstalledAddonWebEntries,
 } from './addon-web-extensions.js';
+import { registerAppShellSurfaces } from './app-shell-builtins.js';
 import { resolveOptionalApi } from './optional-api.js';
 
 interface AppApiSurface {
@@ -86,6 +87,7 @@ export async function initializeAppShellRuntime(): Promise<void> {
   configureMarked(markedInstance);
   installBrowserNoiseFilters(runtimeWindow);
   installAddonWebApi(runtimeWindow);
+  registerAppShellSurfaces();
   // Expose preact/htm globals for addon web entries (they can't import from the bundle)
   if (runtimeWindow) {
     try {

--- a/runtime/web/src/ui/app-shell-builtins.ts
+++ b/runtime/web/src/ui/app-shell-builtins.ts
@@ -1,0 +1,492 @@
+import { html } from '../vendor/preact-htm.js';
+import { ComposeBox } from '../components/compose-box.js';
+import { SettingsDialogLoader } from '../components/settings-dialog-loader.js';
+import { TimelineQuickActions } from '../components/timeline-quick-actions.js';
+import { TimelineMenu } from '../components/timeline-menu.js';
+import { AgentRequestModal, AgentStatus } from '../components/status.js';
+import { Timeline } from '../components/timeline.js';
+import { WorkspaceExplorer } from '../components/workspace-explorer.js';
+import { TabStrip } from '../components/tab-strip.js';
+import { SystemMetersHud } from '../components/system-meters-hud.js';
+import { listShellSurfaces, registerShellSurface } from './shell-surface-registry.js';
+import { handleComposePost } from './app-main-shell-utils.js';
+
+const BUILTIN_SHELL_SURFACE_IDS = [
+  'piclaw.system-meters-hud',
+  'piclaw.workspace-explorer',
+  'piclaw.workspace-toggle',
+  'piclaw.tab-strip',
+  'piclaw.editor-host',
+  'piclaw.dock-header',
+  'piclaw.dock-body',
+  'piclaw.timeline-menu',
+  'piclaw.timeline-quick-actions',
+  'piclaw.timeline-core',
+  'piclaw.status-core',
+  'piclaw.agent-status-extension',
+  'piclaw.settings-loader',
+  'piclaw.compose-box',
+  'piclaw.agent-request-modal',
+];
+
+function shellOptions(context: { options?: Record<string, any> }): Record<string, any> {
+  return context.options ?? {};
+}
+
+export function registerAppShellSurfaces(): void {
+  const registeredIds = new Set(listShellSurfaces().map((surface) => surface.id));
+  if (BUILTIN_SHELL_SURFACE_IDS.every((id) => registeredIds.has(id))) return;
+
+  registerShellSurface({
+    id: 'piclaw.system-meters-hud',
+    slot: 'app.overlay',
+    label: 'System meters HUD',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    render: () => html`<${SystemMetersHud} mode="overlay" />`,
+  });
+
+  registerShellSurface({
+    id: 'piclaw.workspace-explorer',
+    slot: 'workspace.sidebar',
+    label: 'Workspace explorer',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    canRender: (context) => !shellOptions(context).chatOnlyMode,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${WorkspaceExplorer}
+          onFileSelect=${options.addFileRef}
+          onFolderSelect=${options.addFolderRef}
+          visible=${options.workspaceOpen}
+          active=${options.workspaceOpen || options.editorOpen}
+          onOpenEditor=${options.openEditor}
+          onOpenTerminalTab=${options.openTerminalTab}
+          onOpenVncTab=${options.openVncTab}
+          onToggleTerminal=${options.hasDockPanes ? options.toggleDock : undefined}
+          terminalVisible=${Boolean(options.hasDockPanes && options.dockVisible)}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.workspace-toggle',
+    slot: 'workspace.toggle',
+    label: 'Workspace toggle',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    canRender: (context) => !shellOptions(context).chatOnlyMode,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <button
+          class=${`workspace-toggle-tab${options.workspaceOpen ? ' open' : ' closed'}`}
+          onClick=${options.toggleWorkspace}
+          title=${options.workspaceOpen ? 'Hide workspace' : 'Show workspace'}
+          aria-label=${options.workspaceOpen ? 'Hide workspace' : 'Show workspace'}
+        >
+          <svg class="workspace-toggle-tab-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="6 3 11 8 6 13" />
+          </svg>
+        </button>
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.tab-strip',
+    slot: 'editor.tabbar',
+    label: 'Editor tab strip',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    canRender: (context) => Boolean(shellOptions(context).editorOpen),
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${TabStrip}
+          tabs=${options.tabStripTabs}
+          activeId=${options.tabStripActiveId}
+          onActivate=${options.handleTabActivate}
+          onClose=${options.handleTabClose}
+          onCloseOthers=${options.handleTabCloseOthers}
+          onCloseAll=${options.handleTabCloseAll}
+          onTogglePin=${options.handleTabTogglePin}
+          onTogglePreview=${options.handleTabTogglePreview}
+          onToggleDiff=${options.handleTabToggleDiff}
+          onEditSource=${options.handleTabEditSource}
+          previewTabs=${options.previewTabs}
+          diffTabs=${options.diffTabs}
+          paneOverrides=${options.tabPaneOverrides}
+          detachedTabs=${options.detachedTabs}
+          onReattachTab=${options.handleReattachPane}
+          onToggleDock=${options.hasDockPanes ? options.toggleDock : undefined}
+          dockVisible=${options.hasDockPanes && options.dockVisible}
+          onToggleZen=${options.toggleZenMode}
+          zenMode=${options.zenMode}
+          onPopOutTab=${options.isWebAppMode ? undefined : options.handlePopOutPane}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.editor-host',
+    slot: 'editor.host',
+    label: 'Editor host',
+    owner: 'core',
+    kind: 'required',
+    order: 10,
+    defaultVisible: true,
+    canRender: (context) => Boolean(shellOptions(context).editorOpen),
+    render: (context) => {
+      const options = shellOptions(context);
+      if (options.activeDetachedTab) {
+        return html`
+          <div class="editor-pane-host editor-pane-detached-host">
+            <div class="editor-empty-state">
+              <div class="editor-empty-state-title">${options.activeDetachedTab.label || options.activeDetachedTab.panePath || 'Detached pane'}</div>
+              <div class="editor-empty-state-body">This pane is detached into another window.</div>
+              <div class="editor-empty-state-actions">
+                <button class="editor-empty-state-button" onClick=${() => options.handleReattachPane(options.activeDetachedTab.panePath)}>Reattach here</button>
+              </div>
+            </div>
+          </div>
+        `;
+      }
+      return html`<div class="editor-pane-host" ref=${options.editorContainerRef}></div>`;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.dock-header',
+    slot: 'dock.header',
+    label: 'Dock header',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <div class="dock-panel-header">
+          <span class="dock-panel-title">Terminal</span>
+          <div class="dock-panel-actions">
+            ${!options.isWebAppMode && !options.detachedDockPane && html`
+              <button class="dock-panel-action" onClick=${() => options.handlePopOutPane(options.TERMINAL_TAB_PATH, 'Terminal')} title="Open terminal in window" aria-label="Open terminal in window">
+                <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="2.25" y="2.25" width="8.5" height="8.5" rx="1.5"/>
+                  <path d="M8.5 2.25h5.25v5.25"/>
+                  <path d="M13.75 2.25 7.75 8.25"/>
+                </svg>
+              </button>
+            `}
+            ${options.detachedDockPane && html`
+              <button class="dock-panel-action" onClick=${() => options.handleReattachPane(options.TERMINAL_TAB_PATH)} title="Reattach terminal" aria-label="Reattach terminal">
+                <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="2.25" y="2.25" width="11.5" height="11.5" rx="1.5"/>
+                  <path d="M5.25 8h5.5"/>
+                  <path d="M8 5.25v5.5"/>
+                </svg>
+              </button>
+            `}
+            <button class="dock-panel-close" onClick=${options.toggleDock} title=${'Hide terminal (Ctrl+`)'} aria-label="Hide terminal">
+              <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <line x1="4" y1="4" x2="12" y2="12"/>
+                <line x1="12" y1="4" x2="4" y2="12"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.dock-body',
+    slot: 'dock.body',
+    label: 'Dock body',
+    owner: 'core',
+    kind: 'required',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      if (options.detachedDockPane) {
+        return html`
+          <div class="dock-panel-body dock-panel-body-detached">
+            <div class="editor-empty-state">
+              <div class="editor-empty-state-title">Terminal detached</div>
+              <div class="editor-empty-state-body">The terminal is open in another window.</div>
+              <div class="editor-empty-state-actions">
+                <button class="editor-empty-state-button" onClick=${() => options.handleReattachPane(options.TERMINAL_TAB_PATH)}>Reattach here</button>
+              </div>
+            </div>
+          </div>
+        `;
+      }
+      return html`<div class="dock-panel-body" ref=${options.dockContainerRef}></div>`;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.timeline-menu',
+    slot: 'timeline.menu',
+    label: 'Timeline menu',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${TimelineMenu}
+          workspaceOpen=${options.workspaceOpen}
+          toggleWorkspace=${options.toggleWorkspace}
+          chatOnlyMode=${options.chatOnlyMode}
+          onOpenTerminalTab=${options.openTerminalTab}
+          onOpenVncTab=${options.openVncTab}
+          onToggleTerminal=${options.hasDockPanes ? options.toggleDock : undefined}
+          terminalVisible=${Boolean(options.hasDockPanes && options.dockVisible)}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.timeline-quick-actions',
+    slot: 'timeline.quick-actions',
+    label: 'Timeline quick actions',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${TimelineQuickActions}
+          activeChatAgents=${options.activeChatAgents}
+          currentChatJid=${options.currentChatJid}
+          workspaceOpen=${options.workspaceOpen}
+          chatOnlyMode=${options.chatOnlyMode}
+          terminalVisible=${Boolean(options.hasDockPanes && options.dockVisible)}
+          onSwitchChat=${options.handleBranchPickerChange}
+          onToggleWorkspace=${options.toggleWorkspace}
+          onOpenTerminalTab=${options.openTerminalTab}
+          onOpenVncTab=${options.openVncTab}
+          onToggleTerminalDock=${options.hasDockPanes ? options.toggleDock : undefined}
+          onPrefillCompose=${options.requestComposePrefill}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.timeline-core',
+    slot: 'timeline.core',
+    label: 'Timeline',
+    owner: 'core',
+    kind: 'required',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${Timeline}
+          posts=${options.posts}
+          hasMore=${options.isMainTimelineView ? options.hasMore : false}
+          onLoadMore=${options.isMainTimelineView ? options.loadMore : undefined}
+          timelineRef=${options.timelineRef}
+          onHashtagClick=${options.handleHashtagClick}
+          onMessageRef=${options.addMessageRef}
+          onScrollToMessage=${options.scrollToMessage}
+          onFileRef=${options.openTimelineFileFromPill || options.openFileFromPill}
+          onPostClick=${undefined}
+          onDeletePost=${options.handleDeletePost}
+          onOpenWidget=${options.handleOpenFloatingWidget}
+          onOpenAttachmentPreview=${options.setAttachmentPreview}
+          emptyMessage=${options.currentHashtag ? `No posts with #${options.currentHashtag}` : options.searchQuery ? `No results for "${options.searchQuery}"` : undefined}
+          agents=${options.agents}
+          user=${options.userProfile}
+          reverse=${options.isMainTimelineView}
+          removingPostIds=${options.removingPostIds}
+          searchQuery=${options.searchQuery}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.status-core',
+    slot: 'status.core',
+    label: 'Agent status',
+    owner: 'core',
+    kind: 'required',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${AgentStatus}
+          status=${options.isCompactionStatus(options.agentStatus) ? null : options.agentStatus}
+          draft=${options.agentDraft}
+          plan=${options.agentPlan}
+          thought=${options.agentThought}
+          pendingRequest=${options.pendingRequest}
+          intent=${options.intentToast}
+          turnId=${options.currentTurnId}
+          steerQueued=${options.steerQueued}
+          onPanelToggle=${options.handlePanelToggle}
+          showExtensionPanels=${false}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.agent-status-extension',
+    slot: 'status.extension',
+    label: 'Extension status panels',
+    owner: 'core',
+    kind: 'configurable',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${AgentStatus}
+          extensionPanels=${Array.from(options.extensionStatusPanels.values())}
+          pendingPanelActions=${options.pendingExtensionPanelActions}
+          onExtensionPanelAction=${options.handleExtensionPanelAction}
+          turnId=${options.currentTurnId}
+          steerQueued=${options.steerQueued}
+          onPanelToggle=${options.handlePanelToggle}
+          showCorePanels=${false}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.settings-loader',
+    slot: 'settings.loader',
+    label: 'Settings dialog loader',
+    owner: 'core',
+    kind: 'required',
+    order: 10,
+    defaultVisible: true,
+    render: () => html`<${SettingsDialogLoader} />`,
+  });
+
+  registerShellSurface({
+    id: 'piclaw.compose-box',
+    slot: 'compose.box',
+    label: 'Compose box',
+    owner: 'core',
+    kind: 'required',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${ComposeBox}
+          onPost=${(response: unknown) => {
+            handleComposePost({
+              response,
+              viewStateRef: options.viewStateRef,
+              scrollToBottom: options.scrollToBottom,
+            });
+          }}
+          onFocus=${options.handleComposeFocus}
+          searchMode=${options.searchOpen}
+          searchScope=${options.searchScope}
+          onSearch=${options.handleSearch}
+          onSearchScopeChange=${options.handleSearchScopeChange || options.setSearchScope}
+          onEnterSearch=${options.enterSearchMode}
+          onExitSearch=${options.exitSearchMode}
+          fileRefs=${options.fileRefs}
+          onRemoveFileRef=${options.removeFileRef}
+          onClearFileRefs=${options.clearFileRefs}
+          onSetFileRefs=${options.setFileRefsFromCompose}
+          folderRefs=${options.folderRefs}
+          onRemoveFolderRef=${options.removeFolderRef}
+          onClearFolderRefs=${options.clearFolderRefs}
+          onSetFolderRefs=${options.setFolderRefsFromCompose}
+          messageRefs=${options.messageRefs}
+          onRemoveMessageRef=${options.removeMessageRef}
+          onClearMessageRefs=${options.clearMessageRefs}
+          onSetMessageRefs=${options.setMessageRefsFromCompose}
+          onSwitchChat=${options.handleBranchPickerChange}
+          onRenameSession=${options.handleRenameCurrentBranch}
+          isRenameSessionInProgress=${options.isRenamingBranch}
+          onCreateSession=${options.handleCreateSessionFromCompose}
+          onCreateRootSession=${options.handleCreateRootSessionFromCompose}
+          onDeleteSession=${options.handlePruneCurrentBranch}
+          onPurgeArchivedSession=${options.handlePurgeArchivedBranch}
+          onRestoreSession=${options.handleRestoreBranch}
+          activeEditorPath=${options.chatOnlyMode ? null : options.tabStripActiveId}
+          onAttachEditorFile=${options.chatOnlyMode ? undefined : options.attachActiveEditorFile}
+          onOpenFilePill=${options.openFileFromPill}
+          followupQueueCount=${options.followupQueueCount}
+          followupQueueItems=${options.followupQueueItems}
+          onInjectQueuedFollowup=${options.handleInjectQueuedFollowup}
+          onRemoveQueuedFollowup=${options.handleRemoveQueuedFollowup}
+          onMoveQueuedFollowup=${options.handleMoveQueuedFollowup}
+          onSubmitIntercept=${options.handleBtwIntercept}
+          onMessageResponse=${options.handleMessageResponse}
+          onSubmitError=${options.handleComposeSubmitError}
+          isAgentActive=${options.isComposeBoxAgentActive}
+          activeChatAgents=${options.activeChatAgents}
+          currentChatJid=${options.currentChatJid}
+          connectionStatus=${options.connectionStatus}
+          stateAccessFailed=${options.stateAccessFailed}
+          activeModel=${options.activeModel}
+          agentModelsPayload=${options.agentModelsPayload}
+          modelUsage=${options.activeModelUsage}
+          thinkingLevel=${options.activeThinkingLevel}
+          supportsThinking=${options.supportsThinking}
+          contextUsage=${options.contextUsage}
+          notificationsEnabled=${options.notificationsEnabled}
+          notificationPermission=${options.notificationPermission}
+          onToggleNotifications=${options.handleToggleNotifications}
+          onModelChange=${options.setActiveModel}
+          onModelStateChange=${options.applyModelState}
+          statusNotice=${options.isCompactionStatus(options.agentStatus) ? options.agentStatus : null}
+          extensionWorkingState=${options.extensionWorkingState}
+          prefillRequest=${options.composePrefillRequest}
+        />
+      `;
+    },
+  });
+
+  registerShellSurface({
+    id: 'piclaw.agent-request-modal',
+    slot: 'app.modal',
+    label: 'Agent request modal',
+    owner: 'core',
+    kind: 'required',
+    order: 10,
+    defaultVisible: true,
+    render: (context) => {
+      const options = shellOptions(context);
+      return html`
+        <${AgentRequestModal}
+          request=${options.pendingRequest}
+          onRespond=${() => {
+            options.setPendingRequest(null);
+            options.pendingRequestRef.current = null;
+          }}
+        />
+      `;
+    },
+  });
+}

--- a/runtime/web/src/ui/shell-surface-registry.ts
+++ b/runtime/web/src/ui/shell-surface-registry.ts
@@ -1,0 +1,347 @@
+import type { ComponentChildren, VNode } from 'preact';
+
+export type ShellSurfaceRenderResult = ComponentChildren | VNode | null;
+
+export type ShellSurfaceSlot =
+  | 'app.overlay'
+  | 'workspace.sidebar'
+  | 'workspace.toggle'
+  | 'workspace.splitter'
+  | 'editor.region'
+  | 'editor.tabbar'
+  | 'editor.host'
+  | 'editor.preview'
+  | 'editor.splitter'
+  | 'dock.splitter'
+  | 'dock.panel'
+  | 'dock.header'
+  | 'dock.body'
+  | 'timeline.menu'
+  | 'timeline.quick-actions'
+  | 'timeline.header'
+  | 'timeline.above'
+  | 'timeline.core'
+  | 'timeline.below'
+  | 'status.core'
+  | 'status.extension'
+  | 'compose.before'
+  | 'compose.box'
+  | 'compose.after'
+  | 'settings.loader'
+  | 'app.modal';
+
+export type ShellSurfaceOwner = 'core' | 'addon';
+export type ShellSurfaceKind = 'required' | 'configurable' | 'additive';
+
+export interface ShellSurfaceRenderContext<TOptions = Record<string, unknown>> {
+  slot: ShellSurfaceSlot;
+  surface: ShellSurfaceDefinition<TOptions>;
+  options: TOptions;
+  addonContext?: unknown;
+}
+
+export interface ShellSurfaceDefinition<TOptions = Record<string, unknown>> {
+  id: string;
+  slot: ShellSurfaceSlot;
+  label: string;
+  owner: ShellSurfaceOwner;
+  kind: ShellSurfaceKind;
+  order: number;
+  defaultVisible: boolean;
+  render(context: ShellSurfaceRenderContext<TOptions>): ShellSurfaceRenderResult;
+  canRender?(context: ShellSurfaceRenderContext<TOptions>): boolean;
+  persistVisibility?: boolean;
+  persistGeometry?: boolean;
+}
+
+export interface ShellSurfacePublicInfo {
+  id: string;
+  slot: ShellSurfaceSlot;
+  label: string;
+  owner: ShellSurfaceOwner;
+  kind: ShellSurfaceKind;
+  order: number;
+  visible: boolean;
+  configurable: boolean;
+}
+
+type ShellSurfaceGeometry = Record<string, unknown>;
+type ShellSurfaceChangedListener = () => void;
+type ShellSlotRenderInput<TOptions = Record<string, unknown>> = Partial<Omit<ShellSurfaceRenderContext<TOptions>, 'slot' | 'surface'>>;
+
+const SHELL_SURFACE_SLOTS: ShellSurfaceSlot[] = [
+  'app.overlay',
+  'workspace.sidebar',
+  'workspace.toggle',
+  'workspace.splitter',
+  'editor.region',
+  'editor.tabbar',
+  'editor.host',
+  'editor.preview',
+  'editor.splitter',
+  'dock.splitter',
+  'dock.panel',
+  'dock.header',
+  'dock.body',
+  'timeline.menu',
+  'timeline.quick-actions',
+  'timeline.header',
+  'timeline.above',
+  'timeline.core',
+  'timeline.below',
+  'status.core',
+  'status.extension',
+  'compose.before',
+  'compose.box',
+  'compose.after',
+  'settings.loader',
+  'app.modal',
+];
+
+const VALID_SHELL_SURFACE_SLOTS = new Set<string>(SHELL_SURFACE_SLOTS);
+const STORAGE_PREFIX = 'piclaw.shell.surface.';
+const VISIBLE_SUFFIX = '.visible';
+const GEOMETRY_SUFFIX = '.geometry';
+
+const registry = new Map<string, ShellSurfaceDefinition>();
+const subscribers = new Set<ShellSurfaceChangedListener>();
+const createdStorageKeys = new Set<string>();
+
+function assertValidDefinition(definition: ShellSurfaceDefinition): void {
+  if (typeof definition.id !== 'string' || definition.id.trim().length === 0) {
+    throw new Error('Shell surface id must be a non-empty string');
+  }
+  if (!VALID_SHELL_SURFACE_SLOTS.has(definition.slot)) {
+    throw new Error(`Invalid shell surface slot: ${String(definition.slot)}`);
+  }
+}
+
+function sortSurfaces(a: ShellSurfaceDefinition, b: ShellSurfaceDefinition): number {
+  const orderDiff = a.order - b.order;
+  if (orderDiff !== 0) return orderDiff;
+  return a.id.localeCompare(b.id);
+}
+
+function toPublicInfo(definition: ShellSurfaceDefinition): ShellSurfacePublicInfo {
+  return {
+    id: definition.id,
+    slot: definition.slot,
+    label: definition.label,
+    owner: definition.owner,
+    kind: definition.kind,
+    order: definition.order,
+    visible: getShellSurfaceVisible(definition.id, definition.defaultVisible),
+    configurable: definition.kind !== 'required',
+  };
+}
+
+function getStorage(): Storage | null {
+  const candidate = globalThis.localStorage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  if (!candidate) return null;
+  try {
+    const probeKey = `${STORAGE_PREFIX}probe`;
+    candidate.getItem(probeKey);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+function visibilityKey(id: string): string {
+  return `${STORAGE_PREFIX}${id}${VISIBLE_SUFFIX}`;
+}
+
+function geometryKey(id: string): string {
+  return `${STORAGE_PREFIX}${id}${GEOMETRY_SUFFIX}`;
+}
+
+function getStorageItem(key: string): string | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function setStorageItem(key: string, value: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(key, value);
+    createdStorageKeys.add(key);
+  } catch {
+    return;
+  }
+}
+
+function removeStorageItem(key: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(key);
+  } catch {
+    return;
+  }
+}
+
+function notifyBrowserEvent(): void {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') return;
+  try {
+    const event = typeof CustomEvent === 'function'
+      ? new CustomEvent('piclaw:shell-surfaces-changed')
+      : new Event('piclaw:shell-surfaces-changed');
+    window.dispatchEvent(event);
+  } catch (error) {
+    console.error('Failed to dispatch shell surfaces changed event', error);
+  }
+}
+
+function buildRenderContext<TOptions>(
+  slot: ShellSurfaceSlot,
+  definition: ShellSurfaceDefinition<TOptions>,
+  context: ShellSlotRenderInput<TOptions> = {},
+): ShellSurfaceRenderContext<TOptions> {
+  return {
+    ...context,
+    slot,
+    surface: definition,
+    options: (context.options ?? {}) as TOptions,
+  };
+}
+
+export function registerShellSurface(definition: ShellSurfaceDefinition): () => void {
+  assertValidDefinition(definition);
+  registry.set(definition.id, definition);
+  notifyShellSurfacesChanged();
+  return () => unregisterShellSurface(definition.id);
+}
+
+export function unregisterShellSurface(id: string): void {
+  if (!registry.delete(id)) return;
+  notifyShellSurfacesChanged();
+}
+
+export function getShellSurface(id: string): (ShellSurfaceDefinition & ShellSurfacePublicInfo) | undefined {
+  const definition = registry.get(id);
+  if (!definition) return undefined;
+  return {
+    ...definition,
+    visible: getShellSurfaceVisible(definition.id, definition.defaultVisible),
+    configurable: definition.kind !== 'required',
+  };
+}
+
+export function listShellSurfaces(slot?: ShellSurfaceSlot): ShellSurfacePublicInfo[] {
+  return Array.from(registry.values())
+    .filter((definition) => !slot || definition.slot === slot)
+    .sort(sortSurfaces)
+    .map(toPublicInfo);
+}
+
+export function renderShellSlot<TOptions = Record<string, unknown>>(
+  slot: ShellSurfaceSlot,
+  context: ShellSlotRenderInput<TOptions> = {},
+): ShellSurfaceRenderResult[] {
+  return Array.from(registry.values())
+    .filter((definition) => definition.slot === slot)
+    .sort(sortSurfaces)
+    .flatMap((definition) => {
+      if (!getShellSurfaceVisible(definition.id, definition.defaultVisible)) return [];
+      const renderContext = buildRenderContext(slot, definition as ShellSurfaceDefinition<TOptions>, context);
+      try {
+        if (definition.canRender && !definition.canRender(renderContext as ShellSurfaceRenderContext)) return [];
+      } catch (error) {
+        console.error(`Shell surface canRender failed for ${definition.id}`, error);
+        return [];
+      }
+      try {
+        return [definition.render(renderContext as ShellSurfaceRenderContext)];
+      } catch (error) {
+        console.error(`Shell surface render failed for ${definition.id}`, error);
+        return [];
+      }
+    });
+}
+
+export function getShellSurfaceVisible(id: string, fallback: boolean): boolean {
+  const definition = registry.get(id);
+  if (definition?.kind === 'required') return true;
+  const raw = getStorageItem(visibilityKey(id));
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return fallback;
+}
+
+export function setShellSurfaceVisible(id: string, visible: boolean): void {
+  const definition = registry.get(id);
+  if (definition?.kind === 'required' && !visible) return;
+  setStorageItem(visibilityKey(id), String(visible));
+  notifyShellSurfacesChanged();
+}
+
+export function clearShellSurfaceVisible(id: string): void {
+  removeStorageItem(visibilityKey(id));
+  createdStorageKeys.delete(visibilityKey(id));
+  notifyShellSurfacesChanged();
+}
+
+export function getShellSurfaceGeometry(id: string): ShellSurfaceGeometry | null {
+  const raw = getStorageItem(geometryKey(id));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ShellSurfaceGeometry;
+  } catch {
+    return null;
+  }
+}
+
+export function setShellSurfaceGeometry(id: string, geometry: ShellSurfaceGeometry): void {
+  setStorageItem(geometryKey(id), JSON.stringify(geometry));
+  notifyShellSurfacesChanged();
+}
+
+export function clearShellSurfaceGeometry(id: string): void {
+  removeStorageItem(geometryKey(id));
+  createdStorageKeys.delete(geometryKey(id));
+  notifyShellSurfacesChanged();
+}
+
+export function subscribeShellSurfacesChanged(listener: ShellSurfaceChangedListener): () => void {
+  subscribers.add(listener);
+  return () => subscribers.delete(listener);
+}
+
+export function notifyShellSurfacesChanged(): void {
+  for (const listener of Array.from(subscribers)) {
+    try {
+      listener();
+    } catch (error) {
+      console.error('Shell surface subscriber failed', error);
+    }
+  }
+  notifyBrowserEvent();
+}
+
+export function resetShellSurfaceRegistryForTests(): void {
+  registry.clear();
+  subscribers.clear();
+  const storage = getStorage();
+  if (storage) {
+    for (const key of Array.from(createdStorageKeys)) {
+      removeStorageItem(key);
+    }
+    try {
+      for (let index = storage.length - 1; index >= 0; index -= 1) {
+        const key = storage.key(index);
+        if (key?.startsWith(STORAGE_PREFIX) && (key.endsWith(VISIBLE_SUFFIX) || key.endsWith(GEOMETRY_SUFFIX))) {
+          storage.removeItem(key);
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to clear shell surface test storage keys', error);
+    }
+  }
+  createdStorageKeys.clear();
+}


### PR DESCRIPTION
## Idea

- Big fan of piclaw!
- I appreciate how pi's TUI is basically customizable in any way
- I attempted a slop PR to make the app shell more customizable in piclaw
- **My thinking is: I believe you basically got everything right in your version of what a "claw-for-pi" should be — but I do think the app shell should be more malleable**
- Feel free to close if you disagree; thanks!

---

## Summary

This PR adds a frontend-only shell surface registry so Piclaw's app chrome can become customizable without changing the backend chat/runtime model.

The motivating idea is to lean into the same customizability ethos that makes building on top of `pi` attractive: keep the durable chat/session/runtime foundations intact, but make the surrounding app shell more declarative and extensible.

## Reasoning

Piclaw already has strong core abstractions around chat turns, `chatJid`, panes, add-ons, and runtime extension loading. The part that is currently least customizable is the web app shell: sidebar, tab strip, dock header/body, timeline menu, quick actions, status areas, settings loader, and composer placement are mostly hardcoded in `renderMainShell`.

This change does **not** try to turn everything into a pane or alter agent/chat semantics. Instead it introduces a separate shell-surface abstraction:

- content panes remain handled by the existing pane registry
- chat timeline and composer remain required/special surfaces
- backend runtime, queues, cursors, and AgentPool remain unchanged
- app chrome becomes registered by stable built-in surface ids
- add-ons can contribute only constrained additive surfaces in safe slots

The result is a path toward configurable product shape while preserving Piclaw's existing UX by default.

## What changed

- Added `runtime/web/src/ui/shell-surface-registry.ts`
  - frontend-only registry
  - slot validation
  - ordered rendering
  - visibility/geometry persistence
  - change subscriptions and browser events
  - required-surface visibility protection

- Added `runtime/web/src/ui/app-shell-builtins.ts`
  - idempotent registration of built-in `piclaw.*` shell surfaces
  - preserves current default app shell rendering

- Updated `runtime/web/src/ui/app-main-shell-render.ts`
  - renders registered shell slots inside the existing structural wrappers
  - preserves direct-child CSS/layout contracts
  - keeps splitters structural
  - keeps timeline/composer/editor/dock hosts special

- Extended add-on web API
  - `__piclaw_web.registerShellSurface`
  - `__piclaw_registerShellSurface`
  - additive-only allowlisted slots
  - rejects `piclaw.*` ids and core/special slots

- Added Settings → Shell
  - lists shell surfaces by slot
  - toggles configurable/additive surfaces
  - keeps required surfaces read-only
  - reset controls for visibility/geometry persistence

- Added project skill
  - `.pi/skills/pi-workers-orchestration/SKILL.md`
  - captures the pi-workers orchestration protocol used for this work

## Test results

Passed locally:

- `bun test runtime/test/web/shell-surface-registry.test.ts runtime/test/web/app-main-shell-render.test.ts runtime/test/web/app-main-shell-composition.test.ts runtime/test/web/app-main-render-composition.test.ts runtime/test/web/addon-web-extensions.test.ts runtime/test/web/app-shell-bootstrap.test.ts runtime/test/web/settings-pane-registry.test.ts runtime/test/web/shell-settings.test.ts runtime/test/web/settings-widget-fixture.test.ts`
  - 45 pass, 0 fail
- `bun run typecheck`
- `bun run build:web`
- `bun run check:silent-swallows`

I also attempted `make ci-fast`. It ran broadly but failed on an existing/unrelated runtime test issue:

- `runtime/test/runtime/supervisor-config-sync.test.ts`
- `sync_workspace_supervisor_defaults: command not found`

The shell-specific targeted tests, typecheck, and web build passed.
