### PR TITLE
feat: macOS terminal resize via native PTY addon

### DIFF
--- a/docs/macos-terminal-resize.md
+++ b/docs/macos-terminal-resize.md
@@ -1,0 +1,118 @@
+# macOS Terminal Resize — Known Limitation & Architecture Notes
+
+> Reference for future PRs touching the web terminal on macOS.
+
+## Summary
+
+macOS `/usr/bin/top` (setuid root) does **not** resize when the PTY master fd
+is held in a **child process** that communicates via pipes (the `pty_spawn`
+architecture). All other terminal applications (nano, vim, htop, ncurses apps,
+shell scripts) resize correctly.
+
+## What works
+
+| App | Resize | Notes |
+|-----|--------|-------|
+| Shell prompt (`stty size`) | ✅ | Correct after every resize |
+| nano | ✅ | Full-screen ncurses redraw |
+| vim | ✅ | Full-screen ncurses redraw |
+| htop | ✅ | Not setuid |
+| Custom ncurses / ANSI apps | ✅ | SIGWINCH delivered, ioctl returns new size |
+| `/usr/bin/top` | ❌ | Setuid root — see below |
+
+## Root cause
+
+The issue is in **how** the PTY child process is created, not in the resize
+ioctl itself.
+
+### The fork-vs-posix_spawn gap
+
+Terminal.app, iTerm2, and Go's `creack/pty` library all use this sequence:
+
+```
+fork()
+  ├─ child (before exec):
+  │    setsid()              ← new session, become session leader
+  │    ioctl(slave, TIOCSCTTY) ← set controlling terminal
+  │    dup2(slave, 0/1/2)
+  │    close(extras)
+  │    exec(shell)
+  └─ parent:
+       ioctl(master, TIOCSWINSZ)  ← kernel delivers SIGWINCH to fg group
+```
+
+The critical detail: `setsid()` + `TIOCSCTTY` happen **between fork and exec**,
+in the raw child context before any new program image loads.
+
+Bun's `Bun.spawn()` uses `posix_spawn()`, which does **not** support running
+custom code between process creation and exec. We tried a C helper
+(`pty_login`) that calls `setsid` + `TIOCSCTTY` after exec — the calls
+succeed, but macOS does not treat the controlling terminal relationship the
+same way for setuid binaries. The setuid `top` never responds to SIGWINCH.
+
+### Evidence from automated testing
+
+A Playwright + xterm.js test framework was built to verify resize by measuring
+top's output volume before and after `ioctl(TIOCSWINSZ)`:
+
+| Architecture | top resized? | Output ratio |
+|---|---|---|
+| Go webterm (`creack/pty`, direct fd in server, real `fork`) | ✅ | 0.070 |
+| `pty_spawn` C binary (7 ioctl variants tested) | ❌ | 0.78–1.09 |
+| `pty_spawn` rewritten in Go (pipe relay) | ❌ | 0.79 |
+| FFI `openpty` + `pty_login` helper (Bun holds master fd) | ❌ | 1.09 |
+
+A ratio near **0.16** indicates resize (area ratio of 60×15 / 140×40).
+Values near **0.8–1.0** mean no resize occurred.
+
+### Why only `top`?
+
+`/usr/bin/top` is a **setuid root** binary with the entitlement
+`com.apple.system-task-ports.read`. macOS applies stricter security checks
+for SIGWINCH delivery to setuid processes. Non-setuid apps receive SIGWINCH
+normally regardless of PTY architecture.
+
+## Implementation
+
+This PR uses a native C addon (`pty_native.c`, ~80 lines) compiled to a
+`.dylib` on first use. It provides three functions:
+
+- `pty_open(rows, cols)` — creates a PTY pair via `openpty()` with `O_CLOEXEC`
+- `pty_fork_exec_simple(slaveFd, shell)` — `fork()` with `setsid()` + `TIOCSCTTY` in the fork-exec gap, then `exec(shell)`
+- `pty_resize(masterFd, rows, cols)` — `ioctl(TIOCSWINSZ)`
+
+The `fork()` happens directly in Bun's process. Only async-signal-safe
+functions are called before `exec()` replaces the child process image.
+PTY I/O uses Node's `fs.read`/`fs.write` on the master fd.
+
+If `cc` is not available (no Xcode CLT), the compile fails gracefully and
+piclaw falls back to the existing `expect`-based PTY.
+
+### Files
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `pty_native.c` | ~80 | Native PTY addon (C source, compiled on first use) |
+| `terminal-session-service.ts` | +150 | macOS PTY integration: load dylib, spawn, I/O, resize |
+
+### What changes for Linux
+
+Nothing. All macOS code is gated by `IS_MACOS`. Zero code paths change on Linux.
+
+## References
+
+- `creack/pty` (Go): `go/pkg/mod/github.com/creack/pty@v1.1.18/start.go`
+- iTerm2 PTY code: `github.com/gnachman/iTerm2/sources/Tasks/PTYTask.m`
+
+### Troubleshooting
+
+If terminal resize doesn't work for `top` on macOS, ensure Xcode Command
+Line Tools are installed:
+
+```bash
+xcode-select --install
+```
+
+The native addon requires `cc` to compile on first use. Without it, piclaw
+falls back to the `expect`-based PTY which works for all apps except
+setuid `top`.

