### PR TITLE
fix: preserve terminal session across tab switches

### DIFF
--- a/runtime/src/channels/web/terminal/terminal-session-service.ts
+++ b/runtime/src/channels/web/terminal/terminal-session-service.ts
@@ -70,7 +70,7 @@ const TERMINAL_ANON_CLIENT_HEADER = "x-piclaw-terminal-client";
 
 const IS_LINUX = process.platform === "linux";
 const DEFAULT_TERMINAL_HANDOFF_TTL_MS = 5 * 60 * 1000;
-const DEFAULT_TERMINAL_RECONNECT_GRACE_MS = 3_000;
+const DEFAULT_TERMINAL_RECONNECT_GRACE_MS = 300_000;
 const DEFAULT_TERMINAL_OUTPUT_HISTORY_LIMIT_BYTES = 2 * 1024 * 1024;
 const log = createLogger("web.terminal-session-service");
 
@@ -324,8 +324,13 @@ export class TerminalSessionService {
   attachClient(ws: ServerWebSocket<TerminalSocketData>): void {
     const owner = ws.data;
     const isHandoff = this.validateHandoff(owner);
+    const existingSession = this.sessions.get(owner.token);
     const canResumeDetachedSession = !isHandoff && this.canResumeDetachedSession(owner);
-    if (!isHandoff && !canResumeDetachedSession) {
+    // Allow same-owner reconnect without resetting the session — the old client
+    // may still be closing (WebSocket close is async). This prevents a race where
+    // a tab-switch dispose + remount kills the shell because the old WS hasn't
+    // fully closed yet.
+    if (!isHandoff && !canResumeDetachedSession && !existingSession) {
       this.resetSession(owner, "fresh attach");
     }
     const session = this.ensureSession(owner);


### PR DESCRIPTION
## Problem

The web terminal loses its shell session (environment variables, working directory, command history) when switching to another tab (e.g. editor) and back. Even switching away for a few seconds resets the terminal to a fresh shell.

## Root cause

Two compounding issues:

### 1. WebSocket close race condition

The pane runtime disposes and recreates pane instances on every tab switch. `dispose()` initiates WebSocket close (async), then the new instance connects immediately. In `attachClient()`:

```
1. Old WS: socket.close() called [async — close event pending]
2. New WS: connects to server
3. attachClient(newWS):
   - canResumeDetachedSession → false (session.clients.size > 0, old WS still there)
   - resetSession() → KILLS THE SHELL (SIGHUP)
4. Old WS close event arrives (too late — session already destroyed)
```

The reconnect grace period was never reached because `resetSession` fired first.

### 2. Reconnect grace too short

`DEFAULT_TERMINAL_RECONNECT_GRACE_MS` was 3 seconds — too short for normal tab navigation where users may spend minutes editing a file.

## Fix (1 file, +7 −2 lines)

### Race condition fix

Skip `resetSession` when a session already exists for the same owner token:

```typescript
const existingSession = this.sessions.get(owner.token);
  this.resetSession(owner, "fresh attach");
}
```

The old client's close event arrives shortly after and is cleaned up normally via `detachClient`. The new client attaches to the existing session seamlessly.

### Grace period increase

```typescript
const DEFAULT_TERMINAL_RECONNECT_GRACE_MS = 300_000; // 5 minutes (was 3 seconds)
```

Shell survives tab switches and is cleaned up after 5 minutes of true abandonment. Users can still get a fresh terminal by typing `exit` in the shell.

## Side effect: dock/tab contention improved

Previously, opening a terminal dock while a terminal tab existed killed the tab's shell. With this fix, both panes attach to the **same session** — they share the shell (like two windows into the same tmux session) instead of fighting over it.

## Testing

- macOS 26.5 (Apple M5 Pro), native install
- `export foo=bar` → switch to editor → wait 30s → switch back → `echo $foo` prints `bar` ✅
- All 8 existing terminal session service tests pass
- Handoff, shutdown, and IO relay tests unaffected