### PR TITLE
Fix auto-compaction to use fresh provider usage (fix for #716)

### DIFF
--- a/runtime/src/agent-pool/compaction.ts
+++ b/runtime/src/agent-pool/compaction.ts
@@ -132,7 +132,6 @@ type ContextEstimateCacheEntry = {
   entryCount: number;
   tokens: number;
   at: number;
-  allowProviderClamp: boolean;
 };
 
 function readProviderContextTokens(session: AgentSession): number | null {
@@ -172,7 +171,7 @@ export function estimateContextTokensFromSession(session: AgentSession): number 
     // entry count. Clamp cached estimates upward so fresh provider usage can
     // still trigger compaction and the web context meter does not drop during
     // tool execution before rebounding on the next assistant message.
-    const tokens = cached.allowProviderClamp && providerTokens != null ? Math.max(cached.tokens, providerTokens) : cached.tokens;
+    const tokens = providerTokens != null ? Math.max(cached.tokens, providerTokens) : cached.tokens;
     if (tokens !== cached.tokens) ctxEstimateCache.set(mgr as object, { ...cached, tokens, at: now });
     return tokens;
   }
@@ -182,28 +181,14 @@ export function estimateContextTokensFromSession(session: AgentSession): number 
   }
 
   const context = mgr.buildSessionContext();
-  const hasCompactionSummary = context.messages.some((message: any) => message?.role === "compactionSummary");
   const estimatedTokens = context.messages.reduce((total: number, message: any) => total + estimateMessageTokens(message), 0);
 
-  // Assistant usage metadata is scoped to the prompt that produced that
-  // assistant message. After a compaction, kept assistant messages can still
-  // carry pre-compaction usage totals, so trusting getContextUsage()/last usage
-  // makes the freshly compacted context look huge and triggers repeated idle
-  // compactions. Once a compacted summary is present, estimate the resolved
-  // compacted context directly from the messages instead.
-  if (!hasCompactionSummary) {
-    if (providerTokens !== null) {
-      // Native usage is often the most accurate count for the prompt that just
-      // ran, but it can lag behind newly appended tool results/messages. Never
-      // let stale native usage hide current context growth from auto-compaction.
-      const tokens = Math.max(providerTokens, estimatedTokens);
-      ctxEstimateCache.set(mgr as object, { leafId, entryCount, tokens, at: now, allowProviderClamp: true });
-      return tokens;
-    }
-  }
-
-  ctxEstimateCache.set(mgr as object, { leafId, entryCount, tokens: estimatedTokens, at: now, allowProviderClamp: !hasCompactionSummary });
-  return estimatedTokens;
+  // Native usage is the most accurate count for the prompt that just ran, but
+  // it can lag behind newly appended tool results/messages. Use the larger
+  // value so neither source can hide current context growth.
+  const tokens = providerTokens === null ? estimatedTokens : Math.max(providerTokens, estimatedTokens);
+  ctxEstimateCache.set(mgr as object, { leafId, entryCount, tokens, at: now });
+  return tokens;
 }
 
 export interface CompactionContextReport {

--- a/runtime/test/agent-control/agent-control-handlers.test.ts
+++ b/runtime/test/agent-control/agent-control-handlers.test.ts
@@ -840,7 +840,16 @@ test("agent control compacts undersized model switches and skips them while cycl
 
   let currentIndex = 0;
   session.model = models[currentIndex];
-  session.getContextUsage = () => ({ tokens: 150000, contextWindow: 200000, percent: 75 }) as any;
+  session.getContextUsage = () => {
+    const awaitingPostCompactionUsage = session.sessionContext.messages.some(
+      (message: any) => message.role === "compactionSummary",
+    );
+    return {
+      tokens: awaitingPostCompactionUsage ? null : 150000,
+      contextWindow: 200000,
+      percent: awaitingPostCompactionUsage ? null : 75,
+    } as any;
+  };
   session.setModel = async (model: any) => {
     session.model = model;
     const nextIndex = models.findIndex((entry) => entry.provider === model.provider && entry.id === model.id);

--- a/runtime/test/agent-pool/compaction.test.ts
+++ b/runtime/test/agent-pool/compaction.test.ts
@@ -323,8 +323,8 @@ test("estimateContextTokensFromSession clamps cached estimates to fresh provider
   expect(estimateContextTokensFromSession(session)).toBe(321_100);
 });
 
-test("estimateContextTokensFromSession keeps compacted contexts below stale provider usage", () => {
-  let providerTokens = 150_000;
+test("estimateContextTokensFromSession uses provider usage once it is fresh after compaction", () => {
+  let providerTokens: number | null = null;
   const session = {
     getContextUsage: () => ({ tokens: providerTokens }),
     sessionManager: {
@@ -341,7 +341,7 @@ test("estimateContextTokensFromSession keeps compacted contexts below stale prov
 
   expect(estimateContextTokensFromSession(session)).toBeLessThan(150_000);
   providerTokens = 200_000;
-  expect(estimateContextTokensFromSession(session)).toBeLessThan(150_000);
+  expect(estimateContextTokensFromSession(session)).toBe(200_000);
 });
 
 test("getAutoCompactionTokenStatusForSession uses fresh provider usage above threshold despite cached lower estimate", () => {
@@ -1018,7 +1018,7 @@ test("estimateContextTokensFromSession ignores stale assistant usage after compa
       role: "toolResult",
       content: [{ type: "text", text: "small result" }],
     },
-  ], 230_000);
+  ]);
 
   const estimated = estimateContextTokensFromSession(session);
 


### PR DESCRIPTION
Use the greater of provider-reported usage and Piclaw’s message estimate, including after compaction and on cache hits. Pi returns null until post-compaction usage is fresh, preventing stale values from being reused.

This prevents context undercounting and delayed auto-compaction when any compaction summary exists in session.