### PR TITLE
fix(pwa): handle Number(null) in display scale guard

### DIFF
--- a/runtime/web/static/classic/index.html
+++ b/runtime/web/static/classic/index.html
@@ -51,7 +51,7 @@
                 var raw = localStorage.getItem('piclawPwaDisplayScalePercent');
                 var parsed = raw && raw.trim().endsWith('%') ? Number(raw.trim().slice(0, -1)) : Number(raw);
                 if (parsed > 0 && parsed <= 2) parsed *= 100;
-                if (!Number.isFinite(parsed)) parsed = 100;
+                if (!Number.isFinite(parsed) || parsed <= 0) parsed = 100;
                 var percent = Math.min(115, Math.max(20, Math.round(parsed)));
                 if (isMobile && standalone && percent !== 100) {
                     var scale = (percent / 100).toFixed(2).replace(/0+$/, '').replace(/\.$/, '');

--- a/runtime/web/static/visual/index.html
+++ b/runtime/web/static/visual/index.html
@@ -51,7 +51,7 @@
                 var raw = localStorage.getItem('piclawPwaDisplayScalePercent');
                 var parsed = raw && raw.trim().endsWith('%') ? Number(raw.trim().slice(0, -1)) : Number(raw);
                 if (parsed > 0 && parsed <= 2) parsed *= 100;
-                if (!Number.isFinite(parsed)) parsed = 100;
+                if (!Number.isFinite(parsed) || parsed <= 0) parsed = 100;
                 var percent = Math.min(115, Math.max(20, Math.round(parsed)));
                 if (isMobile && standalone && percent !== 100) {
                     var scale = (percent / 100).toFixed(2).replace(/0+$/, '').replace(/\.$/, '');


### PR DESCRIPTION
## Bug

Standalone PWA on mobile renders at physical pixel resolution instead of CSS pixels, making the UI unusable.

## Root cause

`Number(null)` returns `0`, which passes the `isFinite` check in the inline PWA scale guard script. The guard then computes `percent = Math.max(20, 0)` → `20`, and since `20 !== 100`, it sets `initial-scale=0.20` on the viewport meta tag. This shrinks the viewport to ~1/5th scale on every fresh standalone PWA install where `piclawPwaDisplayScalePercent` has not been explicitly set in localStorage.

The bug only triggers in standalone mode (`isMobile && standalone`) — browser mode skips the guard entirely, which is why the same URL renders correctly in the browser but breaks as an installed PWA.

## Fix

Add `|| parsed <= 0` to the default-value guard:

```diff
- if (!Number.isFinite(parsed)) parsed = 100;
+ if (!Number.isFinite(parsed) || parsed <= 0) parsed = 100;
```

Applied to both `classic/index.html` and `visual/index.html`.

## Testing

- ✅ Verified on Samsung Galaxy standalone PWA — renders correctly, rotation works
- ✅ Existing `pwa-display-scale.test.ts` tests pass (5/5)
- ✅ Edge cases verified: null, undefined, empty string, "0", negative, fractions, percentages, clamping bounds (13/13)
- ✅ Browser rendering unaffected (guard skips when `standalone=false`)
- ✅ Explicit `piclawPwaDisplayScalePercent` values still work correctly

## Risk

iOS standalone PWAs likely had the same latent bug but may have been masked by WebKit ignoring absurd `initial-scale` values. This fix corrects it. No feature removed.