### PR TITLE
Add MiniMax video generation command

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,6 +179,7 @@ In addition to the inline factories, piclaw ships **packaged runtime extensions*
 | Extension | Gate | Purpose |
 |-----------|------|---------|
 | `integrations/azure-openai.ts` | `AOAI_BASE_URL` must be set | Azure OpenAI + Foundry provider with managed-identity or API-key auth |
+| `integrations/minimax-video/` | `MINIMAX_VIDEO_BASE_URL` must be set | MiniMax asynchronous video generation command with workspace-backed output |
 | `integrations/context-mode.ts` | Always loaded | Tool-output storage, search handles, and `exec_batch` tool |
 | `integrations/mcp-status-hints/` | Always loaded | Status-hint providers for MCP/proxy and prefixed-tool surfaces when registry metadata is incomplete |
 | `integrations/keychain/` | Always loaded | `keychain` tool for list/get/set/delete of secure entries |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,6 +251,26 @@ Dynamic-model cost is an estimate inherited from the closest static template (an
 
 For the packaged Azure managed-identity/static-key path and its additional token-budget controls, see [Azure OpenAI extension](azure/azure-openai-extension.md).
 
+### MiniMax video generation
+
+The packaged MiniMax video extension is enabled when `MINIMAX_VIDEO_BASE_URL` is set. It uses MiniMax's native asynchronous video API and saves completed videos under `/workspace/exports/videos`.
+
+The existing `minimax` and `minimax-cn` model providers use the Anthropic-compatible endpoints below. The generic `openai-compatible` login flow can use the corresponding OpenAI-compatible base URL, and the video extension uses that same `/v1` base for its native video requests.
+
+| Region | OpenAI-compatible / video base | Anthropic-compatible base | API key variable |
+|---|---|---|---|
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` | `MINIMAX_API_KEY` |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` | `MINIMAX_CN_API_KEY` |
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `MINIMAX_API_KEY` | _(required for global)_ | API key for the global MiniMax service |
+| `MINIMAX_CN_API_KEY` | _(required for China)_ | API key for the China MiniMax service |
+| `MINIMAX_VIDEO_BASE_URL` | _(required)_ | API base URL: `https://api.minimax.io/v1` for the global service or `https://api.minimaxi.com/v1` for the China service |
+| `MINIMAX_VIDEO_MODEL_ID` | _(required)_ | Video model ID supported by the selected MiniMax endpoint |
+
+Restart Piclaw after setting these variables, then use `/minimax-video <prompt>`. The command also accepts `--duration 6|10`, `--resolution 720P|768P|1080P`, and `--no-prompt-optimizer`.
+
 ## Runtime and agent
 
 | Variable | Default | Purpose |

--- a/docs/tools-and-skills.md
+++ b/docs/tools-and-skills.md
@@ -622,6 +622,7 @@ Direct commands (no LLM round-trip):
 | `/logout [provider]` | Logout from an AI model provider |
 | `/image <prompt> [--size ...] [--count ...] [--quality ...] [--style ...] [--transparent]` | Generate an Azure OpenAI image into workspace-backed files; `--transparent` requests transparent PNG output |
 | `/flux <prompt> [--size ...] [--count ...] [--quality ...]` | Generate an Azure Foundry image into workspace-backed files |
+| `/minimax-video <prompt> [--duration 6\|10] [--resolution 720P\|768P\|1080P] [--no-prompt-optimizer]` | Generate a MiniMax video and save it as a workspace-backed file |
 | `/restart` | Restart the agent and stop subprocesses |
 | `/exit` | Exit the current piclaw process immediately so the service manager restarts it |
 | `/commands` | List available commands (shows sourceInfo provenance: scope, source, and origin for extension commands, templates, and skills) |
@@ -639,7 +640,7 @@ Direct commands (no LLM round-trip):
 
 The bundled `pi-mcp-adapter` now prefers shared MCP config first: `~/.config/mcp/mcp.json` and project-local `.mcp.json`. Pi-owned config still works under `~/.pi/agent/mcp.json` (inside the container image this typically maps to `/config/.pi/agent/mcp.json`) and project-local `.pi/mcp.json`, with `.pi/mcp.json` acting as the final Pi-specific override. Starter examples are seeded at `.mcp.json.example` and `.pi/mcp.json.example`. Use `/mcp setup` for guided onboarding.
 
-`/image` writes generated images back into the workspace and renders them as workspace-backed timeline images plus file-path listings. `/flux` follows the same output pattern, but transparent background requests are currently supported only on `/image`.
+`/image` writes generated images back into the workspace and renders them as workspace-backed timeline images plus file-path listings. `/flux` follows the same output pattern, but transparent background requests are currently supported only on `/image`. `/minimax-video` polls the provider's asynchronous generation task, downloads the completed video into `/workspace/exports/videos`, and posts both an open link and the workspace file path.
 
 `/search` performs a workspace full‑text search (notes + skills) without calling the LLM:
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -99,6 +99,8 @@ Configuration details live in [configuration.md](configuration.md).
 - **`/image` and `/flux`** — workspace-backed image generation commands for
   Azure OpenAI / Foundry; `/image` supports `--transparent` when the selected
   model can generate transparent PNG output
+- **`/minimax-video`** - asynchronous MiniMax video generation with completed
+  files saved under `/workspace/exports/videos`
 - **`image_process`** — sharp-backed workspace image manipulation for resize,
   crop, convert, optimise, metadata inspection, text/SVG/composite operations,
   and animated GIF workflows

--- a/runtime/extensions/integrations/minimax-video/index.ts
+++ b/runtime/extensions/integrations/minimax-video/index.ts
@@ -1,0 +1,380 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { mkdirSync, renameSync, rmSync } from "node:fs";
+import { extname, join } from "node:path";
+
+const VIDEO_POLL_INTERVAL_MS = 5_000;
+const VIDEO_TASK_TIMEOUT_MS = 15 * 60_000;
+const API_REQUEST_TIMEOUT_MS = 30_000;
+const VIDEO_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+const MAX_VIDEO_BYTES = 256 * 1024 * 1024;
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export type MiniMaxVideoArgs = {
+  prompt: string;
+  duration?: 6 | 10;
+  resolution?: "720P" | "768P" | "1080P";
+  promptOptimizer?: boolean;
+};
+
+export type MiniMaxVideoConfig = {
+  apiKey: string;
+  baseUrl: string;
+  modelId: string;
+};
+
+export type SavedVideoFile = {
+  absPath: string;
+  relPath: string;
+  rawUrl: string;
+};
+
+type MiniMaxVideoMessenger = Pick<ExtensionAPI, "sendMessage">;
+
+type MiniMaxBaseResponse = {
+  status_code?: number;
+  status_msg?: string;
+};
+
+type CreateVideoResponse = {
+  task_id?: string | number;
+  base_resp?: MiniMaxBaseResponse;
+};
+
+type QueryVideoResponse = {
+  status?: string;
+  file_id?: string | number;
+  base_resp?: MiniMaxBaseResponse;
+};
+
+type RetrieveFileResponse = {
+  file?: { download_url?: string };
+  base_resp?: MiniMaxBaseResponse;
+};
+
+type MiniMaxVideoHandlers = {
+  fetch: FetchLike;
+  sleep: (milliseconds: number) => Promise<void>;
+  saveVideo: (downloadUrl: string) => Promise<SavedVideoFile>;
+};
+
+class MiniMaxVideoUsageError extends Error {}
+
+function parseOptionValue(tokens: string[], index: number, option: string): string {
+  const value = tokens[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new MiniMaxVideoUsageError(`${option} requires a value.`);
+  }
+  return value;
+}
+
+export function parseMiniMaxVideoArgs(input: string): MiniMaxVideoArgs {
+  const tokens = input.trim().split(/\s+/).filter(Boolean);
+  const promptParts: string[] = [];
+  let duration: MiniMaxVideoArgs["duration"];
+  let resolution: MiniMaxVideoArgs["resolution"];
+  let promptOptimizer: boolean | undefined;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--duration") {
+      const value = Number(parseOptionValue(tokens, index, token));
+      if (value !== 6 && value !== 10) {
+        throw new MiniMaxVideoUsageError("--duration must be 6 or 10 seconds.");
+      }
+      duration = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--resolution") {
+      const value = parseOptionValue(tokens, index, token).toUpperCase();
+      if (value !== "720P" && value !== "768P" && value !== "1080P") {
+        throw new MiniMaxVideoUsageError("--resolution must be 720P, 768P, or 1080P.");
+      }
+      resolution = value;
+      index += 1;
+      continue;
+    }
+    if (token === "--no-prompt-optimizer") {
+      promptOptimizer = false;
+      continue;
+    }
+    if (token.startsWith("--")) {
+      throw new MiniMaxVideoUsageError(`Unknown option: ${token}`);
+    }
+    promptParts.push(token);
+  }
+
+  const prompt = promptParts.join(" ").trim();
+  if (!prompt) throw new MiniMaxVideoUsageError("A video prompt is required.");
+  if (prompt.length > 5_000) throw new MiniMaxVideoUsageError("The video prompt is too long.");
+
+  return {
+    prompt,
+    ...(duration ? { duration } : {}),
+    ...(resolution ? { resolution } : {}),
+    ...(promptOptimizer === false ? { promptOptimizer } : {}),
+  };
+}
+
+export function buildMiniMaxVideoPayload(modelId: string, args: MiniMaxVideoArgs): Record<string, unknown> {
+  return {
+    model: modelId,
+    prompt: args.prompt,
+    ...(args.duration ? { duration: args.duration } : {}),
+    ...(args.resolution ? { resolution: args.resolution } : {}),
+    ...(args.promptOptimizer === false ? { prompt_optimizer: false } : {}),
+  };
+}
+
+export function normalizeMiniMaxVideoBaseUrl(input: string): string {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error("MINIMAX_VIDEO_BASE_URL must be a valid HTTPS URL.");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("MINIMAX_VIDEO_BASE_URL must use HTTPS.");
+  }
+  url.search = "";
+  url.hash = "";
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString().replace(/\/$/, "");
+}
+
+function miniMaxApiKeyName(baseUrl: string): "MINIMAX_API_KEY" | "MINIMAX_CN_API_KEY" {
+  return new URL(baseUrl).hostname.toLowerCase() === "api.minimaxi.com"
+    ? "MINIMAX_CN_API_KEY"
+    : "MINIMAX_API_KEY";
+}
+
+export function readMiniMaxVideoConfig(env: NodeJS.ProcessEnv = process.env): MiniMaxVideoConfig {
+  const baseUrlInput = env.MINIMAX_VIDEO_BASE_URL?.trim() || "";
+  const modelId = env.MINIMAX_VIDEO_MODEL_ID?.trim() || "";
+  const baseUrl = baseUrlInput ? normalizeMiniMaxVideoBaseUrl(baseUrlInput) : "";
+  const apiKeyName = baseUrl ? miniMaxApiKeyName(baseUrl) : null;
+  const apiKey = apiKeyName ? env[apiKeyName]?.trim() || "" : "";
+  const missing = [
+    !baseUrl && "MINIMAX_VIDEO_BASE_URL",
+    !modelId && "MINIMAX_VIDEO_MODEL_ID",
+    !apiKey && (apiKeyName || "MINIMAX_API_KEY or MINIMAX_CN_API_KEY"),
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    throw new Error(`Missing MiniMax video configuration: ${missing.join(", ")}.`);
+  }
+  return { apiKey, baseUrl, modelId };
+}
+
+function endpoint(baseUrl: string, path: string): string {
+  return `${baseUrl}${path}`;
+}
+
+async function fetchWithTimeout(
+  input: string | URL | Request,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function requestJson<T extends { base_resp?: MiniMaxBaseResponse }>(
+  url: string,
+  init: RequestInit,
+): Promise<T> {
+  const response = await fetchWithTimeout(url, init, API_REQUEST_TIMEOUT_MS);
+  const text = await response.text();
+  let payload: T;
+  try {
+    payload = JSON.parse(text) as T;
+  } catch {
+    throw new Error(`MiniMax returned an invalid JSON response (HTTP ${response.status}).`);
+  }
+
+  if (!response.ok) {
+    const detail = payload.base_resp?.status_msg || text.slice(0, 300);
+    throw new Error(`MiniMax request failed (HTTP ${response.status}): ${detail}`);
+  }
+  const statusCode = Number(payload.base_resp?.status_code || 0);
+  if (statusCode !== 0) {
+    throw new Error(`MiniMax request failed (${statusCode}): ${payload.base_resp?.status_msg || "Unknown error"}`);
+  }
+  return payload;
+}
+
+async function createVideoTask(config: MiniMaxVideoConfig, args: MiniMaxVideoArgs): Promise<string> {
+  const payload = await requestJson<CreateVideoResponse>(endpoint(config.baseUrl, "/video_generation"), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(buildMiniMaxVideoPayload(config.modelId, args)),
+  });
+  if (payload.task_id === undefined || payload.task_id === null || payload.task_id === "") {
+    throw new Error("MiniMax did not return a video task ID.");
+  }
+  return String(payload.task_id);
+}
+
+async function waitForVideoFile(config: MiniMaxVideoConfig, taskId: string): Promise<string> {
+  const deadline = Date.now() + VIDEO_TASK_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const url = new URL(endpoint(config.baseUrl, "/query/video_generation"));
+    url.searchParams.set("task_id", taskId);
+    const payload = await requestJson<QueryVideoResponse>(url.toString(), {
+      headers: { Authorization: `Bearer ${config.apiKey}` },
+    });
+    const status = payload.status?.trim().toLowerCase();
+    if (status === "success") {
+      if (payload.file_id === undefined || payload.file_id === null || payload.file_id === "") {
+        throw new Error("MiniMax completed the video task without a file ID.");
+      }
+      return String(payload.file_id);
+    }
+    if (status === "fail" || status === "failed") {
+      throw new Error("MiniMax video generation failed.");
+    }
+    await sleepImpl(VIDEO_POLL_INTERVAL_MS);
+  }
+  throw new Error("MiniMax video generation timed out.");
+}
+
+async function retrieveDownloadUrl(config: MiniMaxVideoConfig, fileId: string): Promise<string> {
+  const url = new URL(endpoint(config.baseUrl, "/files/retrieve"));
+  url.searchParams.set("file_id", fileId);
+  const payload = await requestJson<RetrieveFileResponse>(url.toString(), {
+    headers: { Authorization: `Bearer ${config.apiKey}` },
+  });
+  const downloadUrl = payload.file?.download_url?.trim() || "";
+  if (!downloadUrl) throw new Error("MiniMax did not return a video download URL.");
+  return downloadUrl;
+}
+
+function videoExtension(downloadUrl: string): string {
+  const extension = extname(new URL(downloadUrl).pathname).toLowerCase();
+  return extension === ".webm" || extension === ".mov" ? extension : ".mp4";
+}
+
+async function saveVideo(downloadUrl: string): Promise<SavedVideoFile> {
+  const url = new URL(downloadUrl);
+  if (url.protocol !== "https:") throw new Error("MiniMax returned a non-HTTPS video download URL.");
+
+  const response = await fetchWithTimeout(url, {}, VIDEO_DOWNLOAD_TIMEOUT_MS);
+  if (!response.ok) throw new Error(`MiniMax video download failed (HTTP ${response.status}).`);
+  const declaredLength = Number(response.headers.get("content-length") || 0);
+  if (declaredLength > MAX_VIDEO_BYTES) throw new Error("MiniMax video exceeds the 256 MB workspace limit.");
+
+  const blob = await response.blob();
+  if (blob.size > MAX_VIDEO_BYTES) throw new Error("MiniMax video exceeds the 256 MB workspace limit.");
+
+  const outDir = join("/workspace", "exports", "videos");
+  mkdirSync(outDir, { recursive: true });
+  const filename = `minimax-video-${Date.now()}${videoExtension(downloadUrl)}`;
+  const relPath = join("exports", "videos", filename).replace(/\\/g, "/");
+  const absPath = join("/workspace", relPath);
+  const tempPath = `${absPath}.part`;
+  try {
+    await Bun.write(tempPath, blob);
+    renameSync(tempPath, absPath);
+  } catch (error) {
+    rmSync(tempPath, { force: true });
+    throw error;
+  }
+  return {
+    absPath,
+    relPath,
+    rawUrl: `/workspace/raw?path=${encodeURIComponent(relPath)}`,
+  };
+}
+
+async function generateVideo(config: MiniMaxVideoConfig, args: MiniMaxVideoArgs): Promise<SavedVideoFile> {
+  const taskId = await createVideoTask(config, args);
+  const fileId = await waitForVideoFile(config, taskId);
+  const downloadUrl = await retrieveDownloadUrl(config, fileId);
+  return await saveVideoImpl(downloadUrl);
+}
+
+export function formatGeneratedVideoMessage(
+  modelId: string,
+  prompt: string,
+  file: SavedVideoFile,
+): string {
+  return [
+    `MiniMax video (${modelId}) - ${prompt}`,
+    "",
+    `[Open generated video](${file.rawUrl})`,
+    "",
+    "Files:",
+    `- ${file.absPath}`,
+  ].join("\n");
+}
+
+export function formatMiniMaxVideoError(error: unknown): string {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return "MiniMax video generation failed: The provider request timed out.";
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return `MiniMax video generation failed: ${message.slice(0, 500)}`;
+}
+
+let fetchImpl: FetchLike = fetch;
+let sleepImpl = async (milliseconds: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+};
+let saveVideoImpl = saveVideo;
+
+export function setMiniMaxVideoHandlersForTests(handlers?: Partial<MiniMaxVideoHandlers> | null): void {
+  fetchImpl = handlers?.fetch ?? fetch;
+  sleepImpl = handlers?.sleep ?? (async (milliseconds: number) => {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
+  });
+  saveVideoImpl = handlers?.saveVideo ?? saveVideo;
+}
+
+function sendVideoMessage(pi: MiniMaxVideoMessenger, content: string): void {
+  pi.sendMessage({ customType: "minimax-video", content, display: true } as any);
+}
+
+export async function executeMiniMaxVideoCommand(
+  pi: MiniMaxVideoMessenger,
+  input: string,
+  configOverride?: MiniMaxVideoConfig,
+): Promise<void> {
+  let args: MiniMaxVideoArgs;
+  let config: MiniMaxVideoConfig;
+  try {
+    args = parseMiniMaxVideoArgs(input || "");
+    config = configOverride ?? readMiniMaxVideoConfig();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const usage = "Usage: /minimax-video <prompt> [--duration 6|10] [--resolution 720P|768P|1080P] [--no-prompt-optimizer]";
+    sendVideoMessage(pi, `${detail}\n\n${usage}`);
+    return;
+  }
+
+  sendVideoMessage(pi, `Generating MiniMax video... (${config.modelId})`);
+  void (async () => {
+    try {
+      const file = await generateVideo(config, args);
+      sendVideoMessage(pi, formatGeneratedVideoMessage(config.modelId, args.prompt, file));
+    } catch (error) {
+      sendVideoMessage(pi, formatMiniMaxVideoError(error));
+    }
+  })();
+}
+
+export default function registerMiniMaxVideo(pi: ExtensionAPI): void {
+  pi.registerCommand("minimax-video", {
+    description: "Generate a MiniMax video and save it to the workspace",
+    handler: async (input) => {
+      await executeMiniMaxVideoCommand(pi, input || "");
+    },
+  });
+}

