### PR TITLE
fix: preserve unsaved editor content across tab switches

### DIFF
--- a/runtime/extensions/viewers/editor/editor-extension.ts
+++ b/runtime/extensions/viewers/editor/editor-extension.ts
@@ -285,7 +285,7 @@ export class StandaloneEditorInstance implements PaneInstance {
     private dirtyChangeCb: ((dirty: boolean) => void) | null = null;
     private saveRequestCb: ((content: string) => void) | null = null;
     private closeCb: (() => void) | null = null;
-    private viewStateChangeCb: ((state: { cursorLine: number; cursorCol: number; scrollTop: number }) => void) | null = null;
+    private viewStateChangeCb: ((state: { cursorLine: number; cursorCol: number; scrollTop: number; content?: string }) => void) | null = null;
     private contentChangeCb: ((content: string) => void) | null = null;
 
     // External change detection
@@ -372,6 +372,9 @@ export class StandaloneEditorInstance implements PaneInstance {
 
         if (context.content !== undefined) {
             this.mountEditor(context.content, context.mtime);
+            if (context.dirty) {
+                this.setDirty(true);
+            }
             if (transferState) {
                 this.applyHostTransferState(transferState);
             }
@@ -1163,6 +1166,17 @@ export class StandaloneEditorInstance implements PaneInstance {
 
     dispose(): void {
         if (this.disposed) return;
+        // Flush current viewState (including content if dirty) before tearing down,
+        // so the tab store has the latest unsaved content for restore on re-mount.
+        // Skip for large documents to avoid excessive memory in the tab store.
+        try {
+            if (this.viewStateChangeCb && this.view && this.dirty && !this.largeDocumentMode) {
+                const viewState = this.captureViewState();
+                if (viewState) {
+                    this.viewStateChangeCb({ ...viewState, content: this.view.state.doc.toString() });
+                }
+            }
+        } catch { /* best-effort — don't block dispose */ }
         this.disposed = true;
         this.conflictMonitor?.dispose();
         this.clearDirtyRecheckTimer();
@@ -1239,8 +1253,8 @@ export class StandaloneEditorInstance implements PaneInstance {
 
     // ── Extended PaneInstance methods ────────────────────────────
 
-    /** Register callback for view state changes (cursor, scroll). */
-    onViewStateChange(cb: (state: { cursorLine: number; cursorCol: number; scrollTop: number }) => void): void {
+    /** Register callback for view state changes (cursor, scroll, and content when dirty). */
+    onViewStateChange(cb: (state: { cursorLine: number; cursorCol: number; scrollTop: number; content?: string }) => void): void {
         this.viewStateChangeCb = cb;
     }
 

--- a/runtime/web/src/panes/pane-types.ts
+++ b/runtime/web/src/panes/pane-types.ts
@@ -26,6 +26,8 @@ export interface PaneContext {
     mtime?: string;
     /** File size in bytes. */
     size?: number;
+    /** Whether the content is from an unsaved restore (editor should mark as dirty). */
+    dirty?: boolean;
     /** Optional preview payload for read-only workspace/file previews. */
     preview?: Record<string, unknown>;
     /** Optional host-transfer payload consumed by panes that support detach/reattach handoff. */

--- a/runtime/web/src/ui/app-pane-runtime-orchestration.ts
+++ b/runtime/web/src/ui/app-pane-runtime-orchestration.ts
@@ -1008,10 +1008,15 @@ export function usePaneRuntimeOrchestration(options: UsePaneRuntimeOrchestration
     } else if (resolvedTransferState && 'diffMode' in resolvedTransferState) {
       delete resolvedTransferState.diffMode;
     }
+    const savedViewState = tabStore.getViewState(activeId);
+    const savedContent = savedViewState?.content;
+    const tabIsDirty = tabStore.getTabs().find(t => t.id === activeId)?.dirty;
     const context = {
       path: activeId,
       mode: 'edit',
-      ...(pendingTransfer?.content !== undefined ? { content: pendingTransfer.content } : {}),
+      ...(pendingTransfer?.content !== undefined ? { content: pendingTransfer.content }
+        : tabIsDirty && typeof savedContent === 'string' ? { content: savedContent, dirty: true }
+        : {}),
       ...(pendingTransfer?.mtime !== undefined ? { mtime: pendingTransfer.mtime } : {}),
       ...(resolvedTransferState ? { transferState: resolvedTransferState } : {}),
     };


### PR DESCRIPTION
## Problem

When editing multiple files in separate tabs, unsaved changes are lost on tab switch. Opening `file1.txt`, making edits, switching to `file2.txt`, and switching back shows the on-disk version — all edits gone. The dirty indicator persists and the close warning fires, but the actual content is lost.

## Root cause

The pane runtime (`app-pane-runtime-orchestration.ts:975`) disposes and recreates pane instances on every `tabStripActiveId` change. The editor's `viewState` only saves `{ cursorLine, cursorCol, scrollTop }` — not the document content. On remount, `loadFile()` reads from disk, discarding in-memory unsaved edits.

Additionally, even when content is restored, `mountEditor()` sets `initialContent = restoredContent` and `dirty = false`, so the editor treats the unsaved content as the baseline — a subsequent tab switch won't flush it again.

## Fix (3 files, +25 −4 lines)

### 1. `editor-extension.ts` — flush content on dispose

```typescript
dispose(): void {
    if (this.disposed) return;
    try {
            const viewState = this.captureViewState();
            if (viewState) {
                this.viewStateChangeCb({ ...viewState, content: this.view.state.doc.toString() });
            }
        }
    } catch { /* best-effort — don't block dispose */ }
    // ... existing dispose logic
}
```

Content is flushed **only in dispose()** (not per-keystroke), **only when dirty**, and **skipped for large documents** to avoid excessive memory.

Also: when mounting with `context.dirty = true`, calls `setDirty(true)` after mount so subsequent switches continue preserving content.

### 2. `pane-types.ts` — extend PaneContext

Added `dirty?: boolean` to `PaneContext` interface (clean type contract, no `as any` casts).

### 3. `app-pane-runtime-orchestration.ts` — restore from viewState

When building the mount context, if the tab is dirty and viewState has saved content, uses that content instead of loading from disk:

```typescript
const savedViewState = tabStore.getViewState(activeId);
const savedContent = savedViewState?.content;
const tabIsDirty = tabStore.getTabs().find(t => t.id === activeId)?.dirty;
// ... passes { content: savedContent, dirty: true } if applicable
```

## What's preserved / not preserved

| State | Preserved | Notes |
|---|---|---|
| Unsaved content | ✅ | Flushed to tab store on dispose |
| Cursor position | ✅ | Existing viewState mechanism |
| Scroll position | ✅ | Existing viewState mechanism |
| Dirty indicator | ✅ | Restored via context.dirty |
| Undo history | ❌ | CodeMirror EditorState is destroyed (existing limitation) |
| Large file content | ❌ | Skipped when `largeDocumentMode` to avoid memory bloat |

## Edge cases handled

- **Save then switch**: dirty=false → content NOT flushed → loadFile() on return (correct — disk has latest)
- **Save, edit more, switch**: dirty=true again → content flushed → restored (correct)
- **Pop-out/detach**: `pendingTransfer` takes precedence (unaffected)
- **Browser crash**: content lost (same as any editor without auto-save)
- **Dispose throws**: try/catch ensures cleanup completes

## Testing

- macOS 26.5 (Apple M5 Pro), native install
- Verified: edit file1 → switch to file2 → switch back → edits preserved
- Verified: multiple round-trips (file1 → file2 → file1 → file2 → file1) all preserve content
- Verified: save clears dirty state correctly
- `bun run typecheck` passes