### PR TITLE
Better dream processing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -571,7 +571,7 @@ It runs when there has been activity since the last consolidation.
 | Variable | Default | Purpose |
 |----------|---------|---------||
 | `PICLAW_DREAM_CRON` | `0 1 * * *` | Cron schedule for AutoDream. Evaluated in the runtime timezone (`TZ` / runtime timing config), so the default is 01:00 local runtime time. |
-| `PICLAW_DREAM_MODEL` | _(unset — inherits session model)_ | Pin Dream to a specific model label (e.g. `anthropic/claude-sonnet-4-20250514`). The scheduler switches before the Dream turn and restores the original model afterward. |
+| `PICLAW_DREAM_MODEL` | _(unset — inherits session model)_ | Pin Dream / AutoDream to a specific model label (e.g. `anthropic/claude-sonnet-4-20250514`). The Dream pass applies it to the temporary Dream chat, so it also covers manual `/dream` runs. |
 | `PICLAW_DREAM_BACKUP_KEEP` | `10` | Number of pre-Dream note backups to retain |
 | `PICLAW_DREAM_CUE_FULL_SLICE_MAX_MESSAGES` | `50` | `DREAM_CUES` full-slice cutoff for day message count |
 | `PICLAW_DREAM_CUE_FULL_SLICE_MAX_SESSION_TREES` | `2` | `DREAM_CUES` full-slice cutoff for session-tree count |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -573,6 +573,10 @@ It runs when there has been activity since the last consolidation.
 | `PICLAW_DREAM_CRON` | `0 1 * * *` | Cron schedule for AutoDream. Evaluated in the runtime timezone (`TZ` / runtime timing config), so the default is 01:00 local runtime time. |
 | `PICLAW_DREAM_MODEL` | _(unset — inherits session model)_ | Pin Dream to a specific model label (e.g. `anthropic/claude-sonnet-4-20250514`). The scheduler switches before the Dream turn and restores the original model afterward. |
 | `PICLAW_DREAM_BACKUP_KEEP` | `10` | Number of pre-Dream note backups to retain |
+| `PICLAW_DREAM_CUE_FULL_SLICE_MAX_MESSAGES` | `50` | `DREAM_CUES` full-slice cutoff for day message count |
+| `PICLAW_DREAM_CUE_FULL_SLICE_MAX_SESSION_TREES` | `2` | `DREAM_CUES` full-slice cutoff for session-tree count |
+| `PICLAW_DREAM_CUE_SMALL_TREE_MAX_MESSAGES` | `10` | Per-session-tree cue cutoff under which all messages from that tree are included |
+| `PICLAW_DREAM_CUE_MAX_SNIPPETS` | `100` | Global `DREAM_CUES` snippet budget before large trees downgrade from `5+5` to `2+2` |
 
 - if there is no prior consolidation, AutoDream runs
 - if there have been no sessions since the last consolidation, AutoDream skips

--- a/docs/dream-memory.md
+++ b/docs/dream-memory.md
@@ -52,13 +52,15 @@ front-matter transcript slice. Small bounded days may expose the full slice;
 larger or multi-session days use a per-session-tree cue index plus per-tree
 snippets, and cue thresholds/snippet budgets are Dream env-configurable.
 Unresolved backlog dates are reported after the run if consolidation remains
-incomplete. Default window: last 7 days.
+incomplete. Default window: last 7 days. Daily-note day boundaries follow the
+runtime timezone (`TZ` / runtime timing config), not UTC.
 
 ### AutoDream
 
 Built-in scheduled task `builtin-dream-midnight` runs nightly at `0 1 * * *` by default.
 That is 01:00 in the runtime timezone (for example, 01:00 Lisbon time when `TZ=Europe/Lisbon`).
-Uses a 2-day window. Runs silently unless you inspect task results.
+Uses a 2-day window, and the day slices it refreshes use that same runtime timezone.
+Runs silently unless you inspect task results.
 Skips when no sessions have occurred since the last consolidation.
 
 ## First-boot bootstrap

--- a/docs/dream-memory.md
+++ b/docs/dream-memory.md
@@ -48,8 +48,11 @@ Dream must not modify project code, tests, or unrelated config.
 Creates a pre-Dream zip backup, refreshes in-window daily note files from the
 messages database, runs the Dream turn, and posts a summary back to chat.
 Unfinished daily notes are seeded with hidden `DREAM_CUES` based on their
-front-matter transcript slice, and unresolved backlog dates are reported after
-the run if consolidation remains incomplete. Default window: last 7 days.
+front-matter transcript slice. Small bounded days may expose the full slice;
+larger or multi-session days use a per-session-tree cue index plus per-tree
+snippets, and cue thresholds/snippet budgets are Dream env-configurable.
+Unresolved backlog dates are reported after the run if consolidation remains
+incomplete. Default window: last 7 days.
 
 ### AutoDream
 

--- a/runtime/docs/dream-memory.md
+++ b/runtime/docs/dream-memory.md
@@ -139,7 +139,7 @@ Dream now treats memory as layered outputs rather than a mirrored `notes/daily/`
 
 ### Incomplete daily-note recovery cues
 
-When runtime seeds or refreshes an unfinished daily note, it also writes a hidden `DREAM_CUES` comment. Those cues are compact transcript hints derived from the message slice described by front matter (`scope_anchor`, `first_message`, `last_message`, `messages_total`, `session_trees`, `session_chats`). Dream should use them before searching broadly, and may inspect the full bounded slice for small days (`messages_total <= 50`, `session_trees <= 2`) before declaring consolidation unsafe. If a pass still leaves unresolved notes, the run result and logs report the unresolved dates.
+When runtime seeds or refreshes an unfinished daily note, it also writes a hidden `DREAM_CUES` comment. Those cues are compact transcript hints derived from the message slice described by front matter (`scope_anchor`, `first_message`, `last_message`, `messages_total`, `session_trees`, `session_chats`). Dream should use them before searching broadly. For bounded-full-slice days (`bounded_full_slice: yes`), it may inspect the full bounded day slice before declaring consolidation unsafe. Larger or multi-session days now include a compact per-session-tree index plus per-tree snippets (all messages for small trees, otherwise first/last windows per tree), with thresholds and snippet budget configurable via Dream cue env vars. If `cue_global_budget_breached: yes`, the final Dream summary should mention that date's budget breach. If a pass still leaves unresolved notes, the run result and logs report the unresolved dates.
 
 ## Files touched
 

--- a/runtime/docs/dream-memory.md
+++ b/runtime/docs/dream-memory.md
@@ -61,6 +61,7 @@ Behavior:
 - Dream work is queued on a dedicated `dream:<chatJid>` lane so it does not block the interactive chat lane
 - a visible agent summary is posted back to the original chat when done
 - default window: last 7 days unless you pass an explicit `/dream <days>`
+- daily-note day boundaries follow the runtime timezone (`TZ` / runtime timing config), not UTC
 
 ### AutoDream
 
@@ -69,6 +70,7 @@ Built-in scheduled task:
 - task id: `builtin-dream-midnight`
 - task kind: `internal`
 - schedule: default cron `0 1 * * *` (01:00 in the runtime timezone)
+- refreshed day slices use that same runtime timezone
 
 Behavior:
 

--- a/runtime/src/agent-memory/daily-notes.ts
+++ b/runtime/src/agent-memory/daily-notes.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
-import { WORKSPACE_DIR } from "../core/config.js";
+import { WORKSPACE_DIR, getRuntimeTimingConfig } from "../core/config.js";
 import { getDb } from "../db.js";
 import { createLogger, debugSuppressedError } from "../utils/logger.js";
 
@@ -12,6 +12,13 @@ const INCOMPLETE_WARNING_TITLE = "> ⚠ **Incomplete daily note**";
 const DREAM_CUES_START = "<!-- DREAM_CUES";
 const DREAM_CUES_END = "DREAM_CUES -->";
 const log = createLogger("agent-memory.daily-notes");
+const DREAM_DAY_TIMEZONE = process.env.TZ || getRuntimeTimingConfig().timezone || "UTC";
+const DREAM_DAY_PARTS_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  timeZone: DREAM_DAY_TIMEZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
 
 interface FrontMatter {
   fields: Record<string, string>;
@@ -26,7 +33,6 @@ interface Row {
   timestamp: string;
   chat_jid: string;
   root_chat_jid: string;
-  day: string;
 }
 
 interface DailyMessageStats {
@@ -67,10 +73,30 @@ function formatDateLong(iso: string): string {
   });
 }
 