--- a/runtime/src/channels/web/terminal/pty_native.c
+++ b/runtime/src/channels/web/terminal/pty_native.c
@@ -1,0 +1,89 @@
+/*
+ * pty_native.c — Minimal macOS PTY addon for Bun/Node.
+ *
+ * Exports three functions via a shared library (.dylib):
+ *   pty_open(rows, cols) → { masterFd, slaveFd }
+ *   pty_fork_exec_simple(slaveFd, shell) → childPid
+ *   pty_resize(masterFd, rows, cols) → 0 on success
+ *
+ * pty_fork_exec_simple does the critical fork() → setsid() → TIOCSCTTY → exec()
+ * in the fork-exec gap, which is required for SIGWINCH delivery to setuid
+ * programs on macOS.
+ *
+ * Compile: cc -shared -o pty_native.dylib pty_native.c
+ */
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <util.h>
+
+/* Result struct for pty_open — caller reads masterFd and slaveFd. */
+struct pty_pair {
+    int master_fd;
+    int slave_fd;
+};
+
+/*
+ * Create a PTY pair with the given initial size.
+ * Returns 0 on success, -1 on failure.
+ */
+int pty_open(struct pty_pair *out, int rows, int cols) {
+    struct winsize ws = { .ws_row = rows, .ws_col = cols };
+    int master, slave;
+    if (openpty(&master, &slave, NULL, NULL, &ws) < 0)
+        return -1;
+    /* O_CLOEXEC on master — child must not inherit after exec */
+    fcntl(master, F_SETFD, FD_CLOEXEC);
+    out->master_fd = master;
+    out->slave_fd = slave;
+    return 0;
+}
+
+/*
+ * Resize the PTY. Returns 0 on success.
+ */
+int pty_resize(int master_fd, int rows, int cols) {
+    struct winsize ws = { .ws_row = rows, .ws_col = cols };
+    return ioctl(master_fd, TIOCSWINSZ, &ws);
+}
+
+/*
+ * Fork+exec with shell path as a simple string.
+ * Calls fork() directly in the calling process (Bun).
+ * The child calls only async-signal-safe functions before exec.
+ */
+pid_t pty_fork_exec_simple(int slave_fd, const char *shell) {
+    pid_t pid = fork();
+    if (pid < 0) return -1;
+
+    if (pid == 0) {
+        setsid();
+        ioctl(slave_fd, TIOCSCTTY, 0);
+        dup2(slave_fd, STDIN_FILENO);
+        dup2(slave_fd, STDOUT_FILENO);
+        dup2(slave_fd, STDERR_FILENO);
+        if (slave_fd > STDERR_FILENO) close(slave_fd);
+
+        int maxfd = (int)sysconf(_SC_OPEN_MAX);
+        if (maxfd < 0) maxfd = 256;
+        for (int fd = 3; fd < maxfd; fd++) close(fd);
+
+        /* Determine args based on shell */
+        size_t slen = strlen(shell);
+        int is_zsh = (slen >= 4 && strcmp(shell + slen - 4, "/zsh") == 0);
+        if (is_zsh) {
+            char *argv[] = {(char*)shell, "+o", "PROMPT_SP", "-i", NULL};
+            execvp(shell, argv);
+        } else {
+            char *argv[] = {(char*)shell, "-i", NULL};
+            execvp(shell, argv);
+        }
+        _exit(127);
+    }
+
+    return pid;
+}

