### PR TITLE
fix(visual): hide Dashboard panel from activity bar

### DIFF
--- a/runtime/web/static/visual/frontend/src/components/activity-bar-registry.ts
+++ b/runtime/web/static/visual/frontend/src/components/activity-bar-registry.ts
@@ -40,5 +40,6 @@ registerActivityBarPanel({ id: "search", icon: "search", label: "Search", order:
 registerActivityBarPanel({ id: "extensions", icon: "extensions", label: "Addons", order: 30 });
 registerActivityBarPanel({ id: "tasks", icon: "tasklist", label: "Tasks", order: 40 });
 registerActivityBarPanel({ id: "scratchpad", icon: "notebook", label: "Scratchpad", order: 50 });
-registerActivityBarPanel({ id: "agent", icon: "dashboard", label: "Dashboard", order: 60 });
+// Dashboard: scaffolding kept but hidden until content is implemented
+// registerActivityBarPanel({ id: "agent", icon: "dashboard", label: "Dashboard", order: 60 });
 registerActivityBarPanel({ id: "settings", icon: "gear", label: "Settings", order: 100, alignBottom: true });


### PR DESCRIPTION
## Problem

The Dashboard panel is registered in the activity bar but has no content yet — clicking it shows an empty panel, confusing users.

## Fix

Comment out the Dashboard registration in `activity-bar-registry.ts`. The scaffolding (component, registry support) is preserved but hidden until real content is implemented.

Fixes cjnova/piclaw#26

## Files changed

- `runtime/web/static/visual/frontend/src/components/activity-bar-registry.ts` — 1 line commented out