-function todayStr(): string { return new Date().toISOString().slice(0, 10); }
+function formatRuntimeDay(value: string | number | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  const parts = DREAM_DAY_PARTS_FORMATTER.formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (!year || !month || !day) return date.toISOString().slice(0, 10);
+  return `${year}-${month}-${day}`;
+}
+
+function shiftDay(day: string, deltaDays: number): string {
+  const [year, month, date] = day.split("-").map((value) => Number.parseInt(value, 10));
+  const shifted = new Date(Date.UTC(year, month - 1, date + deltaDays));
+  return shifted.toISOString().slice(0, 10);
+}
+
+function queryCutoffIsoForDay(day: string): string {
+  return `${shiftDay(day, -1)}T00:00:00.000Z`;
+}
+
+function todayStr(): string { return formatRuntimeDay(Date.now()); }
 
 function windowStartDay(days: number): string {
-  return new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+  return shiftDay(todayStr(), -days);
 }
 
 function buildDailyMessageStats(day: string, messages: Row[]): DailyMessageStats {
@@ -432,43 +458,68 @@ function resolveScope(chatJid: string): { clause: string; params: string[]; mode
   return { clause: "m.chat_jid = ?", params: [normalized], mode: "chat-only", anchor: normalized };
 }
 
-function loadDailyMessageStatsSince(cutoffIso: string, scope: { clause: string; params: string[] }): Map<string, DailyMessageStats> {
+function loadMessageRowsSince(cutoffIso: string, scope: { clause: string; params: string[] }): Row[] {
   const db = getDb();
-  const rows = db.query<{
-    day: string;
-    first_timestamp: string;
-    last_timestamp: string;
-    total_msgs: number;
-    user_msgs: number;
-    bot_msgs: number;
-    session_trees: number;
-    session_chats: number;
-  }, any[]>(
-    `SELECT substr(m.timestamp, 1, 10) AS day,
-            MIN(m.timestamp) AS first_timestamp,
-            MAX(m.timestamp) AS last_timestamp,
-            COUNT(*) AS total_msgs,
-            SUM(CASE WHEN COALESCE(m.is_bot_message, 0) = 0 THEN 1 ELSE 0 END) AS user_msgs,
-            SUM(CASE WHEN COALESCE(m.is_bot_message, 0) = 1 THEN 1 ELSE 0 END) AS bot_msgs,
-            COUNT(DISTINCT COALESCE(cb.root_chat_jid, m.chat_jid)) AS session_trees,
-            COUNT(DISTINCT m.chat_jid) AS session_chats
+  return db.query<Row, any[]>(
+    `SELECT m.sender_name,
+            COALESCE(m.is_bot_message, 0) AS is_bot_message,
+            m.content,
+            m.timestamp,
+            m.chat_jid,
+            COALESCE(cb.root_chat_jid, m.chat_jid) AS root_chat_jid
      FROM messages m
      LEFT JOIN chat_branches cb ON cb.chat_jid = m.chat_jid
      WHERE ${scope.clause}
        AND m.timestamp >= ?
-     GROUP BY day
-     ORDER BY day ASC`
+     ORDER BY m.timestamp ASC`
   ).all(...scope.params, cutoffIso);
+}
 
-  return new Map(rows.map((row) => [row.day, {
-    day: row.day,
-    firstTimestamp: row.first_timestamp,
-    lastTimestamp: row.last_timestamp,
-    totalMsgs: row.total_msgs,
-    userMsgs: row.user_msgs,
-    botMsgs: row.bot_msgs,
-    sessionTrees: row.session_trees,
-    sessionChats: row.session_chats,
+function loadDailyMessageStatsSince(cutoffDay: string, scope: { clause: string; params: string[] }): Map<string, DailyMessageStats> {
+  const rows = loadMessageRowsSince(queryCutoffIsoForDay(cutoffDay), scope);
+  const stats = new Map<string, {
+    firstTimestamp: string;
+    lastTimestamp: string;
+    totalMsgs: number;
+    userMsgs: number;
+    botMsgs: number;
+    sessionTrees: Set<string>;
+    sessionChats: Set<string>;
+  }>();
+
+  for (const row of rows) {
+    const day = formatRuntimeDay(row.timestamp);
+    if (day < cutoffDay) continue;
+    const current = stats.get(day);
+    if (!current) {
+      stats.set(day, {
+        firstTimestamp: row.timestamp,
+        lastTimestamp: row.timestamp,
+        totalMsgs: 1,
+        userMsgs: row.is_bot_message ? 0 : 1,
+        botMsgs: row.is_bot_message ? 1 : 0,
+        sessionTrees: new Set([row.root_chat_jid]),
+        sessionChats: new Set([row.chat_jid]),
+      });
+      continue;
+    }
+    current.lastTimestamp = row.timestamp;
+    current.totalMsgs += 1;
+    if (row.is_bot_message) current.botMsgs += 1;
+    else current.userMsgs += 1;
+    current.sessionTrees.add(row.root_chat_jid);
+    current.sessionChats.add(row.chat_jid);
+  }
+
+  return new Map([...stats.entries()].map(([day, current]) => [day, {
+    day,
+    firstTimestamp: current.firstTimestamp,
+    lastTimestamp: current.lastTimestamp,
+    totalMsgs: current.totalMsgs,
+    userMsgs: current.userMsgs,
+    botMsgs: current.botMsgs,
+    sessionTrees: current.sessionTrees.size,
+    sessionChats: current.sessionChats.size,
   }]));
 }
 
@@ -487,7 +538,7 @@ export function inspectDailyNoteSummaryBacklog(options?: { recentDays?: number }
   let statsByDay = new Map<string, DailyMessageStats>();
 
   try {
-    statsByDay = loadDailyMessageStatsSince(`${cutoff}T00:00:00.000Z`, allChatsScope);
+    statsByDay = loadDailyMessageStatsSince(cutoff, allChatsScope);
   } catch (error) {
     debugSuppressedError(log, "Failed to inspect message days while checking daily-note backlog.", error, {
       operation: "daily_notes.inspect_backlog.message_days",
@@ -545,29 +596,16 @@ export function refreshDailyNotesFromMessages(options?: { days?: number; chatJid
 
   const dailyNotesDir = getDailyNotesDir();
   mkdirSync(dailyNotesDir, { recursive: true });
-  const db = getDb();
   const scope = resolveScope(chatJid);
-  const params: any[] = [...scope.params];
   const cutoffDay = windowStartDay(days);
-  const cutoffIso = `${cutoffDay}T00:00:00.000Z`;
-  const rows = db.query<Row, any[]>(
-    `SELECT m.sender_name,
-            m.is_bot_message,
-            m.content,
-            m.timestamp,
-            m.chat_jid,
-            COALESCE(cb.root_chat_jid, m.chat_jid) AS root_chat_jid,
-            substr(m.timestamp, 1, 10) AS day
-     FROM messages m
-     LEFT JOIN chat_branches cb ON cb.chat_jid = m.chat_jid
-     WHERE ${scope.clause} AND m.timestamp >= ?
-     ORDER BY m.timestamp ASC`
-  ).all(...params, cutoffIso);
+  const rows = loadMessageRowsSince(queryCutoffIsoForDay(cutoffDay), scope);
 
   const dayMap = new Map<string, Row[]>();
   for (const row of rows) {
-    if (!dayMap.has(row.day)) dayMap.set(row.day, []);
-    dayMap.get(row.day)!.push(row);
+    const day = formatRuntimeDay(row.timestamp);
+    if (day < cutoffDay) continue;
+    if (!dayMap.has(day)) dayMap.set(day, []);
+    dayMap.get(day)!.push(row);
   }
 
   const sortedDays = [...dayMap.keys()].sort();

--- a/runtime/src/agent-memory/daily-notes.ts
+++ b/runtime/src/agent-memory/daily-notes.ts
@@ -256,11 +256,98 @@ function buildCueTerms(messages: Row[]): string[] {
     .map(([word]) => word);
 }
 
+interface DreamCueConfig {
+  fullSliceMaxMessages: number;
+  fullSliceMaxSessionTrees: number;
+  smallTreeMaxMessages: number;
+  maxSnippets: number;
+}
+
+interface SessionTreeCuePlan {
+  rootChatJid: string;
+  label: string;
+  chatJids: string[];
+  messages: Row[];
+  selected: Row[];
+  firstTimestamp: string;
+  lastTimestamp: string;
+}
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getDreamCueConfig(): DreamCueConfig {
+  return {
+    fullSliceMaxMessages: readPositiveIntEnv("PICLAW_DREAM_CUE_FULL_SLICE_MAX_MESSAGES", 50),
+    fullSliceMaxSessionTrees: readPositiveIntEnv("PICLAW_DREAM_CUE_FULL_SLICE_MAX_SESSION_TREES", 2),
+    smallTreeMaxMessages: readPositiveIntEnv("PICLAW_DREAM_CUE_SMALL_TREE_MAX_MESSAGES", 10),
+    maxSnippets: readPositiveIntEnv("PICLAW_DREAM_CUE_MAX_SNIPPETS", 100),
+  };
+}
+
+function selectHeadTailMessages(messages: Row[], edgeCount: number): Row[] {
+  if (messages.length <= edgeCount * 2) return [...messages];
+  const output: Row[] = [];
+  const seen = new Set<number>();
+  for (let index = 0; index < Math.min(edgeCount, messages.length); index += 1) {
+    if (seen.has(index)) continue;
+    seen.add(index);
+    output.push(messages[index]);
+  }
+  for (let index = Math.max(edgeCount, messages.length - edgeCount); index < messages.length; index += 1) {
+    if (seen.has(index)) continue;
+    seen.add(index);
+    output.push(messages[index]);
+  }
+  return output;
+}
+
+function buildSessionTreeLabel(rootChatJid: string, chatJids: string[]): string {
+  const uniqueChatJids = [...new Set(chatJids)];
+  const primaryChatJid = uniqueChatJids[0] || rootChatJid;
+  if (primaryChatJid !== rootChatJid) {
+    return `${primaryChatJid} (root: ${rootChatJid})`;
+  }
+  if (uniqueChatJids.length <= 1) return rootChatJid;
+  const extraChats = uniqueChatJids.length - 1;
+  return `${rootChatJid} (+${extraChats} chat${extraChats === 1 ? "" : "s"})`;
+}
+
+function buildSessionTreeCuePlans(messages: Row[], edgeCount: number, smallTreeMaxMessages: number): SessionTreeCuePlan[] {
+  const treeMap = new Map<string, Row[]>();
+  for (const message of messages) {
+    if (!treeMap.has(message.root_chat_jid)) treeMap.set(message.root_chat_jid, []);
+    treeMap.get(message.root_chat_jid)!.push(message);
+  }
+
+  return [...treeMap.entries()]
+    .map(([rootChatJid, treeMessages]) => {
+      const chatJids = [...new Set(treeMessages.map((message) => message.chat_jid))];
+      return {
+        rootChatJid,
+        label: buildSessionTreeLabel(rootChatJid, chatJids),
+        chatJids,
+        messages: treeMessages,
+        selected: treeMessages.length <= smallTreeMaxMessages
+          ? [...treeMessages]
+          : selectHeadTailMessages(treeMessages, edgeCount),
+        firstTimestamp: treeMessages[0].timestamp,
+        lastTimestamp: treeMessages[treeMessages.length - 1].timestamp,
+      };
+    })
+    .sort((left, right) => left.firstTimestamp.localeCompare(right.firstTimestamp));
+}
+
+function formatCueSnippet(message: Row): string {
+  const role = message.is_bot_message ? "assistant" : "user";
+  return `- ${message.timestamp} ${role} ${cleanCueText(message.sender_name, 40)} [${cleanCueText(message.chat_jid, 80)}]: ${cleanCueText(message.content)}`;
+}
+
 function buildDreamCues(messages: Row[], options: { firstTimestamp: string; lastTimestamp: string; totalMsgs: number; sessionTrees: number; sessionChats: number }): string {
-  const includeFullSlice = options.totalMsgs <= 50 && options.sessionTrees <= 2;
-  const selected = includeFullSlice
-    ? messages
-    : [...messages.slice(0, 5), ...messages.slice(Math.max(5, messages.length - 5))];
+  const config = getDreamCueConfig();
+  const includeFullSlice = options.totalMsgs <= config.fullSliceMaxMessages && options.sessionTrees <= config.fullSliceMaxSessionTrees;
   const lines = [
     DREAM_CUES_START,
     "These cues are hidden recovery hints for Dream. Treat front matter as the transcript contract; use message IDs/timestamps with messages search only if more evidence is needed.",
@@ -269,16 +356,50 @@ function buildDreamCues(messages: Row[], options: { firstTimestamp: string; last
     `session_trees: ${options.sessionTrees}`,
     `session_chats: ${options.sessionChats}`,
     `bounded_full_slice: ${includeFullSlice ? "yes" : "no"}`,
+    `cue_full_slice_thresholds: messages<=${config.fullSliceMaxMessages}, session_trees<=${config.fullSliceMaxSessionTrees}`,
   ];
   const terms = buildCueTerms(messages);
   if (terms.length > 0) lines.push(`cue_terms: ${terms.join(", ")}`);
-  lines.push("message_snippets:");
-  for (const msg of selected) {
-    const role = msg.is_bot_message ? "assistant" : "user";
-    lines.push(`- ${msg.timestamp} ${role} ${cleanCueText(msg.sender_name, 40)} [${cleanCueText(msg.chat_jid, 80)}]: ${cleanCueText(msg.content)}`);
+
+  if (includeFullSlice) {
+    lines.push("message_snippets:");
+    for (const message of messages) {
+      lines.push(formatCueSnippet(message));
+    }
+    lines.push(DREAM_CUES_END);
+    return lines.join("\n");
   }
-  if (!includeFullSlice && selected.length < messages.length) {
-    lines.push(`omitted_middle_messages: ${messages.length - selected.length}`);
+
+  let plans = buildSessionTreeCuePlans(messages, 5, config.smallTreeMaxMessages);
+  const initialSnippetCount = plans.reduce((sum, plan) => sum + plan.selected.length, 0);
+  const budgetFallbackApplied = initialSnippetCount > config.maxSnippets;
+  if (budgetFallbackApplied) {
+    plans = buildSessionTreeCuePlans(messages, 2, config.smallTreeMaxMessages);
+  }
+  const selectedSnippetCount = plans.reduce((sum, plan) => sum + plan.selected.length, 0);
+  const budgetBreached = selectedSnippetCount > config.maxSnippets;
+
+  lines.push(`cue_small_tree_max_messages: ${config.smallTreeMaxMessages}`);
+  lines.push(`cue_global_snippet_budget: ${config.maxSnippets}`);
+  lines.push(`cue_per_tree_large_window: ${budgetFallbackApplied ? "2+2" : "5+5"}`);
+  lines.push(`cue_budget_fallback_applied: ${budgetFallbackApplied ? "yes" : "no"}`);
+  lines.push(`cue_global_budget_breached: ${budgetBreached ? "yes" : "no"}`);
+  if (budgetBreached) {
+    lines.push(`cue_global_budget_breached_note: ${selectedSnippetCount} snippets still exceed the ${config.maxSnippets}-snippet budget after reducing large trees to 2+2. Mention this in the Dream report.`);
+  }
+  lines.push("session_tree_index:");
+  for (const plan of plans) {
+    lines.push(`- ${cleanCueText(plan.label, 120)}: messages=${plan.messages.length}, taken=${plan.selected.length}, chats=${plan.chatJids.length}, slice=${plan.firstTimestamp}..${plan.lastTimestamp}`);
+  }
+  lines.push("message_snippets:");
+  for (const plan of plans) {
+    lines.push(`tree: ${cleanCueText(plan.label, 120)} — took ${plan.selected.length}/${plan.messages.length}`);
+    for (const message of plan.selected) {
+      lines.push(formatCueSnippet(message));
+    }
+  }
+  if (selectedSnippetCount < messages.length) {
+    lines.push(`omitted_middle_messages: ${messages.length - selectedSnippetCount}`);
   }
   lines.push(DREAM_CUES_END);
   return lines.join("\n");

--- a/runtime/src/agent-memory/daily-notes.ts
+++ b/runtime/src/agent-memory/daily-notes.ts
@@ -29,6 +29,17 @@ interface Row {
   day: string;
 }
 
+interface DailyMessageStats {
+  day: string;
+  firstTimestamp: string;
+  lastTimestamp: string;
+  totalMsgs: number;
+  userMsgs: number;
+  botMsgs: number;
+  sessionTrees: number;
+  sessionChats: number;
+}
+
 export interface RefreshDailyNotesResult {
   scope_mode: string;
   scope_anchor: string;
@@ -57,6 +68,40 @@ function formatDateLong(iso: string): string {
 }
 
 function todayStr(): string { return new Date().toISOString().slice(0, 10); }
+
+function windowStartDay(days: number): string {
+  return new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+}
+
+function buildDailyMessageStats(day: string, messages: Row[]): DailyMessageStats {
+  return {
+    day,
+    firstTimestamp: messages[0].timestamp,
+    lastTimestamp: messages[messages.length - 1].timestamp,
+    totalMsgs: messages.length,
+    userMsgs: messages.filter((message) => !message.is_bot_message).length,
+    botMsgs: messages.filter((message) => message.is_bot_message).length,
+    sessionTrees: new Set(messages.map((message) => message.root_chat_jid)).size,
+    sessionChats: new Set(messages.map((message) => message.chat_jid)).size,
+  };
+}
+
+function noteSliceMetadataDrift(
+  fields: Record<string, string>,
+  stats: DailyMessageStats,
+  scope: { mode: string; anchor: string },
+): boolean {
+  return (fields.date || "") !== stats.day
+    || (fields.messages_total || "") !== String(stats.totalMsgs)
+    || (fields.messages_user || "") !== String(stats.userMsgs)
+    || (fields.messages_assistant || "") !== String(stats.botMsgs)
+    || (fields.session_trees || "") !== String(stats.sessionTrees)
+    || (fields.session_chats || "") !== String(stats.sessionChats)
+    || (fields.first_message || "") !== stats.firstTimestamp
+    || (fields.last_message || "") !== stats.lastTimestamp
+    || (fields.scope_mode || "") !== scope.mode
+    || (fields.scope_anchor || "") !== scope.anchor;
+}
 
 function splitFrontMatter(content: string): FrontMatter {
   const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
@@ -266,17 +311,68 @@ function resolveScope(chatJid: string): { clause: string; params: string[]; mode
   return { clause: "m.chat_jid = ?", params: [normalized], mode: "chat-only", anchor: normalized };
 }
 
+function loadDailyMessageStatsSince(cutoffIso: string, scope: { clause: string; params: string[] }): Map<string, DailyMessageStats> {
+  const db = getDb();
+  const rows = db.query<{
+    day: string;
+    first_timestamp: string;
+    last_timestamp: string;
+    total_msgs: number;
+    user_msgs: number;
+    bot_msgs: number;
+    session_trees: number;
+    session_chats: number;
+  }, any[]>(
+    `SELECT substr(m.timestamp, 1, 10) AS day,
+            MIN(m.timestamp) AS first_timestamp,
+            MAX(m.timestamp) AS last_timestamp,
+            COUNT(*) AS total_msgs,
+            SUM(CASE WHEN COALESCE(m.is_bot_message, 0) = 0 THEN 1 ELSE 0 END) AS user_msgs,
+            SUM(CASE WHEN COALESCE(m.is_bot_message, 0) = 1 THEN 1 ELSE 0 END) AS bot_msgs,
+            COUNT(DISTINCT COALESCE(cb.root_chat_jid, m.chat_jid)) AS session_trees,
+            COUNT(DISTINCT m.chat_jid) AS session_chats
+     FROM messages m
+     LEFT JOIN chat_branches cb ON cb.chat_jid = m.chat_jid
+     WHERE ${scope.clause}
+       AND m.timestamp >= ?
+     GROUP BY day
+     ORDER BY day ASC`
+  ).all(...scope.params, cutoffIso);
+
+  return new Map(rows.map((row) => [row.day, {
+    day: row.day,
+    firstTimestamp: row.first_timestamp,
+    lastTimestamp: row.last_timestamp,
+    totalMsgs: row.total_msgs,
+    userMsgs: row.user_msgs,
+    botMsgs: row.bot_msgs,
+    sessionTrees: row.session_trees,
+    sessionChats: row.session_chats,
+  }]));
+}
+
 export function inspectDailyNoteSummaryBacklog(options?: { recentDays?: number }): DailyNoteSummaryBacklog {
   const recentDays = Math.max(1, Math.floor(Number(options?.recentDays) || 7));
   const dailyNotesDir = resolve(process.env.PICLAW_WORKSPACE || WORKSPACE_DIR, "notes/daily");
-  const cutoff = new Date(Date.now() - recentDays * 86400000).toISOString().slice(0, 10);
+  const cutoff = windowStartDay(recentDays);
   const today = todayStr();
+  const allChatsScope = resolveScope("*");
   let unsummarised = 0;
   let partial = 0;
   let missing_watermark = 0;
   let missing = 0;
   const dates = new Set<string>();
   const existingDates = new Set<string>();
+  let statsByDay = new Map<string, DailyMessageStats>();
+
+  try {
+    statsByDay = loadDailyMessageStatsSince(`${cutoff}T00:00:00.000Z`, allChatsScope);
+  } catch (error) {
+    debugSuppressedError(log, "Failed to inspect message days while checking daily-note backlog.", error, {
+      operation: "daily_notes.inspect_backlog.message_days",
+      recentDays,
+    });
+  }
 
   if (existsSync(dailyNotesDir)) {
     for (const file of readdirSync(dailyNotesDir).filter((entry) => /^\d{4}-\d{2}-\d{2}\.md$/.test(entry)).sort()) {
@@ -288,6 +384,10 @@ export function inspectDailyNoteSummaryBacklog(options?: { recentDays?: number }
       const summary = extractSummary(body);
       const summarisedUntil = (fields.summarised_until || '').trim();
       const needsSummaryUpdate = body.includes(SUMMARY_UPDATE_MARKER);
+      const hasIncompleteWarning = body.includes(INCOMPLETE_WARNING_TITLE);
+      const stats = statsByDay.get(date);
+      const metadataDrift = stats ? noteSliceMetadataDrift(fields, stats, allChatsScope) : false;
+      const newerMessagesExist = Boolean(summary && summarisedUntil && stats && stats.lastTimestamp > summarisedUntil);
 
       if (!summary) {
         unsummarised += 1;
@@ -299,34 +399,19 @@ export function inspectDailyNoteSummaryBacklog(options?: { recentDays?: number }
         dates.add(date);
         continue;
       }
-      if (needsSummaryUpdate) {
+      if (needsSummaryUpdate || hasIncompleteWarning || metadataDrift || newerMessagesExist) {
         partial += 1;
         dates.add(date);
       }
     }
   }
 
-  try {
-    const db = getDb();
-    const rows = db.query<{ day: string }, [string, string]>(
-      `SELECT DISTINCT substr(timestamp, 1, 10) AS day
-       FROM messages
-       WHERE chat_jid NOT LIKE 'dream:%'
-         AND timestamp >= ?
-         AND substr(timestamp, 1, 10) < ?
-       ORDER BY day ASC`
-    ).all(`${cutoff}T00:00:00.000Z`, today);
-    for (const row of rows) {
-      if (!existingDates.has(row.day)) {
-        missing += 1;
-        dates.add(row.day);
-      }
+  for (const day of [...statsByDay.keys()].sort()) {
+    if (day >= today) continue;
+    if (!existingDates.has(day)) {
+      missing += 1;
+      dates.add(day);
     }
-  } catch (error) {
-    debugSuppressedError(log, "Failed to inspect message days while checking daily-note backlog.", error, {
-      operation: "daily_notes.inspect_backlog.message_days",
-      recentDays,
-    });
   }
 
   return { unsummarised, partial, missing_watermark, missing, dates: [...dates].sort() };
@@ -342,7 +427,8 @@ export function refreshDailyNotesFromMessages(options?: { days?: number; chatJid
   const db = getDb();
   const scope = resolveScope(chatJid);
   const params: any[] = [...scope.params];
-  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+  const cutoffDay = windowStartDay(days);
+  const cutoffIso = `${cutoffDay}T00:00:00.000Z`;
   const rows = db.query<Row, any[]>(
     `SELECT m.sender_name,
             m.is_bot_message,
@@ -355,7 +441,7 @@ export function refreshDailyNotesFromMessages(options?: { days?: number; chatJid
      LEFT JOIN chat_branches cb ON cb.chat_jid = m.chat_jid
      WHERE ${scope.clause} AND m.timestamp >= ?
      ORDER BY m.timestamp ASC`
-  ).all(...params, cutoff);
+  ).all(...params, cutoffIso);
 
   const dayMap = new Map<string, Row[]>();
   for (const row of rows) {
@@ -372,13 +458,8 @@ export function refreshDailyNotesFromMessages(options?: { days?: number; chatJid
   for (const day of sortedDays) {
     const filePath = `${dailyNotesDir}/${day}.md`;
     const messages = dayMap.get(day)!;
-    const firstTimestamp = messages[0].timestamp;
-    const lastTimestamp = messages[messages.length - 1].timestamp;
-    const totalMsgs = messages.length;
-    const userMsgs = messages.filter((m) => !m.is_bot_message).length;
-    const botMsgs = messages.filter((m) => m.is_bot_message).length;
-    const sessionTrees = new Set(messages.map((m) => m.root_chat_jid)).size;
-    const sessionChats = new Set(messages.map((m) => m.chat_jid)).size;
+    const stats = buildDailyMessageStats(day, messages);
+    const { firstTimestamp, lastTimestamp, totalMsgs, userMsgs, botMsgs, sessionTrees, sessionChats } = stats;
     const isToday = day === today;
 
     if (existsSync(filePath)) {
@@ -391,9 +472,11 @@ export function refreshDailyNotesFromMessages(options?: { days?: number; chatJid
       const hasWm = existingWm.length > 0;
       const needsPartialUpdate = Boolean(summary && hasWm && lastTimestamp > existingWm);
       const needsMigration = !hasFrontMatter || !("date" in fields) || !("summarised_until" in fields);
-      const shouldWrite = isToday || force || needsMigration || needsPartialUpdate;
+      const metadataDrift = noteSliceMetadataDrift(fields, stats, scope);
+      const needsSliceReseed = !summary || !hasWm || needsMigration || metadataDrift;
+      const shouldWrite = isToday || force || needsSliceReseed || needsPartialUpdate;
 
-      if (!isToday && !force && !shouldWrite) {
+      if (!shouldWrite) {
         skipped += 1;
         continue;
       }
@@ -406,7 +489,7 @@ export function refreshDailyNotesFromMessages(options?: { days?: number; chatJid
         ? { lastTimestamp }
         : needsPartialUpdate
           ? { summarisedUntil: existingWm, lastTimestamp, needsSummaryUpdate: true }
-          : !hasWm
+          : needsSliceReseed
             ? { lastTimestamp }
             : null;
       body = upsertIncompleteWarning(body, incompleteState);
@@ -416,7 +499,7 @@ export function refreshDailyNotesFromMessages(options?: { days?: number; chatJid
 
       const nextFields: Record<string, string> = {
         ...fields,
-        date: fields.date || day,
+        date: day,
         summarised_until: existingWm,
         messages_total: String(totalMsgs),
         messages_user: String(userMsgs),

--- a/runtime/src/agent-memory/dream-prompt.ts
+++ b/runtime/src/agent-memory/dream-prompt.ts
@@ -27,7 +27,7 @@ export function buildDreamPrompt(options?: { mode?: "manual" | "auto"; days?: nu
     "- Load startup memory from `notes/memory/MEMORY.md` and `notes/index.md`.",
     "- Inspect relevant `notes/daily/*.md` and existing `notes/memory/*` files before deciding what matters.",
     "- Treat daily-note front matter as the deterministic transcript contract: `scope_anchor`, `first_message`, `last_message`, `messages_total`, `session_trees`, and `session_chats` define the bounded evidence slice for that note.",
-    "- Unfinished notes may contain hidden `DREAM_CUES` comments. Use those cue terms/snippets first; for small bounded days (`messages_total <= 50` and `session_trees <= 2`), it is acceptable to inspect the full bounded day slice before declaring consolidation unsafe.",
+    "- Unfinished notes may contain hidden `DREAM_CUES` comments. Use those cue terms/snippets first; when `bounded_full_slice: yes`, it is acceptable to inspect the full bounded day slice before declaring consolidation unsafe.",
     "- Open deeper files only when they are needed to resolve uncertainty.",
     "2. Signal:",
     "- Look for new information worth persisting.",
@@ -65,6 +65,7 @@ export function buildDreamPrompt(options?: { mode?: "manual" | "auto"; days?: nu
     "- Keep daily-note front matter truthful, especially `summarised_until`, `first_message`, and `last_message` when you touch a note.",
     "- A day is not done while either summary placeholder marker is still present in its note; only leave a marker if the note truly remains incomplete after your narrow evidence-gathering pass.",
     "- If a day remains incomplete, mention the unresolved date and why in your final Dream summary so runtime post-processing can surface it clearly.",
+    "- If a day's `DREAM_CUES` report `cue_global_budget_breached: yes`, mention that date and budget breach in your final Dream summary.",
     "",
     "Return a brief summary of what changed across Orient, Signal, Consolidate, and Prune and Index, plus whether runtime post-processing succeeded.",
   ].join("\n");

--- a/runtime/src/agent-memory/refresh.ts
+++ b/runtime/src/agent-memory/refresh.ts
@@ -12,6 +12,7 @@ export const AGENT_MEMORY_PROJECT_PATH = resolve(AGENT_MEMORY_DIR, "project.md")
 export const AGENT_MEMORY_REFERENCE_PATH = resolve(AGENT_MEMORY_DIR, "reference.md");
 const SUMMARY_MARKER = "<!-- NEEDS_SUMMARY -->";
 const SUMMARY_UPDATE_MARKER = "<!-- NEEDS_SUMMARY_UPDATE -->";
+const INCOMPLETE_WARNING_TITLE = "> ⚠ **Incomplete daily note**";
 const MEMORY_LINE_LIMIT = 200;
 const MEMORY_MAX_BYTES = 25 * 1024;
 const MAX_SIGNAL_ITEMS = 6;
@@ -304,6 +305,12 @@ interface TranscriptRow {
 
 function buildScopeFilter(sidecar: DailyAgentSidecar): { clause: string; params: string[] } {
   const anchor = sidecar.scope_anchor || "web:default";
+  if (sidecar.scope_mode === "all-chats" || anchor === "*") {
+    return {
+      clause: "m.chat_jid NOT LIKE 'dream:%'",
+      params: [],
+    };
+  }
   if (sidecar.scope_mode === "all-web-session-trees" || anchor.startsWith("web:")) {
     return {
       clause: "m.chat_jid LIKE 'web:%'",
@@ -382,12 +389,13 @@ function buildSidecar(notePath: string, content: string): DailyAgentSidecar {
   const summary = extractSummary(body);
   const summaryUpdates = extractSummaryUpdates(body);
   const needsSummaryUpdate = body.includes(SUMMARY_UPDATE_MARKER);
+  const hasIncompleteWarning = body.includes(INCOMPLETE_WARNING_TITLE);
   const summarisedUntil = fields.summarised_until || null;
 
   let state: DailyAgentSidecar["state"] = "complete";
   if (!summary) state = "unsummarised";
   else if (!summarisedUntil) state = "missing_watermark";
-  else if (needsSummaryUpdate) state = "partial";
+  else if (needsSummaryUpdate || hasIncompleteWarning) state = "partial";
 
   return {
     schema_version: 1,

--- a/runtime/src/dream.ts
+++ b/runtime/src/dream.ts
@@ -89,16 +89,7 @@ function isDreamToolAllowed(toolName: string): boolean {
 }
 
 function refreshDailyNotes(_chatJid: string, days: number): boolean {
-  const backlog = inspectDailyNoteSummaryBacklog({ recentDays: days });
-  const oldestBacklogDay = backlog.dates.length > 0 ? backlog.dates.slice().sort()[0] : null;
-  const boundedDays = (() => {
-    if (!oldestBacklogDay) return 1;
-    const diffMs = Date.now() - new Date(`${oldestBacklogDay}T00:00:00Z`).getTime();
-    const spanDays = Math.max(1, Math.floor(diffMs / 86400000) + 1);
-    return Math.max(1, Math.min(days, spanDays));
-  })();
-
-  refreshDailyNotesFromMessages({ chatJid: DREAM_ALL_CHATS_SCOPE_ANCHOR, days: boundedDays });
+  refreshDailyNotesFromMessages({ chatJid: DREAM_ALL_CHATS_SCOPE_ANCHOR, days });
   return true;
 }
 

--- a/runtime/src/dream.ts
+++ b/runtime/src/dream.ts
@@ -84,6 +84,34 @@ export interface DreamAgentTurnResult {
   result: string;
 }
 
+function parseModelLabel(label: string): { provider?: string; modelId: string } {
+  const trimmed = String(label || "").trim();
+  const slash = trimmed.indexOf("/");
+  if (slash > 0 && slash < trimmed.length - 1) {
+    return {
+      provider: trimmed.slice(0, slash),
+      modelId: trimmed.slice(slash + 1),
+    };
+  }
+  return { provider: undefined, modelId: trimmed };
+}
+
+async function applyModelLabel(agentPool: AgentPool, chatJid: string, label: string): Promise<string | null> {
+  const trimmed = String(label || "").trim();
+  if (!trimmed) return null;
+  const { provider, modelId } = parseModelLabel(trimmed);
+  const control = await agentPool.applyControlCommand(chatJid, {
+    type: "model",
+    provider,
+    modelId,
+    raw: `/model ${trimmed}`,
+  });
+  if (control.status === "error") {
+    return control.message;
+  }
+  return null;
+}
+
 function isDreamToolAllowed(toolName: string): boolean {
   return DREAM_ALLOWED_TOOL_NAMES.has(String(toolName || "").trim());
 }
@@ -453,7 +481,7 @@ async function createDreamBackup(chatJid: string, mode: "manual" | "auto", days:
   return backupPath;
 }
 
-export async function runDreamAgentTurn(options: { chatJid: string; days?: number; mode?: "manual" | "auto"; agentPool: AgentPool }): Promise<DreamAgentTurnResult> {
+export async function runDreamAgentTurn(options: { chatJid: string; days?: number; mode?: "manual" | "auto"; model?: string | null; agentPool: AgentPool }): Promise<DreamAgentTurnResult> {
   const chatJid = options.chatJid;
   const mode = options.mode === "auto" ? "auto" : "manual";
   const days = Number.isFinite(options.days) && Number(options.days) > 0
@@ -497,6 +525,9 @@ export async function runDreamAgentTurn(options: { chatJid: string; days?: numbe
   let lockFd: number | null = null;
   let shouldCleanupDreamChat = false;
   const dreamChatJid = buildDreamChatJid(chatJid, mode);
+  const requestedDreamModel = typeof options.model === "string" && options.model.trim()
+    ? options.model.trim()
+    : DREAM_MODEL;
   const dreamStartTime = Date.now();
   try {
     const lock = acquireDreamLock();
@@ -512,6 +543,30 @@ export async function runDreamAgentTurn(options: { chatJid: string; days?: numbe
     reapDreamArtifacts(null);
     const backupPath = await createDreamBackup(chatJid, mode, days);
     const dailyNotesRefreshed = refreshDailyNotes(chatJid, days);
+    if (requestedDreamModel) {
+      const modelError = await applyModelLabel(options.agentPool, dreamChatJid, requestedDreamModel);
+      if (modelError) {
+        const refresh = refreshAgentMemoryFromDailyNotes({ recentDays: days });
+        const postBacklog = inspectDailyNoteSummaryBacklog({ recentDays: days });
+        const workspaceIndexRefreshed = await refreshWorkspaceSearchIndex();
+        return {
+          mode,
+          skipped: false,
+          result: [
+            `${mode === "auto" ? "AutoDream" : "Dream"} model switch failed; deterministic refresh completed.`,
+            `- Model switch error: ${modelError}`,
+            `- Daily notes refreshed before Dream: ${dailyNotesRefreshed ? "yes" : "no"}`,
+            formatDailyNoteBacklogSummary(postBacklog),
+            `- Memory refreshed after Dream: yes`,
+            `- Updated memory: ${refresh.memoryPath}`,
+            `- Updated current state: ${refresh.currentStatePath}`,
+            `- Updated recent context: ${refresh.recentContextPath}`,
+            `- Pre-Dream backup: ${backupPath || "(none)"}`,
+            `- Workspace index refreshed: ${workspaceIndexRefreshed ? "yes" : "no"}`,
+          ].filter(Boolean).join("\n"),
+        };
+      }
+    }
     const out = await options.agentPool.runAgent(buildDreamPrompt({ mode, days }), dreamChatJid, {
       timeoutMs: getDreamAgentTimeoutMs(),
       toolCeilingFilter: isDreamToolAllowed,

--- a/runtime/src/task-scheduler.ts
+++ b/runtime/src/task-scheduler.ts
@@ -158,6 +158,7 @@ async function runInternalTask(task: ScheduledTask, deps: SchedulerDeps): Promis
         chatJid: task.chat_jid,
         days: dreamToken.days,
         mode: "auto",
+        model: task.model,
         agentPool: deps.agentPool,
       });
       return {

--- a/runtime/test/agent-memory/daily-notes.test.ts
+++ b/runtime/test/agent-memory/daily-notes.test.ts
@@ -238,3 +238,161 @@ test("refreshDailyNotesFromMessages adds an incomplete warning and summary updat
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("refreshDailyNotesFromMessages rehydrates stale unfinished past notes instead of skipping them", () => {
+  const base = makeTempWorkspace("piclaw-daily-notes-reseed-");
+  try {
+    const day = isoDateDaysAgo(1);
+    const firstTs = `${day}T10:00:00.000Z`;
+    const laterTs = `${day}T18:30:00.000Z`;
+
+    mkdirSync(join(base, "notes", "daily"), { recursive: true });
+    writeFileSync(
+      join(base, "notes", "daily", `${day}.md`),
+      `---\ndate: ${day}\nsummarised_until:\nmessages_total: 1\nmessages_user: 1\nmessages_assistant: 0\nsession_trees: 1\nsession_chats: 1\nfirst_message: ${firstTs}\nlast_message: ${firstTs}\nscope_mode: all-chats\nscope_anchor: *\n---\n# ${day}\n\n## Summary\n\n<!-- NEEDS_SUMMARY -->\n`,
+      "utf8",
+    );
+
+    const script = `
+      import { initDatabase, storeMessage } from ${JSON.stringify(DB_MODULE)};
+      import { refreshDailyNotesFromMessages } from ${JSON.stringify(DAILY_NOTES_MODULE)};
+      initDatabase();
+      storeMessage({
+        id: 'user-1',
+        chat_jid: 'web:default',
+        sender: 'user',
+        sender_name: 'You',
+        content: 'first',
+        timestamp: '${firstTs}',
+        is_bot_message: false,
+      });
+      storeMessage({
+        id: 'agent-1',
+        chat_jid: 'mc-review',
+        sender: 'agent',
+        sender_name: 'Assistant',
+        content: 'later code review follow-up',
+        timestamp: '${laterTs}',
+        is_bot_message: true,
+        is_terminal_agent_reply: true,
+      });
+      const out = refreshDailyNotesFromMessages({ chatJid: '*', days: 7 });
+      console.log(JSON.stringify({ updated: out.updated }));
+    `;
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], { env: makeEnv(base), stdout: "pipe", stderr: "pipe" });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+    const result = JSON.parse(proc.stdout.toString().trim().split("\n").pop()!);
+    expect(result.updated).toBe(1);
+
+    const note = readFileSync(join(base, "notes", "daily", `${day}.md`), "utf8");
+    expect(note).toContain("messages_total: 2");
+    expect(note).toContain("messages_assistant: 1");
+    expect(note).toContain(`last_message: ${laterTs}`);
+    expect(note).toContain(`slice: ${firstTs}..${laterTs}`);
+    expect(note).toContain("mc-review");
+    expect(note).toContain("<!-- NEEDS_SUMMARY -->");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("inspectDailyNoteSummaryBacklog treats stale complete notes as partial backlog", () => {
+  const base = makeTempWorkspace("piclaw-daily-notes-partial-backlog-");
+  try {
+    const day = isoDateDaysAgo(1);
+    const firstTs = `${day}T10:00:00.000Z`;
+    const laterTs = `${day}T18:30:00.000Z`;
+
+    mkdirSync(join(base, "notes", "daily"), { recursive: true });
+    writeFileSync(
+      join(base, "notes", "daily", `${day}.md`),
+      `---\ndate: ${day}\nsummarised_until: ${firstTs}\nmessages_total: 1\nmessages_user: 1\nmessages_assistant: 0\nsession_trees: 1\nsession_chats: 1\nfirst_message: ${firstTs}\nlast_message: ${firstTs}\nscope_mode: all-chats\nscope_anchor: *\n---\n# ${day}\n\n## Summary\n\nEarlier summary.\n`,
+      "utf8",
+    );
+
+    const script = `
+      import { initDatabase, storeMessage } from ${JSON.stringify(DB_MODULE)};
+      import { inspectDailyNoteSummaryBacklog } from ${JSON.stringify(DAILY_NOTES_MODULE)};
+      initDatabase();
+      storeMessage({
+        id: 'user-1',
+        chat_jid: 'web:default',
+        sender: 'user',
+        sender_name: 'You',
+        content: 'first',
+        timestamp: '${firstTs}',
+        is_bot_message: false,
+      });
+      storeMessage({
+        id: 'agent-1',
+        chat_jid: 'mc-review',
+        sender: 'agent',
+        sender_name: 'Assistant',
+        content: 'later code review follow-up',
+        timestamp: '${laterTs}',
+        is_bot_message: true,
+        is_terminal_agent_reply: true,
+      });
+      console.log(JSON.stringify(inspectDailyNoteSummaryBacklog({ recentDays: 7 })));
+    `;
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], { env: makeEnv(base), stdout: "pipe", stderr: "pipe" });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+    const result = JSON.parse(proc.stdout.toString().trim().split("\n").pop()!);
+    expect(result).toMatchObject({ unsummarised: 0, partial: 1, missing_watermark: 0, missing: 0, dates: [day] });
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("refreshDailyNotesFromMessages uses UTC day boundaries for the start of the requested window", () => {
+  const base = makeTempWorkspace("piclaw-daily-notes-boundary-");
+  try {
+    const day = "2026-06-11";
+    const firstTs = `${day}T00:03:10.000Z`;
+    const laterTs = `${day}T23:54:04.812Z`;
+
+    const script = `
+      const fixedNow = new Date('2026-06-13T12:00:00.000Z').getTime();
+      Date.now = () => fixedNow;
+      const { initDatabase, storeMessage } = await import(${JSON.stringify(DB_MODULE)});
+      const { refreshDailyNotesFromMessages } = await import(${JSON.stringify(DAILY_NOTES_MODULE)});
+      initDatabase();
+      storeMessage({
+        id: 'user-1',
+        chat_jid: 'telegram:1',
+        sender: 'user',
+        sender_name: 'You',
+        content: 'early retained message',
+        timestamp: '${firstTs}',
+        is_bot_message: false,
+      });
+      storeMessage({
+        id: 'agent-1',
+        chat_jid: 'telegram:1',
+        sender: 'agent',
+        sender_name: 'Assistant',
+        content: 'late retained message',
+        timestamp: '${laterTs}',
+        is_bot_message: true,
+        is_terminal_agent_reply: true,
+      });
+      const out = refreshDailyNotesFromMessages({ chatJid: '*', days: 2 });
+      console.log(JSON.stringify({ created: out.created, days: out.days }));
+    `;
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], { env: makeEnv(base), stdout: "pipe", stderr: "pipe" });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+    const result = JSON.parse(proc.stdout.toString().trim().split("\n").pop()!);
+    expect(result).toMatchObject({ created: 1, days: [day] });
+
+    const note = readFileSync(join(base, "notes", "daily", `${day}.md`), "utf8");
+    expect(note).toContain(`first_message: ${firstTs}`);
+    expect(note).toContain(`last_message: ${laterTs}`);
+    expect(note).toContain("messages_total: 2");
+    expect(note).toContain("early retained message");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/runtime/test/agent-memory/daily-notes.test.ts
+++ b/runtime/test/agent-memory/daily-notes.test.ts
@@ -346,12 +346,13 @@ test("inspectDailyNoteSummaryBacklog treats stale complete notes as partial back
   }
 });
 
-test("refreshDailyNotesFromMessages uses UTC day boundaries for the start of the requested window", () => {
+test("refreshDailyNotesFromMessages uses runtime-local day boundaries for grouping and window cutoffs", () => {
   const base = makeTempWorkspace("piclaw-daily-notes-boundary-");
   try {
     const day = "2026-06-11";
-    const firstTs = `${day}T00:03:10.000Z`;
-    const laterTs = `${day}T23:54:04.812Z`;
+    const previousLocalDayTs = "2026-06-11T06:59:00.000Z";
+    const firstTs = "2026-06-11T07:01:00.000Z";
+    const laterTs = "2026-06-12T06:30:00.000Z";
 
     const script = `
       const fixedNow = new Date('2026-06-13T12:00:00.000Z').getTime();
@@ -360,11 +361,20 @@ test("refreshDailyNotesFromMessages uses UTC day boundaries for the start of the
       const { refreshDailyNotesFromMessages } = await import(${JSON.stringify(DAILY_NOTES_MODULE)});
       initDatabase();
       storeMessage({
+        id: 'user-prev',
+        chat_jid: 'telegram:1',
+        sender: 'user',
+        sender_name: 'You',
+        content: 'previous local day message',
+        timestamp: '${previousLocalDayTs}',
+        is_bot_message: false,
+      });
+      storeMessage({
         id: 'user-1',
         chat_jid: 'telegram:1',
         sender: 'user',
         sender_name: 'You',
-        content: 'early retained message',
+        content: 'local midnight retained message',
         timestamp: '${firstTs}',
         is_bot_message: false,
       });
@@ -373,7 +383,7 @@ test("refreshDailyNotesFromMessages uses UTC day boundaries for the start of the
         chat_jid: 'telegram:1',
         sender: 'agent',
         sender_name: 'Assistant',
-        content: 'late retained message',
+        content: 'same local day late-night message',
         timestamp: '${laterTs}',
         is_bot_message: true,
         is_terminal_agent_reply: true,
@@ -382,7 +392,14 @@ test("refreshDailyNotesFromMessages uses UTC day boundaries for the start of the
       console.log(JSON.stringify({ created: out.created, days: out.days }));
     `;
 
-    const proc = Bun.spawnSync([process.execPath, "-e", script], { env: makeEnv(base), stdout: "pipe", stderr: "pipe" });
+    const proc = Bun.spawnSync([process.execPath, "-e", script], {
+      env: {
+        ...makeEnv(base),
+        TZ: "America/Los_Angeles",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
     expect(proc.exitCode, proc.stderr.toString()).toBe(0);
     const result = JSON.parse(proc.stdout.toString().trim().split("\n").pop()!);
     expect(result).toMatchObject({ created: 1, days: [day] });
@@ -391,7 +408,49 @@ test("refreshDailyNotesFromMessages uses UTC day boundaries for the start of the
     expect(note).toContain(`first_message: ${firstTs}`);
     expect(note).toContain(`last_message: ${laterTs}`);
     expect(note).toContain("messages_total: 2");
-    expect(note).toContain("early retained message");
+    expect(note).toContain("local midnight retained message");
+    expect(note).toContain("same local day late-night message");
+    expect(note).not.toContain("previous local day message");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("inspectDailyNoteSummaryBacklog groups missing message days in the runtime timezone", () => {
+  const base = makeTempWorkspace("piclaw-daily-notes-backlog-timezone-");
+  try {
+    const day = "2026-06-11";
+    const localLateNightTs = "2026-06-12T06:30:00.000Z";
+
+    const script = `
+      const fixedNow = new Date('2026-06-13T12:00:00.000Z').getTime();
+      Date.now = () => fixedNow;
+      const { initDatabase, storeMessage } = await import(${JSON.stringify(DB_MODULE)});
+      const { inspectDailyNoteSummaryBacklog } = await import(${JSON.stringify(DAILY_NOTES_MODULE)});
+      initDatabase();
+      storeMessage({
+        id: 'user-1',
+        chat_jid: 'telegram:1',
+        sender: 'user',
+        sender_name: 'You',
+        content: 'late local-day message',
+        timestamp: '${localLateNightTs}',
+        is_bot_message: false,
+      });
+      console.log(JSON.stringify(inspectDailyNoteSummaryBacklog({ recentDays: 2 })));
+    `;
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], {
+      env: {
+        ...makeEnv(base),
+        TZ: "America/Los_Angeles",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+    const result = JSON.parse(proc.stdout.toString().trim().split("\n").pop()!);
+    expect(result).toMatchObject({ unsummarised: 0, partial: 0, missing_watermark: 0, missing: 1, dates: [day] });
   } finally {
     rmSync(base, { recursive: true, force: true });
   }

--- a/runtime/test/agent-memory/daily-notes.test.ts
+++ b/runtime/test/agent-memory/daily-notes.test.ts
@@ -396,3 +396,176 @@ test("refreshDailyNotesFromMessages uses UTC day boundaries for the start of the
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("refreshDailyNotesFromMessages builds per-session-tree DREAM_CUES for multi-session days", () => {
+  const base = makeTempWorkspace("piclaw-daily-notes-session-tree-cues-");
+  try {
+    const day = isoDateDaysAgo(1);
+    const script = `
+      import { initDatabase, storeMessage, getDb } from ${JSON.stringify(DB_MODULE)};
+      import { refreshDailyNotesFromMessages } from ${JSON.stringify(DAILY_NOTES_MODULE)};
+      initDatabase();
+      const db = getDb();
+      db.prepare("INSERT INTO chat_branches (branch_id, chat_jid, root_chat_jid, parent_branch_id, agent_name, created_at, updated_at, archived_at) VALUES (?, ?, ?, NULL, ?, ?, ?, NULL)")
+        .run('branch-web-default', 'web:branch', 'web:default', 'test-agent', '${day}T15:59:00.000Z', '${day}T15:59:00.000Z');
+      const items = [];
+      for (let i = 0; i < 12; i += 1) {
+        items.push({
+          id: 'mc-' + i,
+          chat_jid: 'mc-review',
+          sender: i % 2 === 0 ? 'user' : 'agent',
+          sender_name: i % 2 === 0 ? 'You' : 'Assistant',
+          content: 'mc review message ' + i,
+          timestamp: '${day}T14:' + String(i).padStart(2, '0') + ':00.000Z',
+          is_bot_message: i % 2 === 1,
+          is_terminal_agent_reply: i % 2 === 1,
+        });
+      }
+      for (let i = 0; i < 4; i += 1) {
+        items.push({
+          id: 'web-' + i,
+          chat_jid: 'web:branch',
+          sender: i % 2 === 0 ? 'user' : 'agent',
+          sender_name: i % 2 === 0 ? 'You' : 'Assistant',
+          content: 'branch session message ' + i,
+          timestamp: '${day}T16:' + String(i).padStart(2, '0') + ':00.000Z',
+          is_bot_message: i % 2 === 1,
+          is_terminal_agent_reply: i % 2 === 1,
+        });
+      }
+      for (let i = 0; i < 3; i += 1) {
+        items.push({
+          id: 'tg-' + i,
+          chat_jid: 'telegram:1',
+          sender: i % 2 === 0 ? 'user' : 'agent',
+          sender_name: i % 2 === 0 ? 'You' : 'Assistant',
+          content: 'telegram session message ' + i,
+          timestamp: '${day}T18:' + String(i).padStart(2, '0') + ':00.000Z',
+          is_bot_message: i % 2 === 1,
+          is_terminal_agent_reply: i % 2 === 1,
+        });
+      }
+      for (const item of items) storeMessage(item);
+      const out = refreshDailyNotesFromMessages({ chatJid: '*', days: 7 });
+      console.log(JSON.stringify({ created: out.created }));
+    `;
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], { env: makeEnv(base), stdout: "pipe", stderr: "pipe" });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+
+    const note = readFileSync(join(base, "notes", "daily", `${day}.md`), "utf8");
+    expect(note).toContain("bounded_full_slice: no");
+    expect(note).toContain("session_tree_index:");
+    expect(note).toContain("mc-review: messages=12, taken=10");
+    expect(note).toContain("web:branch (root: web:default): messages=4, taken=4");
+    expect(note).toContain("telegram:1: messages=3, taken=3");
+    expect(note).toContain("tree: mc-review — took 10/12");
+    expect(note).toContain("tree: web:branch (root: web:default) — took 4/4");
+    expect(note).toContain("tree: telegram:1 — took 3/3");
+    expect(note).toContain("omitted_middle_messages: 2");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("refreshDailyNotesFromMessages honours cue threshold env overrides", () => {
+  const base = makeTempWorkspace("piclaw-daily-notes-cue-env-");
+  try {
+    const day = isoDateDaysAgo(1);
+    const userTs = `${day}T10:00:00.000Z`;
+    const agentTs = `${day}T10:05:00.000Z`;
+
+    const script = `
+      import { initDatabase, storeMessage } from ${JSON.stringify(DB_MODULE)};
+      import { refreshDailyNotesFromMessages } from ${JSON.stringify(DAILY_NOTES_MODULE)};
+      initDatabase();
+      storeMessage({
+        id: 'user-1',
+        chat_jid: 'web:default',
+        sender: 'user',
+        sender_name: 'You',
+        content: 'hello',
+        timestamp: '${userTs}',
+        is_bot_message: false,
+      });
+      storeMessage({
+        id: 'agent-1',
+        chat_jid: 'web:default',
+        sender: 'agent',
+        sender_name: 'Assistant',
+        content: 'hi',
+        timestamp: '${agentTs}',
+        is_bot_message: true,
+        is_terminal_agent_reply: true,
+      });
+      refreshDailyNotesFromMessages({ chatJid: '*', days: 7 });
+    `;
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], {
+      env: {
+        ...makeEnv(base),
+        PICLAW_DREAM_CUE_FULL_SLICE_MAX_MESSAGES: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+
+    const note = readFileSync(join(base, "notes", "daily", `${day}.md`), "utf8");
+    expect(note).toContain("bounded_full_slice: no");
+    expect(note).toContain("cue_full_slice_thresholds: messages<=1, session_trees<=2");
+    expect(note).toContain("session_tree_index:");
+    expect(note).toContain("web:default: messages=2, taken=2");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("refreshDailyNotesFromMessages downgrades large-tree cues to 2+2 and records budget breaches", () => {
+  const base = makeTempWorkspace("piclaw-daily-notes-cue-budget-");
+  try {
+    const day = isoDateDaysAgo(1);
+    const script = `
+      import { initDatabase, storeMessage } from ${JSON.stringify(DB_MODULE)};
+      import { refreshDailyNotesFromMessages } from ${JSON.stringify(DAILY_NOTES_MODULE)};
+      initDatabase();
+      for (const tree of ['mc-review', 'web:smalltalk', 'telegram:1']) {
+        for (let i = 0; i < 12; i += 1) {
+          storeMessage({
+            id: tree + '-' + i,
+            chat_jid: tree,
+            sender: i % 2 === 0 ? 'user' : 'agent',
+            sender_name: i % 2 === 0 ? 'You' : 'Assistant',
+            content: tree + ' message ' + i,
+            timestamp: '${day}T' + String(10 + (tree === 'mc-review' ? 0 : tree === 'web:smalltalk' ? 1 : 2)).padStart(2, '0') + ':' + String(i).padStart(2, '0') + ':00.000Z',
+            is_bot_message: i % 2 === 1,
+            is_terminal_agent_reply: i % 2 === 1,
+          });
+        }
+      }
+      refreshDailyNotesFromMessages({ chatJid: '*', days: 7 });
+    `;
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], {
+      env: {
+        ...makeEnv(base),
+        PICLAW_DREAM_CUE_MAX_SNIPPETS: "10",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+
+    const note = readFileSync(join(base, "notes", "daily", `${day}.md`), "utf8");
+    expect(note).toContain("cue_budget_fallback_applied: yes");
+    expect(note).toContain("cue_per_tree_large_window: 2+2");
+    expect(note).toContain("cue_global_budget_breached: yes");
+    expect(note).toContain("cue_global_budget_breached_note:");
+    expect(note).toContain("mc-review: messages=12, taken=4");
+    expect(note).toContain("web:smalltalk: messages=12, taken=4");
+    expect(note).toContain("telegram:1: messages=12, taken=4");
+    expect(note).toContain("tree: mc-review — took 4/12");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/runtime/test/agent-memory/refresh.test.ts
+++ b/runtime/test/agent-memory/refresh.test.ts
@@ -68,3 +68,66 @@ test("refresh keeps notes/memory/days sparse by default and only indexes sparse 
     rmSync(base, { recursive: true, force: true });
   }
 });
+
+test("refreshAgentMemoryFromDailyNotes uses all-chats scope when a daily note is anchored to *", () => {
+  const base = mkdtempSync(join(tmpdir(), "piclaw-refresh-all-chats-"));
+  const store = join(base, "store");
+  const data = join(base, "data");
+  mkdirSync(store, { recursive: true });
+  mkdirSync(data, { recursive: true });
+
+  try {
+    const recentDate = isoDateDaysAgo(1);
+    const dailyDir = join(base, "notes", "daily");
+    mkdirSync(dailyDir, { recursive: true });
+    writeFileSync(
+      join(dailyDir, `${recentDate}.md`),
+      `---\ndate: ${recentDate}\nsummarised_until: ${recentDate}T18:30:00.000Z\nmessages_total: 2\nmessages_user: 1\nmessages_assistant: 1\nsession_trees: 1\nsession_chats: 1\nfirst_message: ${recentDate}T14:47:53.547Z\nlast_message: ${recentDate}T15:04:59.757Z\nscope_mode: all-chats\nscope_anchor: *\n---\n# ${recentDate}\n\n## Summary\n\nFull code review of the mycare project was discussed.\n`,
+      "utf8",
+    );
+
+    const script = `
+      import { initDatabase, storeMessage } from ${JSON.stringify(new URL("../../src/db.js", import.meta.url).pathname)};
+      import { refreshAgentMemoryFromDailyNotes } from ${JSON.stringify(new URL("../../src/agent-memory/refresh.js", import.meta.url).pathname)};
+      initDatabase();
+      storeMessage({
+        id: 'user-1',
+        chat_jid: 'mc-review',
+        sender: 'user',
+        sender_name: 'You',
+        content: 'do a full thorough code review of mycare project in workspace and write detailed report about issues that were found.',
+        timestamp: '${recentDate}T14:47:53.547Z',
+        is_bot_message: false,
+      });
+      storeMessage({
+        id: 'agent-1',
+        chat_jid: 'mc-review',
+        sender: 'agent',
+        sender_name: 'Assistant',
+        content: "Here's the full code review report.",
+        timestamp: '${recentDate}T15:04:59.757Z',
+        is_bot_message: true,
+        is_terminal_agent_reply: true,
+      });
+      refreshAgentMemoryFromDailyNotes({ recentDays: 7 });
+    `;
+
+    const env = {
+      ...process.env,
+      PICLAW_WORKSPACE: base,
+      PICLAW_STORE: store,
+      PICLAW_DATA: data,
+      PICLAW_DB_IN_MEMORY: "1",
+    };
+
+    const proc = Bun.spawnSync([process.execPath, "-e", script], { env, stdout: "pipe", stderr: "pipe" });
+    expect(proc.exitCode, proc.stderr.toString()).toBe(0);
+
+    const feedback = readFileSync(join(base, "notes", "memory", "feedback.md"), "utf8");
+    const project = readFileSync(join(base, "notes", "memory", "project.md"), "utf8");
+    expect(feedback).toContain("[mc-review] do a full thorough code review of mycare project");
+    expect(project).toContain("[mc-review] Here's the full code review report.");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/runtime/test/dream-agent-turn.test.ts
+++ b/runtime/test/dream-agent-turn.test.ts
@@ -8,6 +8,50 @@ afterEach(() => {
   // no-op: test uses whichever workspace path the current config module has cached
 });
 
+test("runDreamAgentTurn applies an explicit Dream model override to the temporary dream chat", async () => {
+  const config = await import("../src/core/config.js");
+  rmSync(join(config.WORKSPACE_DIR, "notes"), { recursive: true, force: true });
+  rmSync(join(config.DATA_DIR, "dream-backups"), { recursive: true, force: true });
+  rmSync(join(config.DATA_DIR, "workspace-search"), { recursive: true, force: true });
+
+  const db = await import("../src/db.js");
+  db.initDatabase();
+
+  const fixedNow = Date.parse("2026-01-02T03:04:05.000Z");
+  const expectedDreamChatJid = `dream:manual:web_default:${fixedNow}`;
+  const applied: Array<{ chatJid: string; raw: string | undefined }> = [];
+  const runChats: string[] = [];
+
+  const realNow = Date.now;
+  Date.now = () => fixedNow;
+  try {
+    const dream = await importFresh<typeof import("../src/dream.js")>("../src/dream.js");
+    const result = await dream.runDreamAgentTurn({
+      chatJid: "web:default",
+      days: 2,
+      mode: "manual",
+      model: "openai-compatible/glm-5.1",
+      agentPool: {
+        applyControlCommand: async (chatJid: string, command: { raw?: string }) => {
+          applied.push({ chatJid, raw: command.raw });
+          return { status: "success", message: "ok" };
+        },
+        runAgent: async (_prompt: string, chatJid: string) => {
+          runChats.push(chatJid);
+          return { status: "success", result: "Dream complete." };
+        },
+        disposeChatSession: async () => {},
+      } as any,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(applied).toEqual([{ chatJid: expectedDreamChatJid, raw: "/model openai-compatible/glm-5.1" }]);
+    expect(runChats).toEqual([expectedDreamChatJid]);
+  } finally {
+    Date.now = realNow;
+  }
+});
+
 test("runDreamAgentTurn reaps a stale dream lock and materializes memory files after the model pass", { timeout: 15000 }, async () => {
   const config = await import("../src/core/config.js");
   rmSync(join(config.WORKSPACE_DIR, "notes"), { recursive: true, force: true });

--- a/runtime/test/dream-agent-turn.test.ts
+++ b/runtime/test/dream-agent-turn.test.ts
@@ -8,6 +8,8 @@ afterEach(() => {
   // no-op: test uses whichever workspace path the current config module has cached
 });
 
+const acceptModelChange = async () => ({ status: "success", message: "ok" } as const);
+
 test("runDreamAgentTurn applies an explicit Dream model override to the temporary dream chat", async () => {
   const config = await import("../src/core/config.js");
   rmSync(join(config.WORKSPACE_DIR, "notes"), { recursive: true, force: true });
@@ -103,6 +105,7 @@ test("runDreamAgentTurn reaps a stale dream lock and materializes memory files a
       days: 2,
       mode: "auto",
       agentPool: {
+        applyControlCommand: acceptModelChange,
         runAgent: async () => ({ status: "success", result: "AutoDream complete." }),
         disposeChatSession: async () => {},
       } as any,
@@ -179,6 +182,7 @@ test("runDreamAgentTurn records recovery summaries when the model pass succeeds 
     days: 2,
     mode: "auto",
     agentPool: {
+      applyControlCommand: acceptModelChange,
       runAgent: async () => ({
         status: "success",
         result: "AutoDream complete.",
@@ -214,6 +218,7 @@ test("runDreamAgentTurn falls back to deterministic refresh when the model pass 
     days: 2,
     mode: "auto",
     agentPool: {
+      applyControlCommand: acceptModelChange,
       runAgent: async (_prompt: string, _chatJid: string, options?: { timeoutMs?: number }) => {
         capturedTimeoutMs = options?.timeoutMs;
         return {


### PR DESCRIPTION
## Summary

This PR fixes a group of Dream issues that could make same-day conversations look incomplete, missing, or oddly grouped.

The issues were:

- Dream could trust an existing daily note even when that note had drifted away from the underlying message database
- on multi-session days, cue sampling could underrepresent or effectively hide an entire session tree
- `PICLAW_DREAM_MODEL` was not applied consistently to manual `/dream` runs

This PR makes Dream more faithful to the message DB, improves coverage on busy multi-chat days, applies the Dream model override consistently, and aligns Dream’s day slicing with the configured runtime timezone.

## New env vars

| Variable | Default | Description |
|---|---|---|
| `PICLAW_DREAM_CUE_FULL_SLICE_MAX_MESSAGES` | `50` | Use full bounded transcript slices only when a day has at most this many messages. |
| `PICLAW_DREAM_CUE_FULL_SLICE_MAX_SESSION_TREES` | `2` | Use full bounded transcript slices only when a day has at most this many session trees. |
| `PICLAW_DREAM_CUE_SMALL_TREE_MAX_MESSAGES` | `10` | Include all messages for session trees at or below this size. |
| `PICLAW_DREAM_CUE_MAX_SNIPPETS` | `100` | Global cue budget before large-tree sampling degrades from `5+5` to `2+2`. |

## What changed

### 1. Rebuild stale or incomplete daily notes from the DB
- detect when daily-note front matter no longer matches the authoritative message slice
- reseed stale, incomplete, or partially drifted daily notes from the database
- preserve the Markdown daily-note contract rather than introducing sidecars
- keep these fields truthful:
  - `scope_anchor`
  - `first_message`
  - `last_message`
  - `messages_total`
  - `session_trees`
  - `session_chats`

### 2. Fix all-chats Dream refresh scope
- treat `scope_anchor: "*"` correctly as an all-chats note scope
- ensure Dream refreshes from all non-Dream chats when a note is anchored that way

### 3. Improve `DREAM_CUES` coverage across session trees
- generate cue coverage per session tree instead of flattening the whole day into one stream
- preserve full-slice behavior for small days
- for small trees, include all messages
- for larger trees, include `first 5 + last 5`
- if over budget, degrade to `2 + 2`
- if still over budget, keep `2 + 2` and explicitly report the budget breach
- never silently omit an entire session tree
- include a compact tree index so the prompt shows what was sampled from each tree

### 4. Apply Dream model overrides consistently
- manual `/dream` now applies the Dream model override to the temporary Dream chat
- scheduled AutoDream continues to use its configured task model override
- `PICLAW_DREAM_MODEL` now behaves consistently across both manual and scheduled Dream paths

### 5. Explicitly use runtime-local day boundaries
- Dream daily-note grouping now follows the runtime timezone (`TZ` / runtime timing config)
- the same timezone now governs:
  - when AutoDream runs
  - which calendar day a message belongs to
  - where requested Dream windows begin and end

### 6. Update docs and regression coverage
- document Dream model behavior and runtime-timezone day slicing
- add/expand tests for:
  - stale daily-note reseeding
  - all-chats scope handling
  - per-session-tree cue coverage
  - cue budget fallback / breach reporting
  - manual Dream model override behavior
  - runtime-local day-boundary grouping and backlog detection

## Result

The practical effect is that Dream is much less likely to miss or distort a same-day conversation because:

- an old daily note looked complete when it was actually stale
- one active conversation stole most of the cue budget from another
- manual `/dream` used a different model path than AutoDream

Dream should now rebuild the right slices from the DB, represent multi-session days more fairly, use the configured Dream model consistently, and group messages into days the way the runtime is actually scheduled.

## Note

After changing timezone, boundary-adjacent daily notes may need regeneration so their day assignment matches the new runtime timezone.
