### PR TITLE
Confirmation dialog for workspace tree drag-and-drop file/folder moves

### DIFF
--- a/runtime/test/web/workspace-explorer.test.ts
+++ b/runtime/test/web/workspace-explorer.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from 'bun:test';
 
 import {
+  buildWorkspaceMoveConfirmationMessage,
+  confirmWorkspaceEntryMove,
   getWorkspaceTouchStartIntent,
   mergeWorkspaceTreeUpdates,
 } from '../../web/src/components/workspace-explorer.ts';
@@ -58,6 +60,34 @@ test('workspace touch start ignores rows that are being renamed', () => {
   }, '/workspace/demo.md');
 
   expect(intent).toBeNull();
+});
+
+test('workspace move confirmation describes file and folder destinations', () => {
+  expect(buildWorkspaceMoveConfirmationMessage('notes/report.md', 'archive', 'file')).toBe(
+    'Move file "report.md" from "notes" to "archive"?',
+  );
+  expect(buildWorkspaceMoveConfirmationMessage('projects/demo', '.', 'dir')).toBe(
+    'Move folder "demo" from "projects" to the workspace root?',
+  );
+});
+
+test('workspace move confirmation respects cancel and confirm responses', () => {
+  const prompts: string[] = [];
+  const cancel = confirmWorkspaceEntryMove('notes/report.md', 'archive', 'file', (message: string) => {
+    prompts.push(message);
+    return false;
+  });
+  const confirm = confirmWorkspaceEntryMove('projects/demo', '.', 'dir', (message: string) => {
+    prompts.push(message);
+    return true;
+  });
+
+  expect(cancel).toBe(false);
+  expect(confirm).toBe(true);
+  expect(prompts).toEqual([
+    'Move file "report.md" from "notes" to "archive"?',
+    'Move folder "demo" from "projects" to the workspace root?',
+  ]);
 });
 
 test('workspace root updates preserve descendants loaded beyond the watcher depth', () => {

--- a/runtime/web/src/components/workspace-explorer.ts
+++ b/runtime/web/src/components/workspace-explorer.ts
@@ -639,6 +639,20 @@ export function getWorkspaceTouchStartIntent(event, renamingPath = null) {
     };
 }
 
+export function buildWorkspaceMoveConfirmationMessage(sourcePath, targetPath, entryType) {
+    const sourceName = sourcePath.split('/').pop() || sourcePath;
+    const sourceParent = sourcePath.includes('/')
+        ? (sourcePath.split('/').slice(0, -1).join('/') || '.')
+        : '.';
+    const entryLabel = entryType === 'dir' ? 'folder' : 'file';
+    const describeLocation = (path) => path === '.' ? 'the workspace root' : `"${path}"`;
+    return `Move ${entryLabel} "${sourceName}" from ${describeLocation(sourceParent)} to ${describeLocation(targetPath)}?`;
+}
+
+export function confirmWorkspaceEntryMove(sourcePath, targetPath, entryType, confirmMove = (message) => window.confirm(message)) {
+    return confirmMove(buildWorkspaceMoveConfirmationMessage(sourcePath, targetPath, entryType));
+}
+
 // ── WorkspaceExplorer ─────────────────────────────────────────────────────────
 
 /** Preact component: file tree explorer with upload, rename, and preview. */
@@ -2150,6 +2164,7 @@ export function WorkspaceExplorer({
             ? (sourcePath.split('/').slice(0, -1).join('/') || '.')
             : '.';
         if (targetDir === sourceParent) return;
+        if (!confirmWorkspaceEntryMove(sourcePath, targetDir, node.type)) return;
         try {
             const result = await moveWorkspaceEntry(sourcePath, targetDir);
             const nextPath = result?.path || sourcePath;


### PR DESCRIPTION
## Summary

Accidentally moving files or folders on touch-enabled devices is super common.
This PR adds a confirmation dialog before moving files or folders within the workspace tree.

