### PR TITLE
fix: use expect for web terminal PTY on macOS

### DIFF
--- a/runtime/src/channels/web/terminal/terminal-session-service.ts
+++ b/runtime/src/channels/web/terminal/terminal-session-service.ts
@@ -235,9 +235,21 @@ function findExecutable(name: string): string {
 
 const SCRIPT_BIN = findExecutable("script");
 const BASH_BIN = findExecutable("bash");
+const EXPECT_BIN = findExecutable("expect");
+const USER_SHELL = process.env.SHELL || BASH_BIN;
 
 function defaultSpawnProcess(cwd: string): TerminalProcessLike {
-  return spawn(SCRIPT_BIN, ["-qf", "-c", `${BASH_BIN} -i`, "/dev/null"], {
+  // Linux: use `script` with GNU flags to allocate a PTY.
+  // macOS: `script` fails with piped stdio (tcgetattr error). Use `expect`
+  // to allocate a real PTY instead — it's pre-installed on macOS.
+  // Both paths spawn the user's default shell ($SHELL) instead of hardcoding bash.
+  // For zsh: disable PROMPT_SP to prevent a line of spaces before each prompt
+  // that renders as a blank line in the web terminal.
+  const shellArgs = USER_SHELL.endsWith("/zsh") ? "+o PROMPT_SP -i" : "-i";
+  const command = IS_LINUX
+    ? { bin: SCRIPT_BIN, args: ["-qf", "-c", `${USER_SHELL} ${shellArgs}`, "/dev/null"] }
+    : { bin: EXPECT_BIN, args: ["-c", `log_user 0; spawn -noecho ${USER_SHELL} ${shellArgs}; log_user 1; interact`] };
+  return spawn(command.bin, command.args, {
     cwd,
     env: {
       ...process.env,
@@ -248,6 +260,8 @@ function defaultSpawnProcess(cwd: string): TerminalProcessLike {
       HOME: process.env.HOME || "/home/agent",
       COLUMNS: String(DEFAULT_COLS),
       LINES: String(DEFAULT_ROWS),
+      PROMPT_EOL_MARK: "",
+      SHELL_SESSION_DID_INIT: "1",
     },
     stdio: ["pipe", "pipe", "pipe"],
   }) as ChildProcessWithoutNullStreams;


### PR DESCRIPTION
## Problem

The web terminal fails on native macOS installs (including the Electrobun desktop shell) with three issues:

1. **`script: tcgetattr/ioctl: Operation not supported on socket`** — terminal won't open at all
2. **Hardcoded bash** — macOS default shell is zsh, but the terminal always spawns bash
3. **Blank lines between every zsh prompt** — zsh's PROMPT_SP feature renders as visible blank lines in the web terminal

## Root causes

### 1. BSD `script` vs GNU `script`
`defaultSpawnProcess()` uses `script -qf -c "bash -i" /dev/null` — GNU/Linux syntax. BSD `script` (macOS) doesn't support `-f` and can't allocate a PTY when stdin is piped (`stdio: ["pipe", "pipe", "pipe"]`).

### 2. Hardcoded `BASH_BIN`
The shell binary was hardcoded to `bash`, ignoring `$SHELL`.

### 3. zsh PROMPT_SP
zsh outputs a line of ~120 invisible spaces before each prompt (the `PROMPT_SP` feature) to preserve partial output lines. In a real terminal this is invisible; in the web terminal's Ghostty renderer it shows as a blank line.

## Fix

```typescript
const USER_SHELL = process.env.SHELL || BASH_BIN;
const EXPECT_BIN = findExecutable("expect");

const shellArgs = USER_SHELL.endsWith("/zsh") ? "+o PROMPT_SP -i" : "-i";
const command = IS_LINUX
  ? { bin: SCRIPT_BIN, args: ["-qf", "-c", `${USER_SHELL} ${shellArgs}`, "/dev/null"] }
  : { bin: EXPECT_BIN, args: ["-c", `log_user 0; spawn -noecho ${USER_SHELL} ${shellArgs}; log_user 1; interact`] };
```

Plus env vars: `PROMPT_EOL_MARK=""` and `SHELL_SESSION_DID_INIT=1` to suppress the EOL mark character and macOS session restore messages.

`expect` is pre-installed on macOS at `/usr/bin/expect`. `log_user 0/1` around spawn suppresses expect's own output.

## What changed

| Before | After |
|---|---|
| `script -qf -c "bash -i"` on all platforms | Linux: `script -qf` (unchanged) · macOS: `expect` |
| Always bash | `$SHELL` (user's default) |
| zsh blank lines in web terminal | `+o PROMPT_SP` disables on both platforms |

## Testing

- macOS 26.5 (Apple M5 Pro, native install): zsh opens cleanly, no blank lines, no tcgetattr error, no session restore messages
- Bash fallback works when switching shells inside the terminal
- Linux path unchanged — still uses `script -qf`

1 file changed, 15 insertions(+), 1 deletion(-)