--- a/runtime/src/agent-pool/session.ts
+++ b/runtime/src/agent-pool/session.ts
@@ -114,6 +114,7 @@ type OptionalBundledExtension = {
 
 const OPTIONAL_EXTENSIONS: OptionalBundledExtension[] = [
   { path: resolve(EXTENSIONS_DIR, "integrations", "azure-openai-session", "index.ts"), envGate: "AOAI_BASE_URL" },
+  { path: resolve(EXTENSIONS_DIR, "integrations", "minimax-video", "index.ts"), envGate: "MINIMAX_VIDEO_BASE_URL" },
   { path: resolve(EXTENSIONS_DIR, "integrations", "context-mode.ts") },
   { path: resolve(EXTENSIONS_DIR, "integrations", "bun-runner", "index.ts") },
   { path: resolve(EXTENSIONS_DIR, "integrations", "keychain", "index.ts") },

--- a/runtime/test/extensions/minimax-video.test.ts
+++ b/runtime/test/extensions/minimax-video.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, expect, test } from "bun:test";
+
+import {
+  buildMiniMaxVideoPayload,
+  executeMiniMaxVideoCommand,
+  normalizeMiniMaxVideoBaseUrl,
+  parseMiniMaxVideoArgs,
+  readMiniMaxVideoConfig,
+  setMiniMaxVideoHandlersForTests,
+  type MiniMaxVideoConfig,
+} from "../../extensions/integrations/minimax-video/index.ts";
+import { waitFor } from "../helpers.js";
+
+const CONFIG: MiniMaxVideoConfig = {
+  apiKey: "test-key",
+  baseUrl: "https://api.example.com/v1",
+  modelId: "video-model",
+};
+
+afterEach(() => {
+  setMiniMaxVideoHandlersForTests(null);
+});
+
+test("parseMiniMaxVideoArgs builds supported generation options", () => {
+  const args = parseMiniMaxVideoArgs(
+    "a paper city at sunrise --duration 10 --resolution 1080p --no-prompt-optimizer",
+  );
+
+  expect(args).toEqual({
+    prompt: "a paper city at sunrise",
+    duration: 10,
+    resolution: "1080P",
+    promptOptimizer: false,
+  });
+  expect(buildMiniMaxVideoPayload("video-model", args)).toEqual({
+    model: "video-model",
+    prompt: "a paper city at sunrise",
+    duration: 10,
+    resolution: "1080P",
+    prompt_optimizer: false,
+  });
+});
+
+test("normalizeMiniMaxVideoBaseUrl removes trailing separators and rejects insecure URLs", () => {
+  expect(normalizeMiniMaxVideoBaseUrl("https://api.example.com/v1///"))
+    .toBe("https://api.example.com/v1");
+  expect(() => normalizeMiniMaxVideoBaseUrl("http://api.example.com/v1"))
+    .toThrow("must use HTTPS");
+});
+
+test("executeMiniMaxVideoCommand creates, polls, retrieves, and reports a workspace video", async () => {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const responses = [
+    { task_id: "task-1", base_resp: { status_code: 0 } },
+    { status: "Processing", base_resp: { status_code: 0 } },
+    { status: "Success", file_id: "file-1", base_resp: { status_code: 0 } },
+    { file: { download_url: "https://cdn.example.com/video.mp4" }, base_resp: { status_code: 0 } },
+  ];
+  const sent: Array<{ customType: string; content: string; display?: boolean }> = [];
+
+  setMiniMaxVideoHandlersForTests({
+    fetch: async (input, init) => {
+      requests.push({ url: String(input), init });
+      return new Response(JSON.stringify(responses.shift()), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+    sleep: async () => {},
+    saveVideo: async () => ({
+      absPath: "/workspace/exports/videos/minimax-video-test.mp4",
+      relPath: "exports/videos/minimax-video-test.mp4",
+      rawUrl: "/workspace/raw?path=exports%2Fvideos%2Fminimax-video-test.mp4",
+    }),
+  });
+
+  await executeMiniMaxVideoCommand({
+    sendMessage(message: any) { sent.push(message); },
+  } as any, "a paper city at sunrise --duration 6", CONFIG);
+
+  expect(sent[0]?.content).toContain("Generating MiniMax video...");
+  await waitFor(() => sent.length >= 2, 1_000, 10);
+
+  expect(requests.map((request) => request.url)).toEqual([
+    "https://api.example.com/v1/video_generation",
+    "https://api.example.com/v1/query/video_generation?task_id=task-1",
+    "https://api.example.com/v1/query/video_generation?task_id=task-1",
+    "https://api.example.com/v1/files/retrieve?file_id=file-1",
+  ]);
+  expect(JSON.parse(String(requests[0]?.init?.body))).toEqual({
+    model: "video-model",
+    prompt: "a paper city at sunrise",
+    duration: 6,
+  });
+  expect(sent[1]?.content).toContain("[Open generated video]");
+  expect(sent[1]?.content).toContain("/workspace/exports/videos/minimax-video-test.mp4");
+});
+
+test("readMiniMaxVideoConfig reports every required setting", () => {
+  expect(() => readMiniMaxVideoConfig({})).toThrow(
+    "Missing MiniMax video configuration: MINIMAX_VIDEO_BASE_URL, MINIMAX_VIDEO_MODEL_ID, MINIMAX_API_KEY or MINIMAX_CN_API_KEY.",
+  );
+});
+
+test("readMiniMaxVideoConfig selects the API key for the configured region", () => {
+  expect(readMiniMaxVideoConfig({
+    MINIMAX_API_KEY: "global-key",
+    MINIMAX_VIDEO_BASE_URL: "https://api.minimax.io/v1",
+    MINIMAX_VIDEO_MODEL_ID: "video-model",
+  }).apiKey).toBe("global-key");
+
+  expect(readMiniMaxVideoConfig({
+    MINIMAX_CN_API_KEY: "china-key",
+    MINIMAX_VIDEO_BASE_URL: "https://api.minimaxi.com/v1",
+    MINIMAX_VIDEO_MODEL_ID: "video-model",
+  }).apiKey).toBe("china-key");
+});
+
+test("executeMiniMaxVideoCommand reports invalid input without starting a request", async () => {
+  const sent: Array<{ content: string }> = [];
+
+  await executeMiniMaxVideoCommand({
+    sendMessage(message: any) { sent.push(message); },
+  } as any, "--duration 6", CONFIG);
+
+  expect(sent[0]?.content).toContain("A video prompt is required");
+  expect(sent[0]?.content).toContain("Usage: /minimax-video");
+});

--- a/runtime/test/extensions/optional-bundled-extensions.test.ts
+++ b/runtime/test/extensions/optional-bundled-extensions.test.ts
@@ -86,4 +86,14 @@ describe("bundled optional extensions", () => {
     expect(fake.state.commands.has("cdp-tabs")).toBe(true);
     expect(fake.state.tools.get("cdp_browser")?.description).toContain("Chrome DevTools Protocol");
   });
+
+  test("minimax-video registers the MiniMax video command", async () => {
+    const { default: registerMiniMaxVideo } = await import("../../extensions/integrations/minimax-video/index.ts");
+    const fake = createFakeApi();
+
+    registerMiniMaxVideo(fake.api);
+
+    expect(fake.state.commands.has("minimax-video")).toBe(true);
+    expect(fake.state.commands.get("minimax-video")?.description).toContain("MiniMax video");
+  });
 });


### PR DESCRIPTION
Reason: add target video capability using existing tool/provider pattern

## Summary
- Add an env-gated `/minimax-video` command that creates, polls, retrieves, and saves generated videos.
- Support the global and China services through the existing regional API key conventions and an explicit video model setting.
- Document configuration and cover command registration, request flow, region selection, and error handling.

## Checks
- `bun test runtime/test/extensions/minimax-video.test.ts runtime/test/extensions/optional-bundled-extensions.test.ts`
- `bun run typecheck`
- `cd runtime && bunx eslint src/agent-pool/session.ts test/extensions/minimax-video.test.ts test/extensions/optional-bundled-extensions.test.ts`