--- a/runtime/src/channels/web/terminal/terminal-session-service.ts
+++ b/runtime/src/channels/web/terminal/terminal-session-service.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { openSync, closeSync, readlinkSync, readdirSync, readFileSync, accessSync, constants } from "node:fs";
-import { FFIType, dlopen } from "bun:ffi";
+import { openSync, closeSync, readlinkSync, readdirSync, readFileSync, accessSync, existsSync, statSync, constants, read as fsRead, write as fsWrite } from "node:fs";
+import { dirname, join } from "node:path";
+import { FFIType, dlopen, ptr } from "bun:ffi";
 import type { ServerWebSocket } from "bun";
 
 import { WORKSPACE_DIR } from "../../../core/config.js";
@@ -69,6 +70,7 @@ const TERMINAL_FONT_FAMILY = "FiraCode Nerd Font Mono";
 const TERMINAL_ANON_CLIENT_HEADER = "x-piclaw-terminal-client";
 
 const IS_LINUX = process.platform === "linux";
+const IS_MACOS = process.platform === "darwin";
 const DEFAULT_TERMINAL_HANDOFF_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_TERMINAL_RECONNECT_GRACE_MS = 300_000;
 const DEFAULT_TERMINAL_OUTPUT_HISTORY_LIMIT_BYTES = 2 * 1024 * 1024;
@@ -164,6 +166,147 @@ function resizePty(ptsPath: string, cols: number, rows: number): boolean {
   }
 }
 
