### PR TITLE
fix(visual): show raw context window in model picker

### DIFF
--- a/runtime/web/static/visual/frontend/src/components/model-context-bar/ModelPicker.tsx
+++ b/runtime/web/static/visual/frontend/src/components/model-context-bar/ModelPicker.tsx
@@ -1,6 +1,5 @@
 import type { ModelEntry } from "./types";
 import { formatTokenWindow } from "../../utils/format";
-import { getEffectiveContextWindow } from "../../utils/context-budget";
 
 interface ModelPickerProps {
   models: ModelEntry[];
@@ -16,8 +15,7 @@ export function ModelPicker({ models, activeModel, onSelectModel }: ModelPickerP
     >
       {models.map((entry) => {
         const isCurrent = entry.id === activeModel;
-        const effectiveCtx = entry.context_window ? getEffectiveContextWindow(entry.context_window) : null;
-        const ctxK = effectiveCtx ? formatTokenWindow(effectiveCtx) : "";
+        const ctxK = entry.context_window ? formatTokenWindow(entry.context_window) : "";
         return (
           <div
             key={entry.id}


### PR DESCRIPTION
## Problem

The visual UI model picker applies `getEffectiveContextWindow()` before displaying context window sizes, subtracting a 4k system prompt overhead. This shows **996k** instead of **1.0M** for models like claude-opus-4.6.

This is inconsistent — the status bar `ContextRing` and classic UI both display the raw `context_window` value from the API.

## Root Cause

`ModelPicker.tsx` imported `getEffectiveContextWindow` from `utils/context-budget.ts` and applied it to each model's `context_window` before formatting for display. This budget math belongs in the backend (compaction, orchestration), not the display layer.

## Fix

Remove `getEffectiveContextWindow()` from `ModelPicker.tsx` — display raw `context_window` directly using `formatTokenWindow()`.

**1 file changed, 1 insertion, 3 deletions.**

## Before / After

| Model | Before | After |
|-------|--------|-------|
| claude-opus-4.6 | 996k | 1.0M |
| claude-sonnet-4.6 | 996k | 1.0M |
| claude-haiku-4.5 | 136k | 140k |
| gemini-2.5-pro | 120k | 124k |