### PR TITLE
Enable PWA display scale on iOS/iPadOS standalone apps

### DIFF
--- a/runtime/test/web/pwa-display-scale.test.ts
+++ b/runtime/test/web/pwa-display-scale.test.ts
@@ -6,7 +6,7 @@ import {
   applyPwaDisplayScale,
   buildPwaDisplayScaleViewportContent,
   formatPwaDisplayScaleRatio,
-  isAndroidStandalonePwa,
+  isMobileStandalonePwa,
   normalizePwaDisplayScalePercent,
   persistPwaDisplayScalePercent,
   readStoredPwaDisplayScalePercent,
@@ -15,6 +15,8 @@ import {
 function createRuntime(options: {
   userAgent?: string;
   displayMode?: string;
+  maxTouchPoints?: number;
+  standalone?: boolean;
   stored?: string | null;
 } = {}) {
   const storage = new Map<string, string>();
@@ -29,7 +31,11 @@ function createRuntime(options: {
   };
   const listeners: Array<{ type: string; event: any }> = [];
   return {
-    navigator: { userAgent: options.userAgent || 'Mozilla/5.0' },
+    navigator: {
+      userAgent: options.userAgent || 'Mozilla/5.0',
+      maxTouchPoints: options.maxTouchPoints ?? 0,
+      standalone: options.standalone ?? false,
+    },
     localStorage: {
       getItem: (key: string) => storage.has(key) ? storage.get(key)! : null,
       setItem: (key: string, value: string) => storage.set(key, String(value)),
@@ -58,12 +64,14 @@ describe('PWA display scale helpers', () => {
     expect(formatPwaDisplayScaleRatio(75)).toBe('0.75');
   });
 
-  test('detects Android standalone, fullscreen, and minimal-ui display modes only', () => {
-    expect(isAndroidStandalonePwa(createRuntime({ userAgent: 'Android', displayMode: 'standalone' }))).toBe(true);
-    expect(isAndroidStandalonePwa(createRuntime({ userAgent: 'Android', displayMode: 'fullscreen' }))).toBe(true);
-    expect(isAndroidStandalonePwa(createRuntime({ userAgent: 'Android', displayMode: 'minimal-ui' }))).toBe(true);
-    expect(isAndroidStandalonePwa(createRuntime({ userAgent: 'Android' }))).toBe(false);
-    expect(isAndroidStandalonePwa(createRuntime({ userAgent: 'iPhone', displayMode: 'standalone' }))).toBe(false);
+  test('detects standalone mobile PWAs across Android and iOS/iPadOS', () => {
+    expect(isMobileStandalonePwa(createRuntime({ userAgent: 'Android', displayMode: 'standalone' }))).toBe(true);
+    expect(isMobileStandalonePwa(createRuntime({ userAgent: 'Android', displayMode: 'fullscreen' }))).toBe(true);
+    expect(isMobileStandalonePwa(createRuntime({ userAgent: 'Android', displayMode: 'minimal-ui' }))).toBe(true);
+    expect(isMobileStandalonePwa(createRuntime({ userAgent: 'iPhone', displayMode: 'standalone' }))).toBe(true);
+    expect(isMobileStandalonePwa(createRuntime({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)', maxTouchPoints: 5, standalone: true }))).toBe(true);
+    expect(isMobileStandalonePwa(createRuntime({ userAgent: 'Android' }))).toBe(false);
+    expect(isMobileStandalonePwa(createRuntime({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)', displayMode: 'standalone' }))).toBe(false);
   });
 
   test('builds default viewport content unless a non-default scale applies', () => {
@@ -73,8 +81,8 @@ describe('PWA display scale helpers', () => {
     expect(buildPwaDisplayScaleViewportContent(75, { applies: true })).toContain('viewport-fit=cover');
   });
 
-  test('persists and applies the saved scale only for Android standalone PWA runtime', () => {
-    const runtime = createRuntime({ userAgent: 'Android', displayMode: 'standalone' });
+  test('persists and applies the saved scale for standalone mobile PWA runtime', () => {
+    const runtime = createRuntime({ userAgent: 'iPhone', displayMode: 'standalone' });
 
     expect(persistPwaDisplayScalePercent(75, runtime)).toBe(75);
     expect(readStoredPwaDisplayScalePercent(runtime)).toBe(75);
@@ -83,8 +91,8 @@ describe('PWA display scale helpers', () => {
     expect(runtime.__listeners.some((entry: any) => entry.type === 'piclaw:pwa-display-scale-changed')).toBe(true);
   });
 
-  test('restores default viewport content outside Android standalone mode', () => {
-    const runtime = createRuntime({ userAgent: 'Android', stored: '75' });
+  test('restores default viewport content outside standalone mobile mode', () => {
+    const runtime = createRuntime({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)', displayMode: 'standalone', stored: '75' });
     const result = applyPwaDisplayScale(runtime);
 
     expect(result.applied).toBe(false);

--- a/runtime/web/src/ui/pwa-display-scale.ts
+++ b/runtime/web/src/ui/pwa-display-scale.ts
@@ -1,3 +1,5 @@
+import { isMobileBrowserMode, isStandaloneWebAppMode } from './chat-window.js';
+
 export const PWA_DISPLAY_SCALE_STORAGE_KEY = 'piclawPwaDisplayScalePercent';
 export const PWA_DISPLAY_SCALE_EVENT = 'piclaw:pwa-display-scale-changed';
 export const DEFAULT_PWA_DISPLAY_SCALE_PERCENT = 100;
@@ -53,19 +55,11 @@ export function readStoredPwaDisplayScalePercent(runtime: any = typeof window !=
   }
 }
 
-export function isAndroidStandalonePwa(runtime: any = typeof window !== 'undefined' ? window : null): boolean {
+export function isMobileStandalonePwa(runtime: any = typeof window !== 'undefined' ? window : null): boolean {
   const runtimeWindow = getRuntimeWindow(runtime);
   const runtimeNavigator = getRuntimeNavigator(runtimeWindow);
-  const userAgent = String(runtimeNavigator?.userAgent || '');
-  if (!/Android/i.test(userAgent)) return false;
-
-  try {
-    return ['standalone', 'fullscreen', 'minimal-ui'].some((mode) =>
-      Boolean(runtimeWindow?.matchMedia?.(`(display-mode: ${mode})`)?.matches),
-    );
-  } catch {
-    return false;
-  }
+  return isStandaloneWebAppMode({ window: runtimeWindow, navigator: runtimeNavigator })
+    && isMobileBrowserMode({ window: runtimeWindow, navigator: runtimeNavigator });
 }
 
 export function buildPwaDisplayScaleViewportContent(percent: number, options: { applies?: boolean } = {}): string {
@@ -85,7 +79,7 @@ export function applyPwaDisplayScale(runtime: any = typeof window !== 'undefined
 } {
   const runtimeWindow = getRuntimeWindow(runtime);
   const percent = readStoredPwaDisplayScalePercent(runtimeWindow);
-  const applied = isAndroidStandalonePwa(runtimeWindow) && percent !== DEFAULT_PWA_DISPLAY_SCALE_PERCENT;
+  const applied = isMobileStandalonePwa(runtimeWindow) && percent !== DEFAULT_PWA_DISPLAY_SCALE_PERCENT;
   const content = buildPwaDisplayScaleViewportContent(percent, { applies: applied });
   const viewport = runtimeWindow?.document?.querySelector?.('meta[name="viewport"]');
   viewport?.setAttribute?.('content', content);

--- a/runtime/web/static/classic/index.html
+++ b/runtime/web/static/classic/index.html
@@ -36,12 +36,14 @@
     <title>PiClaw</title>
     <meta name="apple-mobile-web-app-title" content="PiClaw">
     <script>
-        // Android standalone PWA scale guard: apply the saved display scale before CSS loads.
+        // Mobile standalone PWA scale guard: apply the saved display scale before CSS loads.
         (function() {
             try {
-                var isAndroid = /Android/i.test(navigator.userAgent || '');
-                var standalone = false;
-                if (window.matchMedia) {
+                var userAgent = navigator.userAgent || '';
+                var maxTouchPoints = Number(navigator.maxTouchPoints || 0);
+                var isMobile = /Android|webOS|iPhone|iPad|iPod|Mobile|Windows Phone/i.test(userAgent) || maxTouchPoints > 1;
+                var standalone = Boolean(navigator.standalone);
+                if (!standalone && window.matchMedia) {
                     standalone = window.matchMedia('(display-mode: standalone)').matches ||
                         window.matchMedia('(display-mode: fullscreen)').matches ||
                         window.matchMedia('(display-mode: minimal-ui)').matches;
@@ -51,7 +53,7 @@
                 if (parsed > 0 && parsed <= 2) parsed *= 100;
                 if (!Number.isFinite(parsed)) parsed = 100;
                 var percent = Math.min(115, Math.max(20, Math.round(parsed)));
-                if (isAndroid && standalone && percent !== 100) {
+                if (isMobile && standalone && percent !== 100) {
                     var scale = (percent / 100).toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
                     var viewport = document.getElementById('piclaw-viewport') || document.querySelector('meta[name="viewport"]');
                     if (viewport) {

--- a/runtime/web/static/visual/index.html
+++ b/runtime/web/static/visual/index.html
@@ -36,12 +36,14 @@
     <title>PiClaw</title>
     <meta name="apple-mobile-web-app-title" content="PiClaw">
     <script>
-        // Android standalone PWA scale guard: apply the saved display scale before CSS loads.
+        // Mobile standalone PWA scale guard: apply the saved display scale before CSS loads.
         (function() {
             try {
-                var isAndroid = /Android/i.test(navigator.userAgent || '');
-                var standalone = false;
-                if (window.matchMedia) {
+                var userAgent = navigator.userAgent || '';
+                var maxTouchPoints = Number(navigator.maxTouchPoints || 0);
+                var isMobile = /Android|webOS|iPhone|iPad|iPod|Mobile|Windows Phone/i.test(userAgent) || maxTouchPoints > 1;
+                var standalone = Boolean(navigator.standalone);
+                if (!standalone && window.matchMedia) {
                     standalone = window.matchMedia('(display-mode: standalone)').matches ||
                         window.matchMedia('(display-mode: fullscreen)').matches ||
                         window.matchMedia('(display-mode: minimal-ui)').matches;
@@ -51,7 +53,7 @@
                 if (parsed > 0 && parsed <= 2) parsed *= 100;
                 if (!Number.isFinite(parsed)) parsed = 100;
                 var percent = Math.min(115, Math.max(20, Math.round(parsed)));
-                if (isAndroid && standalone && percent !== 100) {
+                if (isMobile && standalone && percent !== 100) {
                     var scale = (percent / 100).toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
                     var viewport = document.getElementById('piclaw-viewport') || document.querySelector('meta[name="viewport"]');
                     if (viewport) {


### PR DESCRIPTION
The Scale control is already visible in the hamburger menu on iOS, but it currently has no effect. This change makes it functional rather than leaving it as a no-op.

### What changed

- replaced Android-specific PWA scale detection with shared **mobile + standalone** detection
- reused existing standalone/mobile helpers instead of duplicating platform logic
- updated the early viewport bootstrap in:
  - `runtime/web/static/classic/index.html`
  - `runtime/web/static/visual/index.html`
- updated display-scale runtime logic in:
  - `runtime/web/src/ui/pwa-display-scale.ts`
- expanded tests to cover:
  - Android standalone
  - iPhone standalone
  - iPadOS-style standalone detection (`Macintosh` UA + touch + `navigator.standalone`)

### Why

Before this PR:

- the Scale input was visible in the UI on iOS/iPadOS
- but the saved value was never actually applied
- because both the bootstrap path and runtime path only enabled scaling for Android standalone PWAs

After this PR:

- the Scale control should apply in **standalone mobile PWAs**, not just Android
- desktop and non-standalone browser behavior remain unchanged

### Notes

This PR does **not** change the workspace explorer scale system; it only affects the **PWA display scale** used by the hamburger-menu Scale control.