+// ── macOS native PTY ─────────────────────────────────────────────────
+//
+// On macOS, terminal resize for setuid programs (e.g. /usr/bin/top)
+// requires fork()+setsid()+TIOCSCTTY in the fork-exec gap. Bun's
+// Bun.spawn uses posix_spawn which cannot do this. A small native
+// addon (.dylib, ~80 lines of C) provides the necessary fork+exec.
+// PTY I/O uses Node's fs.read/fs.write on the master fd.
+
+interface MacOSPtyLib {
+  pty_open(pairPtr: unknown, rows: number, cols: number): number;
+  pty_fork_exec_simple(slaveFd: number, shellPtr: unknown): number;
+  pty_resize(masterFd: number, rows: number, cols: number): number;
+}
+
+let _macPtyLib: MacOSPtyLib | null = null;
+let _macPtyLibLoaded = false;
+
+function getMacOSPtyLib(): MacOSPtyLib | null {
+  if (_macPtyLibLoaded) return _macPtyLib;
+  _macPtyLibLoaded = true;
+  try {
+    const dir = dirname(import.meta.path);
+    const dylibPath = join(dir, "pty_native.dylib");
+    const srcPath = join(dir, "pty_native.c");
+
+    const needsCompile = existsSync(srcPath) && (
+      !existsSync(dylibPath) ||
+      statSync(srcPath).mtimeMs > statSync(dylibPath).mtimeMs
+    );
+    if (needsCompile) {
+      const { execFileSync } = require("node:child_process");
+      execFileSync("cc", ["-shared", "-o", dylibPath, srcPath], { timeout: 10000, stdio: "ignore" });
+    }
+    if (!existsSync(dylibPath)) return null;
+
+    const lib = dlopen(dylibPath, {
+      pty_open: { args: [FFIType.ptr, FFIType.i32, FFIType.i32], returns: FFIType.i32 },
+      pty_fork_exec_simple: { args: [FFIType.i32, FFIType.ptr], returns: FFIType.i32 },
+      pty_resize: { args: [FFIType.i32, FFIType.i32, FFIType.i32], returns: FFIType.i32 },
+    });
+
+    _macPtyLib = {
+      pty_open: (p: any, r: number, c: number) => lib.symbols.pty_open(p, r, c) as number,
+      pty_fork_exec_simple: (sfd: number, sh: any) => lib.symbols.pty_fork_exec_simple(sfd, sh) as number,
+      pty_resize: (mfd: number, r: number, c: number) => lib.symbols.pty_resize(mfd, r, c) as number,
+    };
+    log.info("macOS native PTY loaded", { dylibPath });
+  } catch (error) {
+    debugSuppressedError(log, "macOS native PTY unavailable", error);
+    _macPtyLib = null;
+  }
+  return _macPtyLib;
+}
+
+function spawnMacOSNativePty(cwd: string, cols: number, rows: number): TerminalProcessLike | null {
+  const ptyLib = getMacOSPtyLib();
+  if (!ptyLib) return null;
+
+  const pair = new Int32Array(2);
+  if (ptyLib.pty_open(ptr(pair), rows, cols) !== 0) return null;
+  const masterFd = pair[0];
+  const slaveFd = pair[1];
+
+  const shell = USER_SHELL;
+  const shellBuf = Buffer.alloc(Buffer.byteLength(shell) + 1);
+  shellBuf.write(shell);
+  const childPid = ptyLib.pty_fork_exec_simple(slaveFd, ptr(shellBuf));
+  closeSync(slaveFd);
+
+  if (childPid <= 0) { closeSync(masterFd); return null; }
+
+  const dataListeners: Array<(chunk: string | Uint8Array) => void> = [];
+  const exitListeners: Array<(code: number | null, signal: NodeJS.Signals | null) => void> = [];
+  let closed = false;
+  const readBuf = Buffer.alloc(32768);
+  const textDecoder = new TextDecoder("utf-8", { fatal: false });
+
+  function readLoop() {
+    if (closed) return;
+    fsRead(masterFd, readBuf, 0, readBuf.length, null, (err, n) => {
+      if (closed) return;
+      if (err || !n) {
+        if (err && (err as any).code === "EIO") {
+          closed = true;
+          for (const l of exitListeners) l(null, null);
+          return;
+        }
+        setTimeout(readLoop, 10);
+        return;
+      }
+      const data = textDecoder.decode(readBuf.subarray(0, n), { stream: true });
+      for (const l of dataListeners) l(data);
+      readLoop();
+    });
+  }
+  readLoop();
+
+  const exitCheck = setInterval(() => {
+    try { process.kill(childPid, 0); } catch {
+      if (!closed) {
+        closed = true;
+        clearInterval(exitCheck);
+        for (const l of exitListeners) l(null, null);
+      }
+    }
+  }, 2000);
+
+  const proc: TerminalProcessLike & {
+    __macOSNativePty: boolean;
+    __resize(cols: number, rows: number): void;
+  } = {
+    __macOSNativePty: true,
+    __resize(newCols: number, newRows: number) {
+      if (!closed) ptyLib.pty_resize(masterFd, newRows, newCols);
+    },
+    stdin: {
+      write(chunk: string | Uint8Array) {
+        if (closed) return;
+        const data = typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk);
+        fsWrite(masterFd, data, 0, data.length, null, (err) => {
+          if (err) debugSuppressedError(log, "macOS PTY write failed", err as Error);
+        });
+      },
+    },
+    stdout: { on(event: string, listener: (chunk: string | Uint8Array) => void) { if (event === "data") dataListeners.push(listener); return this; } },
+    stderr: { on() { return this; } },
+    on(event: string, listener: (code: number | null, signal: NodeJS.Signals | null) => void) { if (event === "exit") exitListeners.push(listener); return this; },
+    kill(signal?: NodeJS.Signals | number) {
+      if (closed) return true;
+      closed = true;
+      clearInterval(exitCheck);
+      try { process.kill(childPid, typeof signal === "string" ? signal : "SIGHUP"); } catch (error) { debugSuppressedError(log, "macOS PTY kill failed", error as Error); }
+      try { closeSync(masterFd); } catch (error) { debugSuppressedError(log, "macOS PTY close failed", error as Error); }
+      return true;
+    },
+    pid: childPid,
+  };
+
+  return proc;
+}
+
 /**
  * Find child PIDs of a given parent by reading /proc.
  */
