### PR TITLE
Add /quota command to display remaining quota status

### DIFF
--- a/runtime/src/agent-control/agent-control-handlers.ts
+++ b/runtime/src/agent-control/agent-control-handlers.ts
@@ -29,6 +29,7 @@ import {
   handleCommands,
   handleContext,
   handleLast,
+  handleQuota,
   handleSearchWorkspace,
   handleState,
   handleStats,
@@ -83,6 +84,8 @@ export async function applyControlCommand(
       return handleStats(session, command);
     case "context":
       return handleContext(session, command);
+    case "quota":
+      return handleQuota(session, command);
     case "last":
       return handleLast(session, command);
     case "compact":

--- a/runtime/src/agent-control/agent-control-types.ts
+++ b/runtime/src/agent-control/agent-control-types.ts
@@ -75,6 +75,10 @@ export type AgentControlCommand =
       raw: string;
     }
   | {
+      type: "quota";
+      raw: string;
+    }
+  | {
       type: "last";
       raw: string;
     }

--- a/runtime/src/agent-control/command-parsers.ts
+++ b/runtime/src/agent-control/command-parsers.ts
@@ -519,6 +519,7 @@ export const COMMAND_PARSERS: Record<string, CommandParser> = {
   "/state": simple("state"),
   "/stats": simple("stats"),
   "/context": simple("context"),
+  "/quota": simple("quota"),
   "/last": simple("last"),
   "/compact": parseCompact,
   "/auto-compact": parseAutoCompact,

--- a/runtime/src/agent-control/command-registry.ts
+++ b/runtime/src/agent-control/command-registry.ts
@@ -26,6 +26,7 @@ export const CONTROL_COMMAND_DEFINITIONS: ControlCommandDefinition[] = [
   { name: "/state", description: "Show current session state" },
   { name: "/stats", description: "Show session token and cost stats" },
   { name: "/context", description: "Show context window usage", aliases: ["/ctx"] },
+  { name: "/quota", description: "Show cached provider quota / rate-limit usage for the current model" },
   { name: "/last", description: "Show last assistant response" },
   { name: "/compact", description: "Manually compact the session" },
   { name: "/auto-compact", description: "Toggle auto-compaction" },

--- a/runtime/src/agent-control/handlers/info.ts
+++ b/runtime/src/agent-control/handlers/info.ts
@@ -1,8 +1,9 @@
 /**
  * agent-control/handlers/info.ts – Handlers for informational / read-only commands.
  *
- * Handles /commands, /state, /stats, /context, /last, /search-workspace,
- * /labels, and /label. These commands display session state, token usage,
+ * Handles /commands, /state, /stats, /context, /quota, /last,
+ * /search-workspace, /labels, and /label. These commands display session
+ * state, token usage,
  * and search results without modifying the session.
  *
  * Consumers: agent-control-handlers.ts dispatches to these handlers.
@@ -18,6 +19,7 @@ import { getChatJid } from "../../core/chat-context.js";
 import { getSessionStorageConfig } from "../../core/config.js";
 import { getSessionFileLineCount } from "../../session-rotation.js";
 import { getAutoCompactionTokenStatusForSession } from "../../agent-pool/compaction.js";
+import { peekProviderUsage } from "../../agent-pool/provider-usage.js";
 import { getTokenUsageByModel, getTokenUsageByProvider, getTokenUsageTotals } from "../../db.js";
 import { createLogger, debugSuppressedError } from "../../utils/logger.js";
 import { searchWorkspace } from "../../workspace-search.js";
@@ -27,6 +29,7 @@ const log = createLogger("agent-control.info");
 type StateCommand = Extract<AgentControlCommand, { type: "state" }>;
 type StatsCommand = Extract<AgentControlCommand, { type: "stats" }>;
 type ContextCommand = Extract<AgentControlCommand, { type: "context" }>;
+type QuotaCommand = Extract<AgentControlCommand, { type: "quota" }>;
 type LastCommand = Extract<AgentControlCommand, { type: "last" }>;
 type CommandsCommand = Extract<AgentControlCommand, { type: "commands" }>;
 type SearchCommand = Extract<AgentControlCommand, { type: "search_workspace" }>;
@@ -237,6 +240,29 @@ export async function handleContext(session: AgentSession, _command: ContextComm
   return {
     status: "success",
     message: lines.join("\n"),
+  };
+}
+
+/** Handle /quota: dump the cached provider usage snapshot for the current model (no live refetch). */
+export async function handleQuota(session: AgentSession, _command: QuotaCommand): Promise<AgentControlResult> {
+  const provider = session.model?.provider ?? null;
+  const modelLabel = session.model ? `${session.model.provider}/${session.model.id}` : "<none>";
+  const snapshot = provider ? peekProviderUsage(provider, { allowStale: true }) : null;
+  if (!snapshot) {
+    return { status: "success", message: `${modelLabel}\nNo quota data available.` };
+  }
+
+  const parts = [
+    snapshot.plan ? `Plan: ${snapshot.plan}` : null,
+    snapshot.hint_short?.trim() || null,
+    snapshot.primary?.reset_description || null,
+    snapshot.secondary?.reset_description || null,
+  ].filter((part): part is string => Boolean(part));
+  const quotaLine = parts.length > 0 ? parts.join(" • ") : "No quota data available.";
+
+  return {
+    status: "success",
+    message: `${modelLabel}\n${quotaLine}`,
   };
 }
 

--- a/runtime/test/agent-control/agent-control-handlers.test.ts
+++ b/runtime/test/agent-control/agent-control-handlers.test.ts
@@ -6,13 +6,14 @@
  * and error/success result formatting.
  */
 
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, truncateSync, writeFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { withChatContext } from "../../src/core/chat-context.js";
+import { clearProviderUsageCache, warmProviderUsage } from "../../src/agent-pool/provider-usage.js";
 import { listTrackedProcesses, registerProcess } from "../../src/utils/process-tracker.js";
 import { getTestWorkspace, setEnv } from "../helpers.js";
-import { DEFAULT_TEST_MODEL, TestAgentControlSession, cleanupRotatedSessionArtifacts, createTestModelRegistry, createTestSessionRuntime } from "./session-fixture.js";
+import { DEFAULT_TEST_MODEL, TestAgentControlSession, cleanupRotatedSessionArtifacts, createTestAuthStorage, createTestModelRegistry, createTestSessionRuntime } from "./session-fixture.js";
 
 let restoreEnv: (() => void) | null = null;
 let restoreIdentityState: (() => void) | null = null;
@@ -69,6 +70,7 @@ beforeEach(async () => {
   restoreIdentityState = await saveIdentityState();
   saveConfig();
   cleanupRotatedSessionArtifacts(process.cwd());
+  clearProviderUsageCache();
 });
 
 afterEach(() => {
@@ -78,6 +80,7 @@ afterEach(() => {
   restoreIdentityState?.();
   restoreIdentityState = null;
   restoreConfig();
+  clearProviderUsageCache();
 });
 
 const registry = createTestModelRegistry([DEFAULT_TEST_MODEL]);
@@ -129,6 +132,32 @@ test("agent control info and mode commands", async () => {
   expect(stats.message).toContain("**Tracked usage (persisted)**");
   expect(stats.message).toContain("**Per provider**");
   expect(stats.message).toContain("**Per model**");
+
+  const coldQuota = await applyControlCommand(runtime as any, registry, { type: "quota", raw: "/quota" });
+  expect(coldQuota.message).toBe("openai/gpt-test\nNo quota data available.");
+
+  const authStorage = createTestAuthStorage();
+  authStorage.set("zai", { type: "api_key", key: "test-key" });
+  const previousFetch = globalThis.fetch;
+  const fetchMock = mock(async () => new Response(JSON.stringify({
+    data: {
+      level: "Pro",
+      limits: [
+        { type: "TOKENS_LIMIT", percentage: 38, nextResetTime: Date.now() + 90 * 60 * 1000 },
+        { type: "TIME_LIMIT", percentage: 59, nextResetTime: Date.now() + 48 * 60 * 60 * 1000 },
+      ],
+    },
+  })));
+  globalThis.fetch = fetchMock as any;
+  try {
+    await warmProviderUsage(authStorage as any, "zai");
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  session.model = { provider: "zai", id: "glm-4.6", reasoning: true } as any;
+  const warmQuota = await applyControlCommand(runtime as any, registry, { type: "quota", raw: "/quota" });
+  expect(warmQuota.message).toBe("zai/glm-4.6\nPlan: Pro • 5h 62% • tools 41% • resets in ~1h 30m • resets in ~2d 0h");
 
   const context = await applyControlCommand(runtime as any, registry, { type: "context", raw: "/context" });
   expect(context.message).toContain("**Context usage**");

--- a/runtime/test/agent-control/agent-control.test.ts
+++ b/runtime/test/agent-control/agent-control.test.ts
@@ -128,6 +128,9 @@ test("parseControlCommand parses model and thinking commands", () => {
   const stateCmd = parseControlCommand("/state");
   expect(stateCmd?.type).toBe("state");
 
+  const quotaCmd = parseControlCommand("/quota");
+  expect(quotaCmd?.type).toBe("quota");
+
   const autoCompactCmd = parseControlCommand("/auto-compact on");
   expect(autoCompactCmd?.type).toBe("auto_compact");
   expect(autoCompactCmd && "enabled" in autoCompactCmd ? autoCompactCmd.enabled : null).toBe(true);

--- a/runtime/test/agent-control/fuzz-audit.ts
+++ b/runtime/test/agent-control/fuzz-audit.ts
@@ -20,6 +20,7 @@ const ROUTING_SAMPLES: Record<string, string> = {
   "/state": "/state",
   "/stats": "/stats",
   "/context": "/context",
+  "/quota": "/quota",
   "/last": "/last",
   "/compact": "/compact keep focus",
   "/auto-compact": "/auto-compact on",

--- a/runtime/web/src/components/compose-box.ts
+++ b/runtime/web/src/components/compose-box.ts
@@ -36,6 +36,7 @@ export const SLASH_COMMANDS = [
   { name: "/state", description: "Show current session state" },
   { name: "/stats", description: "Show session token and cost stats" },
   { name: "/context", description: "Show context window usage" },
+  { name: "/quota", description: "Show cached provider quota / rate-limit usage" },
   { name: "/last", description: "Show last assistant response" },
   { name: "/compact", description: "Manually compact the session" },
   { name: "/auto-compact", description: "Toggle auto-compaction" },

--- a/runtime/web/static/visual/frontend/src/components/command-palette-params.ts
+++ b/runtime/web/static/visual/frontend/src/components/command-palette-params.ts
@@ -18,6 +18,7 @@ const COMMAND_PARAMS: Record<string, CommandParam> = {
   "/stats": { type: "bare" },
   "/state": { type: "bare" },
   "/context": { type: "bare" },
+  "/quota": { type: "bare" },
   "/abort": { type: "bare" },
   "/last": { type: "bare" },
   "/restart": { type: "bare" },


### PR DESCRIPTION
## Summary
Adds a built-in /quota command that displays cached quota and rate-limit information for the current model’s provider.

This is useful for non-web channels. For example, I’m working on making the Telegram channel a first-class citizen in Piclaw, but there’s currently no way to view remaining quotas from there.

<img width="725" height="157" alt="fbdbdfb" src="https://github.com/user-attachments/assets/dbe583f2-da33-4c47-9657-0092c9a904e7" />
<img width="383" height="153" alt="dvsdvs" src="https://github.com/user-attachments/assets/5833ac2c-b256-4317-9b43-bf24e64ffeea" />

## What it does
- uses already-fetched provider usage only
- does **not** trigger a live refetch
- prints:
  - current `provider/model`
  - cached quota text in the same style as the compose-box tooltip, including:
    - `Plan: ...`
    - compact usage hint
    - `resets in ...` text where available
- falls back to `No quota data available.` when nothing is cached