### PR TITLE
Remember last opened session in standalone PWA

### DIFF
--- a/runtime/web/src/ui/app-location-navigation.ts
+++ b/runtime/web/src/ui/app-location-navigation.ts
@@ -1,13 +1,120 @@
 import { useCallback, useEffect, useMemo, useState } from '../vendor/preact-htm.js';
+import { isStandaloneWebAppMode } from './chat-window.js';
+import {
+  loadStoredLastMainChatJid,
+  readAppLocationModes,
+  saveStoredLastMainChatJid,
+} from './app-shell-state.js';
+
+function readModeParam(raw: string | null | undefined): boolean {
+  const value = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+function parseUrl(href: string): URL {
+  try {
+    return new URL(String(href || 'http://localhost/'));
+  } catch {
+    return new URL(String(href || '/'), 'http://localhost/');
+  }
+}
 
 export function resolveNavigationUrl(nextUrl: unknown, baseHref: string): string {
   return new URL(String(nextUrl || ''), baseHref).toString();
 }
 
+export interface ResolveStandaloneLaunchHrefOptions {
+  standalone?: boolean;
+  storedChatJid?: string | null;
+}
+
+/**
+ * In standalone/PWA mode, replace the launch chat with the last persisted main chat.
+ * Use `preserve_launch_url=1` on explicit deep links to bypass this restore.
+ */
+export function resolveStandaloneLaunchHref(
+  currentHref: string,
+  options: ResolveStandaloneLaunchHrefOptions = {},
+): string {
+  const url = parseUrl(currentHref);
+  const { standalone = false, storedChatJid = null } = options;
+  const normalizedStoredChatJid = typeof storedChatJid === 'string' ? storedChatJid.trim() : '';
+
+  if (!standalone || !normalizedStoredChatJid) {
+    return url.toString();
+  }
+
+  if (readModeParam(url.searchParams.get('preserve_launch_url'))) {
+    return url.toString();
+  }
+
+  const modes = readAppLocationModes(url.searchParams);
+  if (modes.panePopoutMode || modes.branchLoaderMode) {
+    return url.toString();
+  }
+
+  url.searchParams.delete('branch_loader');
+  url.searchParams.delete('branch_source_chat_jid');
+  url.searchParams.delete('pane_popout');
+  url.searchParams.delete('pane_path');
+  url.searchParams.delete('pane_label');
+
+  if (normalizedStoredChatJid === 'web:default') {
+    url.searchParams.delete('chat_jid');
+  } else {
+    url.searchParams.set('chat_jid', normalizedStoredChatJid);
+  }
+
+  return url.toString();
+}
+
+export interface PersistLastMainChatFromHrefOptions {
+  standalone?: boolean;
+}
+
+/**
+ * Persist the active main chat from the current location.
+ * Skip popout/loader contexts so they do not clobber the remembered main session.
+ * Also skip non-standalone `chat_only` windows to avoid desktop popup windows
+ * overwriting the remembered main shell/PWA session.
+ */
+export function persistLastMainChatFromHref(
+  currentHref: string,
+  options: PersistLastMainChatFromHrefOptions = {},
+): string | null {
+  const url = parseUrl(currentHref);
+  const { standalone = false } = options;
+  const modes = readAppLocationModes(url.searchParams);
+
+  if (modes.panePopoutMode || modes.branchLoaderMode) {
+    return null;
+  }
+
+  if (modes.chatOnlyMode && !standalone) {
+    return null;
+  }
+
+  return saveStoredLastMainChatJid(modes.currentChatJid);
+}
+
+function resolveInitialLocationHref(): string {
+  if (typeof window === 'undefined') return 'http://localhost/';
+
+  const currentHref = window.location.href;
+  const restoredHref = resolveStandaloneLaunchHref(currentHref, {
+    standalone: isStandaloneWebAppMode({ window, navigator: window.navigator }),
+    storedChatJid: loadStoredLastMainChatJid(),
+  });
+
+  if (restoredHref !== currentHref) {
+    window.history.replaceState(null, '', restoredHref);
+  }
+
+  return window.location.href;
+}
+
 export function useAppLocationNavigation() {
-  const [locationHref, setLocationHref] = useState(() =>
-    typeof window === 'undefined' ? 'http://localhost/' : window.location.href,
-  );
+  const [locationHref, setLocationHref] = useState(resolveInitialLocationHref);
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
@@ -15,6 +122,13 @@ export function useAppLocationNavigation() {
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    persistLastMainChatFromHref(locationHref, {
+      standalone: isStandaloneWebAppMode({ window, navigator: window.navigator }),
+    });
+  }, [locationHref]);
 
   const navigate = useCallback((nextUrl: unknown, options: { replace?: boolean } = {}) => {
     if (typeof window === 'undefined') return;

--- a/runtime/web/src/ui/app-shell-state.ts
+++ b/runtime/web/src/ui/app-shell-state.ts
@@ -1,7 +1,10 @@
-import { getLocalStorageItem } from '../utils/storage.js';
+import { getLocalStorageItem, setLocalStorageItem } from '../utils/storage.js';
 
 /** Shared localStorage key for the BTW side-conversation session cache. */
 export const BTW_SESSION_KEY = 'piclaw_btw_session';
+
+/** Shared localStorage key for the last main chat session opened in the shell/PWA. */
+export const LAST_MAIN_CHAT_JID_KEY = 'piclaw_last_main_chat';
 
 /** Cooldown window that prevents duplicate branch-rename submits. */
 export const RENAME_BRANCH_FORM_GUARD_MS = 900;
@@ -64,6 +67,18 @@ export interface LoadStoredBtwSessionOptions {
   storageKey?: string;
 }
 
+/** Optional overrides for recovering the persisted last main chat id. */
+export interface LoadStoredLastMainChatJidOptions {
+  readItem?: (key: string) => string | null | undefined;
+  storageKey?: string;
+}
+
+/** Optional overrides for persisting the last main chat id. */
+export interface SaveStoredLastMainChatJidOptions {
+  writeItem?: (key: string, value: string) => void;
+  storageKey?: string;
+}
+
 /** Optional overrides for parsing location-driven app shell modes. */
 export interface ReadAppLocationModesOptions {
   defaultChatJid?: string;
@@ -99,6 +114,11 @@ function readAssetVersionFromImportMeta(importMetaUrl: string | null | undefined
 function readTextParam(locationParams: LocationParamsLike, key: string, fallback = ''): string {
   const raw = locationParams?.get?.(key);
   return raw && raw.trim() ? raw.trim() : fallback;
+}
+
+function normalizeChatJid(value: unknown): string | null {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized || null;
 }
 
 /** Resolve the current authenticated app bundle version from import.meta or the loaded script tag. */
@@ -174,6 +194,23 @@ export function loadStoredBtwSession(options: LoadStoredBtwSessionOptions = {}):
   } catch {
     return null;
   }
+}
+
+/** Load the last main chat/session JID persisted for shell/PWA relaunch. */
+export function loadStoredLastMainChatJid(options: LoadStoredLastMainChatJidOptions = {}): string | null {
+  const readItem = typeof options.readItem === 'function' ? options.readItem : getLocalStorageItem;
+  const storageKey = options.storageKey || LAST_MAIN_CHAT_JID_KEY;
+  return normalizeChatJid(readItem(storageKey));
+}
+
+/** Persist the last main chat/session JID for shell/PWA relaunch. */
+export function saveStoredLastMainChatJid(chatJid: unknown, options: SaveStoredLastMainChatJidOptions = {}): string | null {
+  const normalized = normalizeChatJid(chatJid);
+  if (!normalized) return null;
+  const writeItem = typeof options.writeItem === 'function' ? options.writeItem : setLocalStorageItem;
+  const storageKey = options.storageKey || LAST_MAIN_CHAT_JID_KEY;
+  writeItem(storageKey, normalized);
+  return normalized;
 }
 
 /** Parse location-driven shell modes for the main app. */


### PR DESCRIPTION
PiClaw currently always starts on the same page when the standalone PWA is restarted, instead of reopening the session the user last had open. This is especially noticeable on Android, where the OS restarts PWAs frequently, so users keep getting bounced back to the same original page/session rather than resuming where they left off.

This change makes the standalone/PWA shell remember the last main chat session and restore it on launch.