@@ -245,10 +388,14 @@ function buildShellArgs(): string[] {
 }
 
 function defaultSpawnProcess(cwd: string): TerminalProcessLike {
+  // macOS: prefer native PTY addon for proper resize (including setuid apps like top).
+  if (IS_MACOS) {
+    const proc = spawnMacOSNativePty(cwd, DEFAULT_COLS, DEFAULT_ROWS);
+    if (proc) return proc;
+  }
+
   // Linux: use `script` with GNU flags to allocate a PTY.
-  // macOS: `script` fails with piped stdio (tcgetattr error). Use `expect`
-  // to allocate a real PTY instead — it's pre-installed on macOS.
-  // Both paths spawn the user's default shell ($SHELL) instead of hardcoding bash.
+  // macOS fallback: use `expect` (no resize for setuid apps).
   const shellArgs = buildShellArgs();
   const command = IS_LINUX
     ? { bin: SCRIPT_BIN, args: ["-qf", "-c", [USER_SHELL, ...shellArgs].join(" "), "/dev/null"] }
@@ -475,6 +622,14 @@ export class TerminalSessionService {
    * kernel window size.
    */
   private resizeSession(session: TerminalSessionRecord, cols: number, rows: number): void {
+    // macOS native PTY: resize via ioctl in the addon
+    const proc = session.process as any;
+    if (proc?.__macOSNativePty && typeof proc.__resize === "function") {
+      proc.__resize(cols, rows);
+      return;
+    }
+
+    // Linux: ioctl on PTS device + SIGWINCH to children
     const pid = session.process.pid;
     if (!pid) return;
 


### PR DESCRIPTION
## Summary

On macOS, terminal resize for setuid programs (e.g. `/usr/bin/top`) requires `fork()` + `setsid()` + `TIOCSCTTY` in the fork-exec gap. Bun's `Bun.spawn` uses `posix_spawn` which cannot do this — SIGWINCH is never delivered to the setuid process.

## Solution

A native C addon (`pty_native.c`, 89 lines) compiled to `.dylib` on first use. It provides:
- `pty_open()` — creates a PTY pair via `openpty()` with `O_CLOEXEC`
- `pty_fork_exec_simple()` — `fork()` with `setsid()` + `TIOCSCTTY` in the fork-exec gap, then `exec(shell)`
- `pty_resize()` — `ioctl(TIOCSWINSZ)`

The `fork()` happens directly in Bun's process. Only async-signal-safe functions are called before `exec()` replaces the child image (same pattern as Go's `creack/pty` and iTerm2). PTY I/O uses Node's `fs.read`/`fs.write` on the master fd.

## What changed

| File | Lines | Purpose |
|------|-------|---------|
| `pty_native.c` | 89 | Native PTY addon (C source, compiled on first use) |
| `terminal-session-service.ts` | +160 | macOS PTY integration: load dylib, spawn, I/O, resize |
| `docs/macos-terminal-resize.md` | 118 | Investigation findings + architecture notes |

## Linux impact

**None.** All macOS code is gated by `IS_MACOS` (`process.platform === "darwin"`). Zero code paths change on Linux.

## Compile requirement

Requires `cc` (Xcode Command Line Tools) on macOS. If unavailable, falls back to the existing `expect`-based PTY — everything works except setuid `top` resize.

## Test results

- `top` resize on macOS: ✅ (verified via Playwright automated test + manual verification)
- `nano`, `vim`, shell commands: ✅
- Splitter drag (rapid resize): ✅
- Shell exit detection: ✅
- Fallback to `expect` when `cc` unavailable: ✅
- Linux behavior: unchanged (all macOS paths gated)