### PR TITLE
prevent Firefox timeline scroll jitter

### DIFF
--- a/runtime/web/static/classic/css/content.css
+++ b/runtime/web/static/classic/css/content.css
@@ -129,12 +129,12 @@
  * skip layout/paint for historical rows far outside the timeline viewport.
  * Unsupported engines ignore both declarations and keep the existing layout.
  */
-@supports (content-visibility: auto) {
+/*@supports (content-visibility: auto) {
     .timeline-content > .post {
         content-visibility: auto;
         contain-intrinsic-size: auto 120px;
     }
-}
+}*/
 
 .post.removing {
     opacity: 0;


### PR DESCRIPTION
Removed `content-visibility: auto` and `contain-intrinsic-size: auto 120px` from classic timeline posts, because they are causing visible jitter and jumps when scrolling long timelines UP in Firefox (152.0.6).

Removal was chosen over a Firefox-specific browser hack for simpler, consistent cross-browser behavior.
